### PR TITLE
Phase 2 prep: golden image scripted layers, disruption monitor, seeding runbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ vendor/*
 
 # Lab artifacts (evidence records, screenshots, guest DB copies)
 lab/artifacts/
+
+# Build artifacts (source + build.sh are the record)
+lab/guest/disruption-monitor/disruption-monitor

--- a/docs/lab/golden-runbook.md
+++ b/docs/lab/golden-runbook.md
@@ -1,0 +1,124 @@
+# Golden Image Runbook — human seeding session
+
+The scripted layers (L0 clone/resize, L1 determinism hardening, Things installed **but never launched**, sdef dumped, metadata skeleton) are done by [`lab/scripts/golden-build.sh`](../../lab/scripts/golden-build.sh). This runbook is the one-time ~half-day human session that finishes the golden image. Every step that needs your eyes/clicks is marked **[CLICK]**; everything else is copy-paste into a host terminal.
+
+**Session rule: the moment you first launch Things (step 2.1) the 15-day trial clock starts.** Do the whole session in one sitting so the golden freezes with a maximally fresh trial. If interrupted, it's fine — clones pin the clock — but fresh is better.
+
+## 0. Boot + connect
+
+```sh
+export TART_HOME=/Volumes/Workspace/tart
+tart run things-lab-golden-v1 &            # windowed (no --no-graphics): you'll want the screen
+IP=$(tart ip things-lab-golden-v1)         # retry until it answers
+```
+
+Open **Screen Sharing** → connect to `$IP` → user `admin` / password `admin`. (Or use the Tart window directly.)
+
+## 1. One terminal helper on the host
+
+```sh
+alias vmssh='sshpass -p admin ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null admin@'"$IP"
+```
+
+## 2. Things first launch + settings — **[CLICK]**
+
+1. In the VM: launch Things (Dock/Spotlight or `vmssh 'open -a Things3'`). **Record the timestamp**:
+   ```sh
+   vmssh '/Applications/Things3.app/Contents/MacOS/thingscli defaults read firstAppLaunchDate'
+   ```
+2. **[CLICK]** Walk the welcome flow. **Decline / skip Things Cloud** (no account).
+3. **[CLICK]** Things → Settings…:
+   - General: **Enable Things URLs** → after enabling, click **Manage** under the URL scheme section and copy the auth token (or read it later from SQLite — both work; record it in metadata).
+   - General: uncheck any "check for updates automatically" option.
+   - Today: leave "Group to-dos in the Today list by project or area" **ON** (record whatever you choose — it affects probe screenshots).
+4. Quit Things (⌘Q).
+5. Update metadata (host):
+   ```sh
+   vmssh 'python3 - <<PY
+   import json,subprocess,datetime
+   p="/Users/admin/things-lab/metadata.json"
+   m=json.load(open(p))
+   m["trialFirstLaunch"]="<PASTE ISO TIMESTAMP>"
+   m["pinnedDate"]="<trialFirstLaunch + 2 days, YYYY-MM-DD>"
+   m["humanLayersDone"]=m.get("humanLayersDone",[])+["L2"]
+   json.dump(m,open(p,"w"),indent=2)
+   PY'
+   ```
+   (Or just edit the file over Screen Sharing — content matters, method doesn't.)
+
+## 3. TCC grants — **[CLICK]** (clones inherit these forever)
+
+Push the monitor binary first (host):
+```sh
+sshpass -p admin scp -o StrictHostKeyChecking=no lab/guest/disruption-monitor/disruption-monitor admin@$IP:/Users/admin/things-lab/bin/
+```
+
+1. **Automation (AppleEvents), sshd → Things + System Events.** From the host run:
+   ```sh
+   vmssh 'osascript -e "tell application \"Things3\" to get name"'          # triggers prompt
+   vmssh 'osascript -e "tell application \"System Events\" to get name of first process"'
+   ```
+   **[CLICK]** In Screen Sharing, click **Allow** on each consent dialog. Re-run the commands; both must return values with no prompt.
+2. **Accessibility + Screen Recording for the monitor and sshd.** **[CLICK]** System Settings → Privacy & Security:
+   - Accessibility → **+** → add `/Users/admin/things-lab/bin/disruption-monitor` and `/usr/libexec/sshd-keygen-wrapper`
+   - Screen & System Audio Recording → **+** → add both again
+   - Full Disk Access → **+** → add `/usr/libexec/sshd-keygen-wrapper`
+3. **Neutralize Sequoia's monthly screen-capture re-consent** (host):
+   ```sh
+   vmssh 'defaults write ~/Library/Group\ Containers/group.com.apple.replayd/ScreenCaptureApprovals.plist "/Users/admin/things-lab/bin/disruption-monitor" -date "4321-01-01 00:00:00 +0000"'
+   ```
+4. Verify monitor runs and emits events:
+   ```sh
+   vmssh 'nohup ~/things-lab/bin/disruption-monitor >/dev/null 2>&1 & sleep 2; tail -2 ~/things-lab/events.ndjson; pkill -x disruption-monitor'
+   ```
+
+## 4. LaunchAgent for the monitor (host, no clicks)
+
+```sh
+vmssh 'cat > ~/Library/LaunchAgents/com.thingslab.disruption-monitor.plist <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>com.thingslab.disruption-monitor</string>
+  <key>ProgramArguments</key><array><string>/Users/admin/things-lab/bin/disruption-monitor</string></array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+</dict></plist>
+PLIST
+launchctl bootstrap gui/501 ~/Library/LaunchAgents/com.thingslab.disruption-monitor.plist
+launchctl print gui/501/com.thingslab.disruption-monitor | head -3'
+```
+
+## 5. Proxy shortcuts — **[CLICK]** (deferred OK)
+
+Building the ~8 parameterized proxy shortcuts in Shortcuts.app is only needed for the Lab-5 Shortcuts campaign — **you can defer this to a second short session**. When ready: build each proxy per `docs/design/lab.md` §4.4, run each once (absorb consents), then export signed copies back into the repo (`shortcuts sign`).
+
+Minimum for now: **[CLICK]** open Shortcuts.app once, dismiss any first-run dialog, Settings → Advanced → enable **Allow Running Scripts**.
+
+## 6. Seed dataset
+
+Mostly scripted (I run it via URL scheme once Things URLs are enabled), except UI-only structures:
+
+1. Scripted part (host; I do this): areas, tags + hierarchy, projects, to-dos in every state, evening items, checklists, completed/trashed items — via `things:///json` with the auth token, then verified by `things snapshot --db` against the guest DB.
+2. **[CLICK]** UI-only part (you, ~10 min, exact spec provided at session time):
+   - Headings: in project `LAB-PROJ-HEADINGS`, add headings `Alpha` and `Beta`; drag two seeded to-dos under each.
+   - Repeating: create `LAB-REPEAT-DAILY` (to-do, repeats every day) and `LAB-REPEAT-WEEKLY-PROJ` (project, repeats weekly).
+   - Complete one project via UI (choose "complete all" at the prompt) so a logged project exists.
+3. Quit Things cleanly (⌘Q). I then record the schema fingerprint + UUID→role manifest into metadata.json.
+
+## 7. Freeze
+
+```sh
+tart stop things-lab-golden-v1
+```
+
+Golden is never booted again — every run clones it. Rebuilds (new Things version / changed proxies) rerun `golden-build.sh v2` + this runbook; budget ~1 hour once the first session's learnings are folded in.
+
+## Sanity checklist before freezing
+
+- [ ] `thingscli defaults read firstAppLaunchDate` recorded in metadata.json
+- [ ] Things URLs enabled; auth token recorded (or readable via SQLite `TMSettings.uriSchemeAuthenticationToken`)
+- [ ] Both osascript commands run prompt-free
+- [ ] Monitor LaunchAgent emits `frontmost` events after a fresh login (`tart stop` + `tart run` + check events.ndjson)
+- [ ] Seed dataset present; `things snapshot --db <guest path>` counts match the seed manifest
+- [ ] Things is QUIT and the VM stopped

--- a/lab/guest/disruption-monitor/build.sh
+++ b/lab/guest/disruption-monitor/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Host-side build of the disruption monitor (arm64 macOS guest target).
+# Output: lab/guest/disruption-monitor/disruption-monitor (scp'd into the
+# golden image during the seeding session; ad-hoc signed for a stable TCC
+# identity).
+set -euo pipefail
+cd "$(dirname "$0")"
+swiftc -O -target arm64-apple-macos15.0 main.swift -o disruption-monitor
+codesign --force --sign - --identifier com.thingslab.disruption-monitor disruption-monitor
+echo "built: $(pwd)/disruption-monitor"
+codesign -dv disruption-monitor 2>&1 | grep -E 'Identifier|Signature'

--- a/lab/guest/disruption-monitor/main.swift
+++ b/lab/guest/disruption-monitor/main.swift
@@ -1,0 +1,102 @@
+// disruption-monitor — in-guest Aqua-session observer for the Things lab.
+//
+// Emits NDJSON events to ~/things-lab/events.ndjson:
+//   {"ts":"…","kind":"launch|activate|terminate|frontmost|window-new|window-close|title-change","detail":{…}}
+// The probe runner brackets probes with MARK sentinels by appending its own
+// lines to the same file; evidence extraction is a log slice between marks.
+//
+// Requires (granted once in the golden image, clones inherit):
+//   - Accessibility (window/title introspection via CGWindowList)
+// Build: see build.sh (host-side cross-compile, arm64 macOS 15+).
+import AppKit
+import Foundation
+
+let thingsBundleId = "com.culturedcode.ThingsMac"
+let outPath = ("~/things-lab/events.ndjson" as NSString).expandingTildeInPath
+
+final class EventSink {
+    private let handle: FileHandle
+    private let iso = ISO8601DateFormatter()
+    init?() {
+        FileManager.default.createFile(atPath: outPath, contents: nil)
+        guard let h = FileHandle(forWritingAtPath: outPath) else { return nil }
+        h.seekToEndOfFile()
+        handle = h
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    }
+    func emit(_ kind: String, _ detail: [String: Any]) {
+        var record: [String: Any] = ["ts": iso.string(from: Date()), "kind": kind]
+        record["detail"] = detail
+        guard let data = try? JSONSerialization.data(withJSONObject: record) else { return }
+        handle.write(data)
+        handle.write(Data("\n".utf8))
+    }
+}
+
+guard let sink = EventSink() else {
+    FileHandle.standardError.write(Data("cannot open \(outPath)\n".utf8))
+    exit(1)
+}
+
+func appDetail(_ note: Notification) -> [String: Any] {
+    guard let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+    else { return [:] }
+    return [
+        "bundleId": app.bundleIdentifier ?? "?",
+        "name": app.localizedName ?? "?",
+        "pid": app.processIdentifier,
+    ]
+}
+
+let nc = NSWorkspace.shared.notificationCenter
+for (name, kind) in [
+    (NSWorkspace.didLaunchApplicationNotification, "launch"),
+    (NSWorkspace.didActivateApplicationNotification, "activate"),
+    (NSWorkspace.didTerminateApplicationNotification, "terminate"),
+] {
+    nc.addObserver(forName: name, object: nil, queue: .main) { note in
+        sink.emit(kind, appDetail(note))
+    }
+}
+
+// 50ms frontmost poll + Things window snapshot diffing via CGWindowList.
+var lastFrontmost = ""
+var lastWindows: [Int: String] = [:] // windowNumber -> title
+
+func thingsWindows() -> [Int: String] {
+    guard
+        let info = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .excludeDesktopElements], kCGNullWindowID)
+            as? [[String: Any]]
+    else { return [:] }
+    var result: [Int: String] = [:]
+    for w in info {
+        guard let owner = w[kCGWindowOwnerName as String] as? String, owner == "Things",
+              let num = w[kCGWindowNumber as String] as? Int
+        else { continue }
+        result[num] = (w[kCGWindowName as String] as? String) ?? ""
+    }
+    return result
+}
+
+Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { _ in
+    let front = NSWorkspace.shared.frontmostApplication?.bundleIdentifier ?? ""
+    if front != lastFrontmost {
+        sink.emit("frontmost", ["bundleId": front])
+        lastFrontmost = front
+    }
+    let windows = thingsWindows()
+    for (num, title) in windows {
+        if let old = lastWindows[num] {
+            if old != title { sink.emit("title-change", ["window": num, "from": old, "to": title]) }
+        } else {
+            sink.emit("window-new", ["window": num, "title": title])
+        }
+    }
+    for (num, title) in lastWindows where windows[num] == nil {
+        sink.emit("window-close", ["window": num, "title": title])
+    }
+    lastWindows = windows
+}
+
+sink.emit("monitor-start", ["pid": ProcessInfo.processInfo.processIdentifier])
+RunLoop.main.run()

--- a/lab/scripts/golden-build.sh
+++ b/lab/scripts/golden-build.sh
@@ -24,8 +24,12 @@ echo "==> L0: clone + resize"
 tart clone "$LAB_BASE_IMAGE" "$VM"
 tart set "$VM" --cpu 4 --memory 8192
 
+trap 'echo "BUILD FAILED — golden VM left RUNNING for inspection (tart stop $VM when done)" >&2' ERR
+
 echo "==> boot"
-tart run "$VM" --no-graphics &
+# stdout/stderr redirected: an inherited pipe would hold downstream readers
+# open for the VM's whole lifetime (learned the hard way)
+tart run "$VM" --no-graphics >/dev/null 2>&1 &
 RUN_PID=$!
 IP="$(lab_wait_for_ssh "$VM" 240)"
 echo "==> guest IP: $IP"
@@ -54,7 +58,10 @@ lab_ssh "$IP" '
   sudo mv /tmp/things-extract/Things3.app /Applications/Things3.app
   rm -rf /tmp/Things3.zip /tmp/things-extract
   test -d /Applications/Things3.app && echo "Things installed (NOT launched)"
-  sdef /Applications/Things3.app > "$HOME/things-lab/artifacts/Things.sdef" && echo "sdef dumped"
+  # NOT the sdef(1) tool — it requires full Xcode, absent in vanilla guests.
+  # Things ships its dictionary as a bundle resource; copying it is equivalent.
+  cp /Applications/Things3.app/Contents/Resources/Things.sdef "$HOME/things-lab/artifacts/Things.sdef"
+  wc -c "$HOME/things-lab/artifacts/Things.sdef"
 '
 
 echo "==> metadata skeleton"

--- a/lab/scripts/golden-build.sh
+++ b/lab/scripts/golden-build.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Golden image builder — scripted layers only (lab.md §2 L0, L1, and the
+# app-install half of L2). Produces a STOPPED `things-lab-golden-vN` with
+# Things installed but NEVER LAUNCHED (first launch starts the 15-day trial
+# clock — that belongs at the start of the human seeding session; see
+# docs/lab/golden-runbook.md).
+set -euo pipefail
+cd "$(dirname "$0")"
+# shellcheck source=env.sh
+source ./env.sh
+
+VERSION="${1:-v1}"
+VM="things-lab-golden-$VERSION"
+REPO_ROOT="$(cd ../.. && pwd)"
+ZIP="$REPO_ROOT/vendor/Things3.zip"
+[ -f "$ZIP" ] || { echo "missing $ZIP (see vendor/manifest.json)" >&2; exit 1; }
+
+if tart list 2>/dev/null | awk '{print $2}' | grep -qx "$VM"; then
+  echo "VM $VM already exists — delete it first if rebuilding: tart delete $VM" >&2
+  exit 1
+fi
+
+echo "==> L0: clone + resize"
+tart clone "$LAB_BASE_IMAGE" "$VM"
+tart set "$VM" --cpu 4 --memory 8192
+
+echo "==> boot"
+tart run "$VM" --no-graphics &
+RUN_PID=$!
+IP="$(lab_wait_for_ssh "$VM" 240)"
+echo "==> guest IP: $IP"
+
+echo "==> L1: determinism hardening"
+lab_ssh "$IP" 'bash -s' <<'GUEST'
+set -euo pipefail
+sudo softwareupdate --schedule off || true
+sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticCheckEnabled -bool false
+sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticDownload -bool false
+sudo defaults write /Library/Preferences/com.apple.SoftwareUpdate AutomaticallyInstallMacOSUpdates -bool false
+defaults write com.apple.commerce AutoUpdate -bool false
+sudo mdutil -a -i off >/dev/null || true
+sudo tmutil disable || true
+sudo systemsetup -setusingnetworktime off >/dev/null 2>&1 || true
+sudo pmset -a sleep 0 displaysleep 0 disksleep 0
+mkdir -p "$HOME/things-lab/bin" "$HOME/things-lab/artifacts"
+echo "hardening done"
+GUEST
+
+echo "==> L2 (scripted half): install Things WITHOUT launching"
+lab_scp "$ZIP" "$LAB_SSH_USER@$IP:/tmp/Things3.zip"
+lab_ssh "$IP" '
+  set -e
+  ditto -xk /tmp/Things3.zip /tmp/things-extract
+  sudo mv /tmp/things-extract/Things3.app /Applications/Things3.app
+  rm -rf /tmp/Things3.zip /tmp/things-extract
+  test -d /Applications/Things3.app && echo "Things installed (NOT launched)"
+  sdef /Applications/Things3.app > "$HOME/things-lab/artifacts/Things.sdef" && echo "sdef dumped"
+'
+
+echo "==> metadata skeleton"
+lab_ssh "$IP" "cat > \$HOME/things-lab/metadata.json" <<META
+{
+  "golden": "$VM",
+  "builtAt": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "baseImage": "$LAB_BASE_IMAGE",
+  "thingsZipSha256": "$(shasum -a 256 "$ZIP" | cut -d' ' -f1)",
+  "thingsVersion": "3.22.11",
+  "trialFirstLaunch": null,
+  "pinnedDate": null,
+  "schemaFingerprint": null,
+  "seedManifest": null,
+  "humanLayersDone": []
+}
+META
+
+echo "==> stop (golden stays stopped until the human seeding session)"
+tart stop "$VM"
+wait "$RUN_PID" 2>/dev/null || true
+tart list | grep "$VM"
+echo "GOLDEN SCRIPTED LAYERS OK — next: docs/lab/golden-runbook.md (human session)"


### PR DESCRIPTION
- `golden-build.sh`: L0 clone/resize + L1 determinism hardening + Things install **without first launch** (trial clock starts at the human seeding session); `things-lab-golden-v1` built and frozen (stopped)
- `disruption-monitor`: Swift NSWorkspace/CGWindowList observer emitting NDJSON evidence events; host-compiled arm64, ad-hoc signed with stable TCC identity (`com.thingslab.disruption-monitor`)
- `docs/lab/golden-runbook.md`: click-by-click human session guide (Things settings, TCC grants, LaunchAgent, seed dataset, freeze checklist)
- Build fixes learned from v1: bundle-resource sdef copy (sdef(1) needs full Xcode), detached tart-run stdout (pipe-wedge), ERR trap leaves VM running for inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)