### PR TITLE
Fix: This Evening expires daily + Today badge model (UI screenshot reconciliation)

### DIFF
--- a/docs/atlas/schema-v26.md
+++ b/docs/atlas/schema-v26.md
@@ -62,7 +62,7 @@ One row per to-do, project, or heading. Cultured Code's own DDL comments record 
 | UI list | Predicate (open, untrashed unless noted) |
 |---|---|
 | Inbox | `start=0` — items keep tags/deadline/checklist and stay in Inbox until area/project/when assigned (validated "Inbox exit semantics") |
-| Today | `start=1 AND startDate <= <today>` — split: `startBucket=0` → Today proper, `=1` → This Evening; each sorted by `todayIndex` ASC |
+| Today | `start IN (1,2) AND startDate <= <today>` — sorted by `todayIndex` ASC. **This Evening expires daily**: an item renders in the Evening section only while `startBucket=1 AND startDate == <today>` exactly; overdue evening items roll back into Today proper (live-verified 2026-07-02 against a UI screenshot — six 2025-01-13 `startBucket=1` stragglers rendered in Today proper, Evening empty). `start=2` rows with past dates are pending promotion; Things promoted them to `start=1` during observation. **Sidebar badge**: red count = Today items with `deadline <= today`, gray = the rest (exact 270/122 reconciliation). **Deadline alone does NOT put an item in Today** — proven by badge-sum reconciliation (12 open deadline-overdue-but-unscheduled items were excluded from the badge total). |
 | Upcoming | future `startDate` (grouped by day at render) |
 | Anytime | `start=1`, no qualifying today/future date; sorted by `index` |
 | Someday | `start=2` |

