### PR TITLE
Lab: paste-free L2 recorder + ssh auth fix + runbook corrections

### DIFF
--- a/docs/lab/golden-runbook.md
+++ b/docs/lab/golden-runbook.md
@@ -17,34 +17,24 @@ Open **Screen Sharing** → connect to `$IP` → user `admin` / password `admin`
 ## 1. One terminal helper on the host
 
 ```sh
-alias vmssh='sshpass -p admin ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null admin@'"$IP"
+alias vmssh='sshpass -p admin ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PreferredAuthentications=password -o PubkeyAuthentication=no -o IdentitiesOnly=yes admin@'"$IP"
 ```
+
+(The password-only options matter: a loaded ssh-agent can exhaust the server's auth attempts with key offers before the password is tried — "Too many authentication failures".)
 
 ## 2. Things first launch + settings — **[CLICK]**
 
-1. In the VM: launch Things (Dock/Spotlight or `vmssh 'open -a Things3'`). **Record the timestamp**:
-   ```sh
-   vmssh '/Applications/Things3.app/Contents/MacOS/thingscli defaults read firstAppLaunchDate'
-   ```
+1. In the VM: launch Things (Dock/Spotlight or `vmssh 'open -a Things3'`). This starts the 15-day trial clock (guest wall-clock — the guest free-runs with network time off; that's fine, clones pin to it).
 2. **[CLICK]** Walk the welcome flow. **Decline / skip Things Cloud** (no account).
 3. **[CLICK]** Things → Settings…:
-   - General: **Enable Things URLs** → after enabling, click **Manage** under the URL scheme section and copy the auth token (or read it later from SQLite — both work; record it in metadata).
+   - General: **Enable Things URLs** → click **Manage** and copy the auth token (needed for step 4).
    - General: uncheck any "check for updates automatically" option.
-   - Today: leave "Group to-dos in the Today list by project or area" **ON** (record whatever you choose — it affects probe screenshots).
-4. Quit Things (⌘Q).
-5. Update metadata (host):
+   - Today: leave "Group to-dos in the Today list by project or area" **OFF** (flat list = cleaner ordering probes; matches production).
+   - Shortcuts/General: CHECK "Allow Shortcuts app to edit large amounts of data without confirmation" (a confirmation dialog mid-probe is a harness wedge; the unchecked behavior is a deferred S-probe).
+4. Quit Things (⌘Q), then record everything from the host — reads the trial clock via thingscli, computes the pinned date, stores token + settings:
    ```sh
-   vmssh 'python3 - <<PY
-   import json,subprocess,datetime
-   p="/Users/admin/things-lab/metadata.json"
-   m=json.load(open(p))
-   m["trialFirstLaunch"]="<PASTE ISO TIMESTAMP>"
-   m["pinnedDate"]="<trialFirstLaunch + 2 days, YYYY-MM-DD>"
-   m["humanLayersDone"]=m.get("humanLayersDone",[])+["L2"]
-   json.dump(m,open(p,"w"),indent=2)
-   PY'
+   lab/scripts/record-l2.sh '<AUTH-TOKEN>'
    ```
-   (Or just edit the file over Screen Sharing — content matters, method doesn't.)
 
 ## 3. TCC grants — **[CLICK]** (clones inherit these forever)
 

--- a/lab/scripts/env.sh
+++ b/lab/scripts/env.sh
@@ -5,25 +5,29 @@ LAB_BASE_IMAGE="ghcr.io/cirruslabs/macos-sequoia-vanilla:latest"
 LAB_SSH_USER="admin"
 LAB_SSH_PASS="admin"
 
+# Password-only auth: a loaded ssh-agent can exhaust the server's auth
+# attempts with key offers before sshpass's password is ever tried
+# ("Too many authentication failures").
+LAB_SSH_OPTS=(
+  -o StrictHostKeyChecking=no
+  -o UserKnownHostsFile=/dev/null
+  -o LogLevel=ERROR
+  -o PreferredAuthentications=password
+  -o PubkeyAuthentication=no
+  -o IdentitiesOnly=yes
+)
+
 lab_ssh() {
   # lab_ssh <ip> <command...>
   local ip="$1"
   shift
-  sshpass -p "$LAB_SSH_PASS" ssh \
-    -o StrictHostKeyChecking=no \
-    -o UserKnownHostsFile=/dev/null \
-    -o LogLevel=ERROR \
-    -o ConnectTimeout=10 \
+  sshpass -p "$LAB_SSH_PASS" ssh "${LAB_SSH_OPTS[@]}" -o ConnectTimeout=10 \
     "$LAB_SSH_USER@$ip" "$@"
 }
 
 lab_scp() {
   # lab_scp <src> <ip>:<dst>  (or any scp arg pair)
-  sshpass -p "$LAB_SSH_PASS" scp \
-    -o StrictHostKeyChecking=no \
-    -o UserKnownHostsFile=/dev/null \
-    -o LogLevel=ERROR \
-    "$@"
+  sshpass -p "$LAB_SSH_PASS" scp "${LAB_SSH_OPTS[@]}" "$@"
 }
 
 lab_wait_for_ssh() {

--- a/lab/scripts/record-l2.sh
+++ b/lab/scripts/record-l2.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Record the L2 human layer into the golden's metadata.json — paste-free.
+# Reads the trial clock from thingscli on the guest, computes the pinned
+# date (+2 days, GUEST wall-clock), stores the auth token and settings.
+# Idempotent: merges into existing metadata.
+#
+# Usage: ./record-l2.sh <auth-token> [vm-name]
+set -euo pipefail
+cd "$(dirname "$0")"
+# shellcheck source=env.sh
+source ./env.sh
+
+TOKEN="${1:?usage: record-l2.sh <auth-token> [vm-name]}"
+VM="${2:-things-lab-golden-v1}"
+IP="$(tart ip "$VM")"
+
+# Quoted heredocs end-to-end: parameters travel as env vars, never via
+# shell interpolation (no escaping pitfalls).
+lab_ssh "$IP" "LAB_TOKEN=$(printf %q "$TOKEN") LAB_VM=$(printf %q "$VM") bash -s" <<'GUEST'
+set -e
+cp /Applications/Things3.app/Contents/Resources/Things.sdef ~/things-lab/artifacts/Things.sdef
+python3 - <<'PY'
+import json, subprocess, datetime, re, os
+cli = "/Applications/Things3.app/Contents/MacOS/thingscli"
+raw = subprocess.run([cli, "defaults", "read", "firstAppLaunchDate"], capture_output=True, text=True).stdout.strip()
+m = re.match(r"(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}) ([+-]\d{4})", raw)
+assert m, f"unparseable firstAppLaunchDate: {raw!r}"
+first = datetime.datetime.strptime(f"{m.group(1)} {m.group(2)}", "%Y-%m-%d %H:%M:%S")
+p = "/Users/admin/things-lab/metadata.json"
+meta = json.load(open(p)) if os.path.exists(p) else {}
+meta.update({
+    "golden": os.environ["LAB_VM"],
+    "thingsVersion": "3.22.11",
+    "trialFirstLaunch": raw,
+    "trialFirstLaunchIso": first.isoformat() + "Z",
+    "pinnedDate": (first + datetime.timedelta(days=2)).strftime("%Y-%m-%d"),
+    "guestClockNote": "guest free-runs (networktime off); all trial math uses GUEST wall-clock",
+    "uriSchemeAuthToken": os.environ["LAB_TOKEN"],
+    "settings": {
+        "groupTodayByParent": False,
+        "thingsCloudDeclined": True,
+        "thingsUrlsEnabled": True,
+        "shortcutsBulkEditWithoutConfirmation": True,
+        "thingsAutoUpdateDisabled": True,
+    },
+})
+layers = meta.get("humanLayersDone", [])
+if "L2" not in layers:
+    layers.append("L2")
+meta["humanLayersDone"] = layers
+json.dump(meta, open(p, "w"), indent=2)
+print("recorded L2:", meta["trialFirstLaunch"], "| pinned:", meta["pinnedDate"])
+PY
+sync
+wc -c ~/things-lab/artifacts/Things.sdef
+GUEST
+echo "L2 RECORDED OK"


### PR DESCRIPTION
Fixes from Mike's live runbook session: the metadata step is now a script (`record-l2.sh`, proven against the running golden), ssh helpers force password auth, and the runbook records the ratified settings choices (Today grouping OFF, Shortcuts bulk-edit consent ON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)