### PR TITLE
Lab step 3: empirical TCC (required grants already present) + monitor agent live

### DIFF
--- a/docs/lab/golden-runbook.md
+++ b/docs/lab/golden-runbook.md
@@ -36,47 +36,38 @@ alias vmssh='sshpass -p admin ssh -o StrictHostKeyChecking=no -o UserKnownHostsF
    lab/scripts/record-l2.sh '<AUTH-TOKEN>'
    ```
 
-## 3. TCC grants — **[CLICK]** (clones inherit these forever)
+## 3. TCC grants
 
-Push the monitor binary first (host):
+**Empirically revised (2026-07-03):** the two grants that matter — **AppleEvents automation** (sshd → Things3 + System Events) and **Full Disk Access** (sshd, for DB reads) — are **already present in the Cirrus vanilla image** (`auth_value=2`, SIP enabled, so genuine). Both `osascript` calls return prompt-free; no clicks were needed. **Accessibility is not needed** — the disruption-monitor uses CGWindowList + NSWorkspace, not the AX API.
+
+Verify (host), no clicks expected:
 ```sh
-sshpass -p admin scp -o StrictHostKeyChecking=no lab/guest/disruption-monitor/disruption-monitor admin@$IP:/Users/admin/things-lab/bin/
+lab/scripts/tcc-check.sh            # asserts AppleEvents + FDA present; reports Screen Recording
 ```
 
-1. **Automation (AppleEvents), sshd → Things + System Events.** From the host run:
-   ```sh
-   vmssh 'osascript -e "tell application \"Things3\" to get name"'          # triggers prompt
-   vmssh 'osascript -e "tell application \"System Events\" to get name of first process"'
-   ```
-   **[CLICK]** In Screen Sharing, click **Allow** on each consent dialog. Re-run the commands; both must return values with no prompt.
-2. **Accessibility + Screen Recording for the monitor and sshd.** **[CLICK]** System Settings → Privacy & Security:
-   - Accessibility → **+** → add `/Users/admin/things-lab/bin/disruption-monitor` and `/usr/libexec/sshd-keygen-wrapper`
-   - Screen & System Audio Recording → **+** → add both again
-   - Full Disk Access → **+** → add `/usr/libexec/sshd-keygen-wrapper`
-3. **Neutralize Sequoia's monthly screen-capture re-consent** (host):
-   ```sh
-   vmssh 'defaults write ~/Library/Group\ Containers/group.com.apple.replayd/ScreenCaptureApprovals.plist "/Users/admin/things-lab/bin/disruption-monitor" -date "4321-01-01 00:00:00 +0000"'
-   ```
-4. Verify monitor runs and emits events:
-   ```sh
-   vmssh 'nohup ~/things-lab/bin/disruption-monitor >/dev/null 2>&1 & sleep 2; tail -2 ~/things-lab/events.ndjson; pkill -x disruption-monitor'
-   ```
-
-## 4. LaunchAgent for the monitor (host, no clicks)
-
+Push the monitor binary (host) — scripted; run from the repo root:
 ```sh