--- a/src/cli/commands/reads.ts
+++ b/src/cli/commands/reads.ts
@@ -97,10 +97,15 @@ export function registerReadCommands(program: Command): void {
   }> = [
     {
       name: "today",
-      description: "The Today list, split into Today and This Evening, in UI order",
+      description:
+        "The Today list, split into Today and This Evening (evening expires daily), with the sidebar badge split (red = deadline due/overdue)",
       fetch: (c) => c.read.today(),
-      render: (data: { today: ListItem[]; evening: ListItem[] }) => [
-        "── Today ──",
+      render: (data: {
+        today: ListItem[];
+        evening: ListItem[];
+        badge: { dueOrOverdue: number; other: number };
+      }) => [
+        `── Today (badge: ${data.badge.dueOrOverdue} due/overdue · ${data.badge.other} other) ──`,
         ...renderList(data.today),
         "── This Evening ──",
         ...renderList(data.evening),

--- a/src/model/entities.ts
+++ b/src/model/entities.ts
@@ -32,7 +32,11 @@ interface TaskCommon {
   start: StartState;
   /** The "When" date (packed int in DB), null when unscheduled. */
   startDate: IsoDate | null;
-  /** Today vs This Evening; only meaningful when the item qualifies for Today. */
+  /**
+   * Raw This-Evening assignment (startBucket). Effective only while
+   * startDate == today — the UI rolls stale evening items back into Today
+   * proper. Use TodayView.evening for UI-faithful placement.
+   */
   todaySection: TodaySection | null;
   deadline: IsoDate | null;
   area: Ref | null;

--- a/src/read/views.ts
+++ b/src/read/views.ts
@@ -5,8 +5,16 @@
  * - inbox:    start=0
  * - today:    startDate <= today AND start IN (1, 2) — start=2 rows with a
  *             past date are "pending promotion" (Things recomputes on launch;
- *             the UI shows them in Today either way). Split by startBucket,
- *             ordered by todayIndex (validated comparator).
+ *             the UI shows them in Today either way; promotion observed live
+ *             2026-07-02). Ordered by todayIndex (validated comparator).
+ *             THIS EVENING expires daily: an item renders in the Evening
+ *             section only when startBucket=1 AND startDate == today exactly;
+ *             overdue bucket=1 items roll back into Today proper (live-
+ *             verified against the UI, 2026-07-02).
+ *             Sidebar badge split: red = items with deadline <= today,
+ *             gray = the rest (exact 270/122 reconciliation on live data).
+ *             Deadline-only items (no qualifying startDate) do NOT enter
+ *             Today — proven by that same badge-sum reconciliation.
  * - anytime:  start=1 AND startDate IS NULL (strictly unscheduled active).
  * - upcoming: start=2 AND startDate > today (matches things.py semantics;
  *             repeating templates' next occurrences are NOT included — they
@@ -46,10 +54,13 @@ function materialize(db: DatabaseSync, rows: TaskRow[]): ListItem[] {
 export interface TodayView {
   today: ListItem[];
   evening: ListItem[];
+  /** Mirrors the sidebar badge: red = deadline due/overdue, gray = the rest. */
+  badge: { dueOrOverdue: number; other: number };
 }
 
 export function todayView(db: DatabaseSync, now?: Date): TodayView {
-  const packedToday = encodePackedDate(localToday(now));
+  const todayIso = localToday(now);
+  const packedToday = encodePackedDate(todayIso);
   const rows = fetchTaskRows(
     db,
     `${OPEN} AND t.startDate IS NOT NULL AND t.startDate <= ? AND t.start IN (1, 2)
@@ -57,9 +68,14 @@ export function todayView(db: DatabaseSync, now?: Date): TodayView {
     [packedToday],
   );
   const items = materialize(db, rows);
+  // Evening membership expires daily: raw startBucket=1 counts only while
+  // startDate is exactly today; stale evening items belong to Today proper.
+  const isEvening = (i: ListItem) => i.todaySection === "evening" && i.startDate === todayIso;
+  const dueOrOverdue = items.filter((i) => i.deadline !== null && i.deadline <= todayIso).length;
   return {
-    today: items.filter((i) => i.todaySection !== "evening"),
-    evening: items.filter((i) => i.todaySection === "evening"),
+    today: items.filter((i) => !isEvening(i)),
+    evening: items.filter(isEvening),
+    badge: { dueOrOverdue, other: items.length - dueOrOverdue },
   };
 }
 

--- a/test/cli/e2e.test.ts
+++ b/test/cli/e2e.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import { buildProgram } from "../../src/cli/main.ts";
+import { localToday } from "../../src/model/dates.ts";
 import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
 import { seedTodo } from "../fixtures/seed.ts";
 
@@ -34,7 +35,9 @@ describe("cli end-to-end (fixture db)", () => {
   it("things today --json emits the versioned envelope with split sections", () => {
     fx = buildFixtureDb();
     seedTodo(fx.db, { title: "morning", startDate: "2020-01-01", todayIndex: 1 });
-    seedTodo(fx.db, { title: "tonight", startDate: "2020-01-01", evening: true });
+    // evening membership requires startDate == today exactly (the CLI path
+    // uses the real clock, so seed the actual current date)
+    seedTodo(fx.db, { title: "tonight", startDate: localToday(), evening: true });
 
     const { stdout, exitCode } = runCli(["today", "--json", "--db", fx.path]);
     expect(exitCode).toBe(0);

--- a/test/unit/views.test.ts
+++ b/test/unit/views.test.ts
@@ -46,6 +46,44 @@ describe("todayView", () => {
     expect(view.today.map((i) => i.title)).toEqual(["t1", "t2", "pending-promotion"]);
     expect(view.evening.map((i) => i.title)).toEqual(["e1"]);
   });
+
+  it("expires stale This Evening assignments back into Today proper (live-verified 2026-07-02)", () => {
+    fx = buildFixtureDb();
+    // Scheduled to This Evening on a PAST day and never done — the UI shows
+    // it in Today proper, not This Evening (the 6 phantom items from 2025-01-13).
+    seedTodo(fx.db, {
+      title: "stale-evening",
+      startDate: "2025-01-13",
+      evening: true,
+      todayIndex: 1,
+    });
+    seedTodo(fx.db, { title: "tonight", startDate: "2026-07-02", evening: true, todayIndex: 2 });
+
+    const view = todayView(fx.db, NOW);
+    expect(view.today.map((i) => i.title)).toEqual(["stale-evening"]);
+    expect(view.evening.map((i) => i.title)).toEqual(["tonight"]);
+    // raw assignment stays visible on the entity for both
+    expect(view.today[0]?.todaySection).toBe("evening");
+  });
+
+  it("badge mirrors the sidebar: deadline due/overdue vs other", () => {
+    fx = buildFixtureDb();
+    seedTodo(fx.db, { title: "overdue-dl", startDate: "2026-07-01", deadline: "2026-06-30" });
+    seedTodo(fx.db, { title: "due-today", startDate: "2026-07-01", deadline: "2026-07-02" });
+    seedTodo(fx.db, { title: "future-dl", startDate: "2026-07-01", deadline: "2026-07-09" });
+    seedTodo(fx.db, { title: "no-dl", startDate: "2026-07-01" });
+
+    const view = todayView(fx.db, NOW);
+    expect(view.badge).toEqual({ dueOrOverdue: 2, other: 2 });
+  });
+
+  it("deadline-only items do NOT enter Today (badge-sum reconciliation finding)", () => {
+    fx = buildFixtureDb();
+    seedTodo(fx.db, { title: "deadline-only", deadline: "2026-06-30" }); // no startDate
+    const view = todayView(fx.db, NOW);
+    expect(view.today).toHaveLength(0);
+    expect(view.evening).toHaveLength(0);
+  });
 });
 
 describe("list views", () => {


### PR DESCRIPTION
Mike's live screenshot showed This Evening empty while the API reported 6 items, and a 270/122 sidebar badge our model didn't explain. Read-only probes resolved all of it:

- **Evening expiry**: `startBucket=1` renders in This Evening only while `startDate == today` exactly — the 6 phantoms were stale 2025-01-13 evening assignments, now correctly in Today proper. Live result after fix: `evening: 0` ✅
- **Badge semantics**: red = Today items with `deadline <= today`, gray = rest. Live: `{dueOrOverdue: 270, other: 122}` — digit-for-digit match ✅
- **Deadline ≠ Today membership**: badge-sum reconciliation proves deadline-only items stay out of Today (12 such items excluded)
- Bonus live observation: Things promoted the 2 pending `start=2` past-dated rows to `start=1` mid-session — promotion behavior confirmed dynamically

Atlas + regression tests updated. 38/38 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)