### PR TITLE
Phase 1 tail: byUuid detail, snapshot dump, --limit flags, CLI e2e tests

### DIFF
--- a/src/cli/commands/reads.ts
+++ b/src/cli/commands/reads.ts
@@ -123,16 +123,6 @@ export function registerReadCommands(program: Command): void {
       description: "Someday items (incubated, undated)",
       fetch: (c) => c.read.someday(),
     },
-    {
-      name: "logbook",
-      description: "Completed and canceled items, most recent first (--limit)",
-      fetch: (c) => c.read.logbook(),
-    },
-    {
-      name: "trash",
-      description: "Trashed items (trashed=1 flag, any status)",
-      fetch: (c) => c.read.trash(),
-    },
   ];
 
   for (const cmd of listCommands) {
@@ -143,6 +133,36 @@ export function registerReadCommands(program: Command): void {
       .option("--db <path>", "explicit database path")
       .action((opts: GlobalReadOpts) => {
         withClient(opts, cmd.name, cmd.fetch, (cmd.render ?? renderList) as (d: never) => string[]);
+      });
+  }
+
+  for (const cmd of [
+    {
+      name: "logbook",
+      description: "Completed and canceled items, most recent first",
+      fetch: (c: ThingsClient, limit: number) => c.read.logbook({ limit }),
+      defaultLimit: 100,
+    },
+    {
+      name: "trash",
+      description: "Trashed items (trashed=1 flag, any status), most recently modified first",
+      fetch: (c: ThingsClient, limit: number) => c.read.trash({ limit }),
+      defaultLimit: 200,
+    },
+  ]) {
+    program
+      .command(cmd.name)
+      .description(cmd.description)
+      .option("--limit <n>", "maximum items to return", String(cmd.defaultLimit))
+      .option("--json", "emit versioned JSON envelope on stdout")
+      .option("--db <path>", "explicit database path")
+      .action((opts: GlobalReadOpts & { limit: string }) => {
+        withClient(
+          opts,
+          cmd.name,
+          (c) => cmd.fetch(c, Number(opts.limit)),
+          renderList as (d: never) => string[],
+        );
       });
   }
 

--- a/src/cli/commands/snapshot.ts
+++ b/src/cli/commands/snapshot.ts
@@ -1,0 +1,38 @@
+/**
+ * `things snapshot` — full normalized dump (all rows, all states) for
+ * diffing, backup forensics, and the lab harness. Human output shows counts;
+ * use --json for the data.
+ */
+import type { Command } from "commander";
+
+import type { Snapshot } from "../../read/snapshot.ts";
+import { withClient } from "./reads.ts";
+
+function renderCounts(snapshot: Snapshot): string[] {
+  const c = snapshot.counts;
+  return [
+    `areas: ${c.areas}  tags: ${c.tags}`,
+    `todos: ${c.todos}  projects: ${c.projects}  headings: ${c.headings}`,
+    `checklist items: ${c.checklistItems}`,
+    `trashed: ${c.trashed}  repeating templates: ${c.repeatingTemplates}`,
+    `(use --json for the full dump)`,
+  ];
+}
+
+export function registerSnapshot(program: Command): void {
+  program
+    .command("snapshot")
+    .description(
+      "Full normalized dump of the library: every task row (all types/states incl. repeating templates and trashed), areas, tags, checklist items — uuid-ordered for stable diffs",
+    )
+    .option("--json", "emit versioned JSON envelope on stdout")
+    .option("--db <path>", "explicit database path")
+    .action((opts: { json?: boolean; db?: string }) => {
+      withClient(
+        opts,
+        "snapshot",
+        (c) => c.read.snapshot(),
+        renderCounts as (d: never) => string[],
+      );
+    });
+}

--- a/src/cli/commands/todo.ts
+++ b/src/cli/commands/todo.ts
@@ -1,0 +1,58 @@
+/**
+ * `things todo show <uuid>` — full detail for one record, including checklist,
+ * inherited tags, and repeating flags (works on templates too).
+ */
+import type { Command } from "commander";
+
+import type { AnyTask } from "../../model/entities.ts";
+import { withClient } from "./reads.ts";
+
+function renderDetail(item: AnyTask | null): string[] {
+  if (!item) return ["(not found)"];
+  if (item.type === "heading") {
+    return [
+      `${item.uuid}  [heading] ${item.title}`,
+      `  project: ${item.project?.title ?? "—"}  index: ${item.index}`,
+    ];
+  }
+  const lines = [
+    `${item.uuid}  [${item.type}] ${item.title}`,
+    `  status: ${item.status}${item.trashed ? " (trashed)" : ""}  start: ${item.start}`,
+    `  when: ${item.startDate ?? "—"}${item.todaySection === "evening" ? " (this evening)" : ""}  deadline: ${item.deadline ?? "—"}`,
+    `  area: ${item.area?.title ?? "—"}${item.type === "to-do" ? `  project: ${item.project?.title ?? "—"}  heading: ${item.heading?.title ?? "—"}` : ""}`,
+    `  tags: ${item.tags.map((t) => t.title).join(", ") || "—"}  inherited: ${(item.inheritedTags ?? []).map((t) => t.title).join(", ") || "—"}`,
+  ];
+  if (item.repeating.isTemplate) lines.push("  repeating: TEMPLATE (invisible in list views)");
+  if (item.repeating.isInstance)
+    lines.push(`  repeating: instance of ${item.repeating.templateUuid}`);
+  if (item.notes)
+    lines.push(`  notes: ${item.notes.length > 200 ? `${item.notes.slice(0, 200)}…` : item.notes}`);
+  if (item.type === "to-do" && item.checklist && item.checklist.length > 0) {
+    lines.push("  checklist:");
+    for (const c of item.checklist) {
+      lines.push(
+        `    [${c.status === "completed" ? "x" : c.status === "canceled" ? "~" : " "}] ${c.title}`,
+      );
+    }
+  }
+  return lines;
+}
+
+export function registerTodoCommands(program: Command): void {
+  const todo = program.command("todo").description("To-do–scoped operations");
+  todo
+    .command("show <uuid>")
+    .description(
+      "Full detail for one record by UUID — includes checklist items, inherited tags, and repeating flags; finds records list views hide (templates, trashed)",
+    )
+    .option("--json", "emit versioned JSON envelope on stdout")
+    .option("--db <path>", "explicit database path")
+    .action((uuid: string, opts: { json?: boolean; db?: string }) => {
+      withClient(
+        opts,
+        "todo-detail",
+        (c) => c.read.byUuid(uuid),
+        renderDetail as (d: never) => string[],
+      );
+    });
+}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -11,6 +11,8 @@ import { Command } from "commander";
 import { registerDoctor } from "./commands/doctor.ts";
 import { registerProjectCommands } from "./commands/project.ts";
 import { registerReadCommands } from "./commands/reads.ts";
+import { registerSnapshot } from "./commands/snapshot.ts";
+import { registerTodoCommands } from "./commands/todo.ts";
 import { ExitCode } from "./exit-codes.ts";
 
 const AGENT_NOTES = `
@@ -32,6 +34,8 @@ export function buildProgram(): Command {
   registerDoctor(program);
   registerReadCommands(program);
   registerProjectCommands(program);
+  registerTodoCommands(program);
+  registerSnapshot(program);
   return program;
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,8 +5,10 @@ import { BASELINES } from "./db/baselines/index.ts";
 import { openConnection, type ThingsConnection } from "./db/connection.ts";
 import { compareToBaseline, observeSchema, type FingerprintStatus } from "./db/fingerprint.ts";
 import { locateThingsDb } from "./db/locate.ts";
-import type { Area, Project, Tag } from "./model/entities.ts";
+import type { AnyTask, Area, Project, Tag } from "./model/entities.ts";
+import { byUuid } from "./read/detail.ts";
 import { projectView, type ProjectView } from "./read/project-view.ts";
+import { snapshotView, type Snapshot } from "./read/snapshot.ts";
 import { areasView, tagsView } from "./read/tags.ts";
 import {
   anytimeView,
@@ -44,6 +46,8 @@ export interface ThingsClient {
     areas(): Area[];
     tags(): Tag[];
     search(query: string, options?: { limit?: number }): ListItem[];
+    byUuid(uuid: string): AnyTask | null;
+    snapshot(): Snapshot;
   };
   close(): void;
 }
@@ -73,6 +77,8 @@ export function openThings(options: OpenOptions = {}): ThingsClient {
       areas: () => areasView(conn.db),
       tags: () => tagsView(conn.db),
       search: (query, o) => searchView(conn.db, query, o),
+      byUuid: (uuid) => byUuid(conn.db, uuid),
+      snapshot: () => snapshotView(conn.db),
     },
     close: () => conn.close(),
   };

--- a/src/read/detail.ts
+++ b/src/read/detail.ts
@@ -1,0 +1,46 @@
+/**
+ * Single-record reads by UUID — includes repeating templates (which list
+ * views hide), checklist items, and inherited tags.
+ */
+import type { DatabaseSync } from "node:sqlite";
+
+import type { AnyTask, ChecklistItem } from "../model/entities.ts";
+import {
+  mapChecklistItem,
+  mapHeading,
+  mapProject,
+  mapTodo,
+  type TaskRow,
+} from "../model/mappers.ts";
+import {
+  fetchChecklistRows,
+  fetchTagsForTasks,
+  fetchTaskByUuid,
+  makeRefResolver,
+} from "./queries.ts";
+import { inheritedTagsFor } from "./tags.ts";
+
+export function byUuid(db: DatabaseSync, uuid: string): AnyTask | null {
+  const row = fetchTaskByUuid(db, uuid);
+  if (!row) return null;
+  return materializeOne(db, row);
+}
+
+function materializeOne(db: DatabaseSync, row: TaskRow): AnyTask {
+  const refs = makeRefResolver(db);
+  if (row.type === 2) return mapHeading(row, refs);
+  const tags = fetchTagsForTasks(db, [row.uuid]).get(row.uuid) ?? [];
+  if (row.type === 1) {
+    const project = mapProject(row, refs, tags);
+    project.inheritedTags = inheritedTagsFor(db, row);
+    return project;
+  }
+  const todo = mapTodo(row, refs, tags);
+  todo.inheritedTags = inheritedTagsFor(db, row);
+  todo.checklist = checklistFor(db, row.uuid);
+  return todo;
+}
+
+export function checklistFor(db: DatabaseSync, taskUuid: string): ChecklistItem[] {
+  return fetchChecklistRows(db, taskUuid).map(mapChecklistItem);
+}

--- a/src/read/snapshot.ts
+++ b/src/read/snapshot.ts
@@ -1,0 +1,76 @@
+/**
+ * Full normalized dump of the library — every TMTask row (all types and
+ * states, including repeating templates and trashed rows), all areas, tags,
+ * and checklist items. UUID-ordered for stable diffing; the lab harness and
+ * pre/post-mutation forensics both consume this.
+ */
+import type { DatabaseSync } from "node:sqlite";
+
+import { q, selectList } from "../db/schema.ts";
+import type { AnyTask, Area, ChecklistItem, Tag } from "../model/entities.ts";
+import {
+  mapChecklistItem,
+  mapHeading,
+  mapProject,
+  mapTodo,
+  type ChecklistRow,
+} from "../model/mappers.ts";
+import { fetchTagsForTasks, fetchTaskRows, makeRefResolver } from "./queries.ts";
+import { areasView, tagsView } from "./tags.ts";
+
+export interface Snapshot {
+  areas: Area[];
+  tags: Tag[];
+  tasks: AnyTask[];
+  checklistItems: ChecklistItem[];
+  counts: {
+    areas: number;
+    tags: number;
+    todos: number;
+    projects: number;
+    headings: number;
+    checklistItems: number;
+    trashed: number;
+    repeatingTemplates: number;
+  };
+}
+
+export function snapshotView(db: DatabaseSync): Snapshot {
+  const areas = areasView(db);
+  const tags = tagsView(db);
+  const rows = fetchTaskRows(db, "1=1 ORDER BY t.uuid ASC");
+  const refs = makeRefResolver(db);
+  const tagMap = fetchTagsForTasks(
+    db,
+    rows.map((r) => r.uuid),
+  );
+  const tasks: AnyTask[] = rows.map((row) => {
+    if (row.type === 2) return mapHeading(row, refs);
+    const rowTags = tagMap.get(row.uuid) ?? [];
+    return row.type === 1 ? mapProject(row, refs, rowTags) : mapTodo(row, refs, rowTags);
+  });
+  const checklistRows = db
+    .prepare(
+      `SELECT ${selectList("TMChecklistItem")} FROM TMChecklistItem ORDER BY ${q("uuid")} ASC`,
+    )
+    .all() as unknown as ChecklistRow[];
+  const checklistItems = checklistRows.map(mapChecklistItem);
+
+  return {
+    areas,
+    tags,
+    tasks,
+    checklistItems,
+    counts: {
+      areas: areas.length,
+      tags: tags.length,
+      todos: rows.filter((r) => r.type === 0).length,
+      projects: rows.filter((r) => r.type === 1).length,
+      headings: rows.filter((r) => r.type === 2).length,
+      checklistItems: checklistItems.length,
+      trashed: rows.filter((r) => r.trashed === 1).length,
+      repeatingTemplates: rows.filter((r) => r.rt1_recurrenceRule !== null || r.repeater !== null)
+        .length,
+    },
+  };
+}

--- a/test/cli/e2e.test.ts
+++ b/test/cli/e2e.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { buildProgram } from "../../src/cli/main.ts";
+import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
+import { seedTodo } from "../fixtures/seed.ts";
+
+let fx: FixtureDb | null = null;
+afterEach(() => {
+  fx?.close();
+  fx = null;
+});
+
+/** Run the CLI in-process, capturing stdout lines. */
+function runCli(argv: string[]): { stdout: string; exitCode: number } {
+  const chunks: string[] = [];
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    chunks.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  const originalExitCode = process.exitCode;
+  try {
+    const program = buildProgram();
+    program.exitOverride();
+    program.parse(argv, { from: "user" });
+    return { stdout: chunks.join(""), exitCode: Number(process.exitCode ?? 0) };
+  } finally {
+    process.stdout.write = originalWrite;
+    process.exitCode = originalExitCode;
+  }
+}
+
+describe("cli end-to-end (fixture db)", () => {
+  it("things today --json emits the versioned envelope with split sections", () => {
+    fx = buildFixtureDb();
+    seedTodo(fx.db, { title: "morning", startDate: "2020-01-01", todayIndex: 1 });
+    seedTodo(fx.db, { title: "tonight", startDate: "2020-01-01", evening: true });
+
+    const { stdout, exitCode } = runCli(["today", "--json", "--db", fx.path]);
+    expect(exitCode).toBe(0);
+    const envelope = JSON.parse(stdout);
+    expect(envelope.apiVersion).toBe(1);
+    expect(envelope.ok).toBe(true);
+    expect(envelope.kind).toBe("today");
+    expect(envelope.meta.dbVersion).toBe(26);
+    expect(envelope.meta.fingerprint).toBe("ok");
+    expect(envelope.data.today.map((i: { title: string }) => i.title)).toEqual(["morning"]);
+    expect(envelope.data.evening.map((i: { title: string }) => i.title)).toEqual(["tonight"]);
+  });
+
+  it("things todo show includes checklist and repeating flags", () => {
+    fx = buildFixtureDb();
+    const uuid = seedTodo(fx.db, { title: "template", recurrenceRule: true });
+    const { stdout, exitCode } = runCli(["todo", "show", uuid, "--json", "--db", fx.path]);
+    expect(exitCode).toBe(0);
+    const envelope = JSON.parse(stdout);
+    expect(envelope.data.repeating.isTemplate).toBe(true);
+    expect(envelope.data.checklist).toEqual([]);
+  });
+
+  it("things snapshot --json counts every row class", () => {
+    fx = buildFixtureDb();
+    seedTodo(fx.db, { title: "a" });
+    seedTodo(fx.db, { title: "tpl", recurrenceRule: true });
+    seedTodo(fx.db, { title: "junk", trashed: true });
+    const { stdout } = runCli(["snapshot", "--json", "--db", fx.path]);
+    const envelope = JSON.parse(stdout);
+    expect(envelope.data.counts.todos).toBe(3);
+    expect(envelope.data.counts.trashed).toBe(1);
+    expect(envelope.data.counts.repeatingTemplates).toBe(1);
+    expect(envelope.data.tasks).toHaveLength(3);
+  });
+
+  it("missing db yields environment error envelope (exit 7)", () => {
+    const { stdout, exitCode } = runCli(["inbox", "--json", "--db", "/nope/missing.sqlite"]);
+    expect(exitCode).toBe(7);
+    const envelope = JSON.parse(stdout);
+    expect(envelope.ok).toBe(false);
+    expect(envelope.error.code).toBe("environment");
+  });
+});


### PR DESCRIPTION
- `things todo show <uuid>`: full record detail incl. checklist, inherited tags, repeating flags — finds rows list views hide (templates, trashed)
- `things snapshot`: full normalized uuid-ordered dump (lab harness + mutation forensics consumer); human view shows counts
- `--limit` properly registered on logbook/trash
- In-process CLI e2e tests: envelope shape, checklist/repeating detail, snapshot counts, environment-error path (exit 7)
- Live-verified against the production library (read-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)