-vmssh 'cat > ~/Library/LaunchAgents/com.thingslab.disruption-monitor.plist <<PLIST
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0"><dict>
-  <key>Label</key><string>com.thingslab.disruption-monitor</string>
-  <key>ProgramArguments</key><array><string>/Users/admin/things-lab/bin/disruption-monitor</string></array>
-  <key>RunAtLoad</key><true/>
-  <key>KeepAlive</key><true/>
-</dict></plist>
-PLIST
-launchctl bootstrap gui/501 ~/Library/LaunchAgents/com.thingslab.disruption-monitor.plist
-launchctl print gui/501/com.thingslab.disruption-monitor | head -3'
+source lab/scripts/env.sh; IP="$(tart ip things-lab-golden-v1)"
+lab_scp lab/guest/disruption-monitor/disruption-monitor "admin@$IP:/Users/admin/things-lab/bin/"
+```
+
+### Screen Recording — **[CLICK]**, OPTIONAL (window titles + screenshots only)
+
+Without it, the monitor still captures every NSWorkspace event (launch/activate/terminate/frontmost = tier 0/1/2) **and** window-new/window-close (a modal/window appeared = tier 3). What it *cannot* do without it: read window **title strings** (they come back `""`) or take `screencapture` screenshots. DB-delta verdicts and disruption tiers do not depend on it, so **the U-probe campaign can run without this.**
+
+To enable (recommended before the AppleScript/Shortcuts campaigns, where modal-title identification and screenshot evidence add real value):
+1. **[CLICK]** System Settings → Privacy & Security → **Screen & System Audio Recording** → **+** → add both `/Users/admin/things-lab/bin/disruption-monitor` and `/usr/libexec/sshd-keygen-wrapper` (⌘⇧G to type the paths).
+2. Neutralize Sequoia's monthly re-consent (host):
+   ```sh
+   lab/scripts/suppress-screencapture-nag.sh
+   ```
+
+## 4. LaunchAgent for the monitor — scripted, done (2026-07-03)
+
+Installed and verified emitting in the Aqua session:
+```sh
+lab/scripts/install-monitor-agent.sh    # bootstrap + kickstart + emission check
+```
 ```
 
 ## 5. Proxy shortcuts — **[CLICK]** (deferred OK)

--- a/lab/scripts/install-monitor-agent.sh
+++ b/lab/scripts/install-monitor-agent.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Install + start the disruption-monitor LaunchAgent in the guest Aqua
+# session, then verify it emits events. Idempotent.
+set -euo pipefail
+cd "$(dirname "$0")"
+# shellcheck source=env.sh
+source ./env.sh
+VM="${1:-things-lab-golden-v1}"
+IP="$(tart ip "$VM")"
+lab_ssh "$IP" 'bash -s' <<'GUEST'
+set -e
+mkdir -p ~/Library/LaunchAgents
+cat > ~/Library/LaunchAgents/com.thingslab.disruption-monitor.plist <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>Label</key><string>com.thingslab.disruption-monitor</string>
+  <key>ProgramArguments</key><array><string>/Users/admin/things-lab/bin/disruption-monitor</string></array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><true/>
+  <key>StandardErrorPath</key><string>/Users/admin/things-lab/monitor.err</string>
+</dict></plist>
+PLIST
+launchctl bootout gui/$(id -u)/com.thingslab.disruption-monitor 2>/dev/null || true
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.thingslab.disruption-monitor.plist
+launchctl kickstart -k gui/$(id -u)/com.thingslab.disruption-monitor
+sleep 2
+osascript -e 'tell application "Finder" to activate' >/dev/null 2>&1 || true
+sleep 1; open -a Things3; sleep 2
+n=$(wc -l < ~/things-lab/events.ndjson 2>/dev/null || echo 0)
+echo "monitor state: $(launchctl print gui/$(id -u)/com.thingslab.disruption-monitor 2>/dev/null | grep -m1 state | tr -d ' ')"
+echo "events after activity burst: $n"
+[ "$n" -gt 0 ] || { echo "MONITOR NOT EMITTING" >&2; exit 1; }
+echo "MONITOR AGENT OK"
+GUEST

--- a/lab/scripts/suppress-screencapture-nag.sh
+++ b/lab/scripts/suppress-screencapture-nag.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Push the Sequoia screen-capture approval date far into the future so the
+# monthly re-consent nag never fires in unattended clones. Run AFTER Screen
+# Recording has been granted in System Settings.
+set -euo pipefail
+cd "$(dirname "$0")"
+# shellcheck source=env.sh
+source ./env.sh
+VM="${1:-things-lab-golden-v1}"
+IP="$(tart ip "$VM")"
+lab_ssh "$IP" 'bash -s' <<'GUEST'
+plist="$HOME/Library/Group Containers/group.com.apple.replayd/ScreenCaptureApprovals.plist"
+for bin in "/Users/admin/things-lab/bin/disruption-monitor" "/usr/libexec/sshd-keygen-wrapper"; do
+  defaults write "$plist" "$bin" -date "4321-01-01 00:00:00 +0000" 2>/dev/null || true
+done
+echo "screen-capture approval dates pushed to 4321 for monitor + sshd"
+GUEST

