### PR TITLE
Fix: Anytime mirrors the UI (Today members starred)

### DIFF
--- a/docs/atlas/schema-v26.md
+++ b/docs/atlas/schema-v26.md
@@ -64,7 +64,7 @@ One row per to-do, project, or heading. Cultured Code's own DDL comments record 
 | Inbox | `start=0` — items keep tags/deadline/checklist and stay in Inbox until area/project/when assigned (validated "Inbox exit semantics") |
 | Today | `start IN (1,2) AND startDate <= <today>` — sorted by `todayIndex` ASC. **This Evening expires daily**: an item renders in the Evening section only while `startBucket=1 AND startDate == <today>` exactly; overdue evening items roll back into Today proper (live-verified 2026-07-02 against a UI screenshot — six 2025-01-13 `startBucket=1` stragglers rendered in Today proper, Evening empty). `start=2` rows with past dates are pending promotion; Things promoted them to `start=1` during observation. **Sidebar badge**: red count = Today items with `deadline <= today`, gray = the rest (exact 270/122 reconciliation). **Deadline alone does NOT put an item in Today** — proven by badge-sum reconciliation (12 open deadline-overdue-but-unscheduled items were excluded from the badge total). |
 | Upcoming | future `startDate` (grouped by day at render) |
-| Anytime | `start=1`, no qualifying today/future date; sorted by `index` |
+| Anytime | **All active items** — `start=1` (dated-current or undated) plus pending-promotion rows; **Today members render with a ★** (live-verified via screenshot 2026-07-02: starred = also in Today, unstarred = unscheduled). Sorted by `index` |
 | Someday | `start=2` |
 | Logbook | `status IN (2,3)`, ordered by `stopDate` DESC |
 | Trash | `trashed=1` (any status) |

--- a/src/cli/commands/reads.ts
+++ b/src/cli/commands/reads.ts
@@ -7,7 +7,7 @@ import type { Command } from "commander";
 import { openThings, type ThingsClient } from "../../client.ts";
 import { ThingsDbNotFoundError } from "../../db/locate.ts";
 import { ThingsDbOpenError } from "../../db/connection.ts";
-import type { ListItem } from "../../read/views.ts";
+import { isTodayMember, type ListItem } from "../../read/views.ts";
 import { ExitCode } from "../exit-codes.ts";
 import { errorEnvelope, okEnvelope, type EnvelopeMeta } from "../output.ts";
 