--- a/lab/scripts/tcc-check.sh
+++ b/lab/scripts/tcc-check.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Assert the TCC grants the harness depends on. Exit 0 if AppleEvents + FDA
+# for sshd are present; reports Screen Recording status (optional).
+set -euo pipefail
+cd "$(dirname "$0")"
+# shellcheck source=env.sh
+source ./env.sh
+VM="${1:-things-lab-golden-v1}"
+IP="$(tart ip "$VM")"
+lab_ssh "$IP" 'bash -s' <<'GUEST'
+udb="$HOME/Library/Application Support/com.apple.TCC/TCC.db"
+sdb="/Library/Application Support/com.apple.TCC/TCC.db"
+ae=$(sqlite3 "$udb" "SELECT auth_value FROM access WHERE service='kTCCServiceAppleEvents' AND client LIKE '%sshd%';" 2>/dev/null | head -1)
+fda=$(sudo sqlite3 "$sdb" "SELECT auth_value FROM access WHERE service='kTCCServiceSystemPolicyAllFiles' AND client LIKE '%sshd%';" 2>/dev/null | head -1)
+scr=$(sudo sqlite3 "$sdb" "SELECT client||'='||auth_value FROM access WHERE service='kTCCServiceScreenCapture';" 2>/dev/null | tr '\n' ' ')
+echo "AppleEvents(sshd)=${ae:-MISSING}  FullDiskAccess(sshd)=${fda:-MISSING}"
+echo "ScreenCapture: ${scr:-none}"
+[ "$ae" = "2" ] && [ "$fda" = "2" ] || { echo "REQUIRED TCC GRANT MISSING" >&2; exit 1; }
+echo "TCC OK (required grants present)"
+GUEST

--- a/lab/scripts/vmssh
+++ b/lab/scripts/vmssh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Interactive SSH into a lab VM (defaults to the golden), password auth,
+# IP auto-resolved per boot. Version-controlled so the throwaway credential
+# and lab logic stay with the lab, not in global dotfiles.
+#
+#   lab/scripts/vmssh                       # interactive shell into the golden
+#   lab/scripts/vmssh 'some command'        # run a command
+#   lab/scripts/vmssh --vm <name> [cmd...]  # target another lab VM
+#
+# If you want a global shortcut, alias to THIS path (not the raw ssh line):
+#   alias vmssh='/Volumes/Workspace/Projects/things-api/lab/scripts/vmssh'
+set -euo pipefail
+cd "$(dirname "$0")"
+# shellcheck source=env.sh
+source ./env.sh
+
+VM="things-lab-golden-v1"
+if [ "${1:-}" = "--vm" ]; then
+  VM="$2"
+  shift 2
+fi
+IP="$(tart ip "$VM")"
+
+if [ "$#" -eq 0 ]; then
+  exec sshpass -p "$LAB_SSH_PASS" ssh "${LAB_SSH_OPTS[@]}" "$LAB_SSH_USER@$IP"
+fi
+exec sshpass -p "$LAB_SSH_PASS" ssh "${LAB_SSH_OPTS[@]}" "$LAB_SSH_USER@$IP" "$@"


### PR DESCRIPTION
TCC clicking turned out mostly unnecessary — the Cirrus vanilla image already ships AppleEvents automation and Full Disk Access for sshd (verified genuine: auth_value=2, SIP enabled). The disruption-monitor uses CGWindowList (not AX), so Accessibility isn't needed. Screen Recording is the only optional gap — it gates window titles + screenshots but not DB-delta verdicts or tier 0/1/2 detection, so the U-probe campaign is unblocked. Monitor LaunchAgent installed and verified emitting in the Aqua session. Adds tcc-check / install-monitor-agent / suppress-screencapture-nag helpers; runbook step 3/4 rewritten to match reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)