@@ -114,8 +114,13 @@ export function registerReadCommands(program: Command): void {
     { name: "inbox", description: "Unprocessed captures (Inbox)", fetch: (c) => c.read.inbox() },
     {
       name: "anytime",
-      description: "Active, unscheduled items (Anytime, strictly unscheduled)",
+      description:
+        "All active items, mirroring the UI: Today members are starred (★), unscheduled items are not",
       fetch: (c) => c.read.anytime(),
+      render: (items: ListItem[]) =>
+        items.length === 0
+          ? ["(empty)"]
+          : items.map((i) => `${isTodayMember(i) ? "★" : " "} ${formatItem(i)}`),
     },
     {
       name: "upcoming",

--- a/src/client.ts
+++ b/src/client.ts
@@ -67,7 +67,7 @@ export function openThings(options: OpenOptions = {}): ThingsClient {
     read: {
       today: () => todayView(conn.db, now()),
       inbox: () => inboxView(conn.db),
-      anytime: () => anytimeView(conn.db),
+      anytime: () => anytimeView(conn.db, now()),
       upcoming: () => upcomingView(conn.db, now()),
       someday: () => somedayView(conn.db),
       logbook: (o) => logbookView(conn.db, o),

--- a/src/read/views.ts
+++ b/src/read/views.ts
@@ -15,7 +15,10 @@
  *             gray = the rest (exact 270/122 reconciliation on live data).
  *             Deadline-only items (no qualifying startDate) do NOT enter
  *             Today — proven by that same badge-sum reconciliation.
- * - anytime:  start=1 AND startDate IS NULL (strictly unscheduled active).
+ * - anytime:  ALL active items — unscheduled PLUS Today members (the UI
+ *             renders Today members with a star; live-verified via screenshot
+ *             2026-07-02: starred = in Today, unstarred = unscheduled).
+ *             Star equivalence: startDate != NULL && <= today.
  * - upcoming: start=2 AND startDate > today (matches things.py semantics;
  *             repeating templates' next occurrences are NOT included — they
  *             are template rows, surfaced separately later).
@@ -84,12 +87,24 @@ export function inboxView(db: DatabaseSync): ListItem[] {
   return materialize(db, rows);
 }
 
-export function anytimeView(db: DatabaseSync): ListItem[] {
+export function anytimeView(db: DatabaseSync, now?: Date): ListItem[] {
+  const packedToday = encodePackedDate(localToday(now));
+  // Mirrors UI membership: every active item, including Today members
+  // (starred in the UI) and pending-promotion rows (start=2, past-dated).
   const rows = fetchTaskRows(
     db,
-    `${OPEN} AND t.start = 1 AND t.startDate IS NULL ORDER BY t."index" ASC`,
+    `${OPEN} AND (
+       (t.start = 1 AND (t.startDate IS NULL OR t.startDate <= ?))
+       OR (t.start = 2 AND t.startDate IS NOT NULL AND t.startDate <= ?)
+     ) ORDER BY t."index" ASC`,
+    [packedToday, packedToday],
   );
   return materialize(db, rows);
+}
+
+/** The UI's star marker in Anytime: the item is also a Today member. */
+export function isTodayMember(item: ListItem, now?: Date): boolean {
+  return item.startDate !== null && item.startDate <= localToday(now);
 }
 
 export function upcomingView(db: DatabaseSync, now?: Date): ListItem[] {

--- a/test/unit/views.test.ts
+++ b/test/unit/views.test.ts
@@ -6,6 +6,7 @@ import { fetchTaskByUuid } from "../../src/read/queries.ts";
 import {
   anytimeView,
   inboxView,
+  isTodayMember,
   logbookView,
   somedayView,
   todayView,
@@ -90,14 +91,32 @@ describe("list views", () => {
   it("routes items to inbox/anytime/upcoming/someday by (start, startDate)", () => {
     fx = buildFixtureDb();
     seedTodo(fx.db, { title: "in-inbox", start: "inbox" });
-    seedTodo(fx.db, { title: "unscheduled", start: "active" });
+    seedTodo(fx.db, { title: "unscheduled", start: "active", index: 1 });
+    seedTodo(fx.db, {
+      title: "scheduled-today",
+      start: "active",
+      startDate: "2026-07-02",
+      index: 2,
+    });
     seedTodo(fx.db, { title: "future", start: "someday", startDate: "2026-07-10" });
     seedTodo(fx.db, { title: "incubating", start: "someday" });
 
     expect(inboxView(fx.db).map((i) => i.title)).toEqual(["in-inbox"]);
-    expect(anytimeView(fx.db).map((i) => i.title)).toEqual(["unscheduled"]);
+    // Anytime mirrors the UI: unscheduled AND Today members (starred in UI)
+    expect(anytimeView(fx.db, NOW).map((i) => i.title)).toEqual(["unscheduled", "scheduled-today"]);
     expect(upcomingView(fx.db, NOW).map((i) => i.title)).toEqual(["future"]);
     expect(somedayView(fx.db).map((i) => i.title)).toEqual(["incubating"]);
+  });
+
+  it("isTodayMember marks the UI star in Anytime", () => {
+    fx = buildFixtureDb();
+    seedTodo(fx.db, { title: "unscheduled", start: "active", index: 1 });
+    seedTodo(fx.db, { title: "starred", start: "active", startDate: "2026-07-01", index: 2 });
+    const items = anytimeView(fx.db, NOW);
+    expect(items.map((i) => [i.title, isTodayMember(i, NOW)])).toEqual([
+      ["unscheduled", false],
+      ["starred", true],
+    ]);
   });
 
   it("logbook orders by stopDate desc and excludes trashed", () => {


### PR DESCRIPTION
Screenshot-verified: Anytime shows ALL active items, with Today members starred. `anytimeView` now matches (1,640 live = 1,248 unscheduled + 392 starred — row-for-row with the screenshot, including the two unstarred items visible in it). `isTodayMember()` exposes the star; CLI renders ★.

🤖 Generated with [Claude Code](https://claude.com/claude-code)