### PR TITLE
Phase 6: regression CI, drift workflow end-to-end, app-oddities catalog

### DIFF
--- a/docs/lab/drift-runbook.md
+++ b/docs/lab/drift-runbook.md
@@ -1,0 +1,31 @@
+# Drift runbook — what to do when a Things update changes the schema
+
+Things app updates can change the database schema. things-api detects this by fingerprint (SHA-256 over the canonical structure of exactly the tables/columns in [src/db/schema.ts](../../src/db/schema.ts)) and **hard-blocks all writes** until a matching baseline ships. This is deliberate safety, not breakage — reads keep working with a warning wherever the depended columns survive.
+
+The full block→accept→re-enable cycle is regression-tested end-to-end in [test/cli/drift-workflow.test.ts](../../test/cli/drift-workflow.test.ts).
+
+## Symptoms
+
+- `things doctor` exits 5, `fingerprint: drift` (or `unknown-version` for a new `databaseVersion`), with per-column detail.
+- Every write returns `blocked:drift` (exit 5). Audit records log the blocked decisions.
+
+## Revalidation workflow (the real fix)
+
+1. **Capture the new surface.** `things doctor --json` → observed fingerprint + drift detail. Note the new Things version.
+2. **Rebuild the lab golden** for the new Things version: download the new trial build (update `vendor/manifest.json` with version + SHA-256), run [`lab/scripts/golden-build.sh`](../../lab/scripts/golden-build.sh) `v<N+1>`, then the human session in [golden-runbook.md](golden-runbook.md) (~1 hour). Check trial-clock inheritance if updating in place (DRIFT-1: if the old clock carries over, rebuild from L0).
+3. **Re-run the full regression** against the new golden: `npm run lab:regress`. Any verdict/tier delta = the update moved the write surface; reconcile suite expectations deliberately, updating the results docs and capability notes with evidence.
+4. **Ship the baseline.** Regenerate the fixture DDL snapshot from the new schema, add `src/db/baselines/db-v<N>.ts` (databaseVersion, fingerprint, known app versions), release.
+5. `things doctor` returns to `ok`; writes re-enable.
+
+## Impatient escape hatch (at your own risk)
+
+```sh
+things doctor --json            # copy fingerprint.value
+things config set accepted-fingerprint sha256:<observed>
+```
+
+Writes re-enable immediately; `doctor` reports `user-accepted` with a standing warning, and **every audit record carries `fingerprint: "user-accepted"`**. Acceptance is exact-hash: a further schema change re-blocks. There is no silent auto-acceptance, ever. Clear it with `things config set accepted-fingerprint ""` after upgrading to a release with a real baseline (any non-matching value is inert, but keep the config honest).
+
+## What reads do under drift
+
+Every read names explicit columns, so removals fail loudly at query time rather than returning silently-wrong shapes. Additions never break anything (extra columns are recorded by doctor, warn-only, excluded from the hash).

--- a/docs/things-app-oddities.md
+++ b/docs/things-app-oddities.md
@@ -1,0 +1,89 @@
+# Things 3 automation-surface oddities — observed behavior catalog
+
+Everything surprising, inconsistent, or hazardous we found while systematically probing Things 3's automation surfaces (URL scheme, AppleScript, and their interaction with the UI). Each entry has reproduction steps, expected vs. actual, and evidence pointers into this repo's probe campaigns. **Section 1 is a genuine crash bug worth reporting to Cultured Code**; the rest ranges from silent-failure hazards to design observations, collected here so a support email can cite them precisely.
+
+**Environment (all findings):** Things 3.22.11 — verified on BOTH the Mac App Store build (32211507, production Mac, macOS 15.7.4) and the direct-download trial build (32211007, clean macOS 15.6 VMs). Deterministically reproduced by the automated probe harness (`npm run lab:regress`); evidence records per probe id live under `lab/artifacts/<runId>/evidence/`.
+
+---
+
+## 1. CRASH: URL-scheme `when=` update on a repeating to-do kills the app
+
+**The report-ready bug.** Setting `when` via the update command on any repeating to-do crashes Things outright — while the equivalent AppleScript command is properly guarded, proving the validation exists but isn't wired into the URL path.
+
+**Reproduce:**
+1. Create a repeating to-do (e.g. daily, fixed schedule — any repeat configuration works; reproduced across multiple rules and inside/outside projects).
+2. Get its uuid (right-click → Share → Copy Link) and the URL auth token (Settings → General → Enable Things URLs → Manage).
+3. `open "things:///update?id=<uuid>&auth-token=<token>&when=today"`
+
+**Expected:** an error (the item's schedule is owned by its repeat rule), like the AppleScript path produces.
+**Actual:** Things terminates immediately. ~1s after the `open` handoff the process dies; macOS writes a crash report to `~/Library/Logs/DiagnosticReports`.
+
+**Contrast — the app already knows how to refuse this.** AppleScript `schedule to do id "<uuid>" for (current date) + 1 * days` on the same row returns a clean scriptable error: `Things3 got an error: Cannot schedule to-do (302)`, exit 1, zero database changes. The guard exists; the URL handler bypasses it.
+
+**Data integrity:** no corruption observed — after relaunch the to-do and its repeat rule are byte-identical (verified by row-level DB diff before/after the crash, every run).
+
+**Also affected:** non-scheduling updates on the same repeating item work fine (`title`, checklist items), so the crash is specific to schedule-class fields via URL.
+
+**Evidence:** first isolated 2026-03-12 on the MAS build (validation notes T12, reproducible across repeat configs); re-reproduced deterministically 2026-07-03 in clean-room VMs on the trial build — probe `U12` (crash detector: process death + `.ips` capture + row-unchanged assertion, green in every acceptance run), guard contrast probe `A21`. Repo refs: `docs/research/validation-notes-step3.md` (T12), `docs/lab/u-suite-results.md`, `docs/lab/a-suite-results.md`, `lab/suites/u-suite.json` (U12), `lab/suites/a-suite.json` (A21).
+
+---
+
+## 2. Silent-failure hazards in the URL scheme
+
+Commands that fail *silently* — the caller gets no signal that nothing (or only part) of the request happened. `open` exits 0 regardless, so an automation caller has no error channel at all; these make read-after-write verification mandatory.
+
+### 2a. Unknown `list=` destination → complete silent no-op
+`things:///update?id=<uuid>&auth-token=<t>&list=No Such Area` does nothing: no modal, no mutation, no log. A typo in a destination name is indistinguishable from success. *(T06/U06)*
+
+### 2b. Unknown tags → silently dropped (partial write)
+`things:///add?title=X&tags=real-tag,typo-tag` creates the to-do with only the tags that already exist; unknown names are discarded without any indication, and no tag is created. The caller believes the full tag set was applied. *(T03/U03, U04)*
+
+### 2c. `heading=` never creates a heading — silently ignored when missing
+On `add`, a `heading=` value that doesn't match an existing heading in the target project is dropped: the to-do is created un-headed. Heading placement works only against pre-existing headings (and matching is by name, so duplicate heading names are ambiguous). *(T09/U09)*
+
+---
+
+## 3. UI vs. URL behavioral divergence: project completion
+
+Completing a project **in the UI** with unresolved children prompts ("mark as completed" etc.). Completing the same project via `things:///update-project?...&completed=true` **silently auto-completes every open child** — no prompt, no signal, canceled children left canceled. Same user intent, materially different outcome depending on the surface. For automation this is a destructive default: one URL can mark dozens of children done. *(T08/U08 — cascade behavior verified row-level)*
+
+---
+
+## 4. Error-modal inconsistencies
+
+### 4a. Error modals don't block execution — they just stack
+URL-error modals (unsupported command, missing auth token) stay on screen until manually dismissed, but subsequent `things:///` commands **keep executing and mutating data behind the open modal** — both further URL commands (T13/U13) and AppleScript commands (A43/X02). A visible error therefore implies neither "stopped" nor "will stop." Unattended machines accumulate stacked modals while data keeps changing.
+
+### 4b. Modal focus behavior differs by command class
+- Bad `add`/`update`/missing-token errors: modal appears **without activating Things** (stays in the background). *(U02/U05)*
+- `things:///json` payload errors and the unsupported `delete` command: the error modal **activates Things and steals focus**. *(U10/U14)*
+
+Same error category, two different disruption behaviors.
+
+### 4c. Modal scope
+The error modal only darkens/blocks the frontmost Things window; other Things windows remain partially interactive. *(T02 notes)*
+
+---
+
+## 5. Observations (arguably by design, but automation-relevant)
+
+### 5a. AppleEvents to a closed Things launch it AND steal focus
+Any AppleScript command — even a pure read like `count of to dos of list "Inbox"` — against a non-running Things launches the app *frontmost*. There is no background-launch behavior on the AppleEvent path; automation must pre-launch with `open -g -a Things3` to avoid yanking the user's focus. *(A40/A41)*
+
+### 5b. Adding an open child silently reopens a resolved project
+Adding (or moving) an open to-do into a completed, canceled, or even already-logged project silently flips the project back to open. Re-resolving the children does not re-complete it. No surface signals this side effect. *(T19/U19)*
+
+### 5c. Checklist updates are replace-all and reset per-item state
+`checklist-items=` replaces the entire checklist; previously completed/canceled checklist items are recreated as open — even when re-sending an identical item list. There is no additive or patch form. *(T07/U07/U20)*
+
+### 5d. Repeating templates are invisible to AppleScript list reads but fetchable by id
+`to dos of list "Someday"` omits repeating templates entirely, yet `to do id "<template-uuid>"` returns them fine. Third-party tooling that enumerates lists (e.g. things.py) can't see repeat rules at all through official read surfaces. *(A12, T16)*
+
+### 5e. `things:///version` launches and foregrounds the app, shows nothing
+Without an x-callback, the version command has no visible output — its only observable effect is launching Things and taking focus. *(T01/U01)*
+
+---
+
+## Suggested report to Cultured Code
+
+Item 1 is the actionable bug: **"URL-scheme `when` update on a repeating to-do crashes Things 3.22.11 (both MAS and direct builds), while the same operation via AppleScript is correctly rejected with error 302 — the URL handler appears to skip the repeating-item validation."** Attach: repro steps above, a crash report from `~/Library/Logs/DiagnosticReports` (the lab harness collects the fresh `.ips` under `lab/artifacts/<runId>/guest-run/crash/` on every `lab:regress` run), and optionally items 2a–2c + 3 as related robustness feedback on the URL scheme's silent-failure modes.

--- a/docs/things-app-oddities.md
+++ b/docs/things-app-oddities.md
@@ -16,7 +16,7 @@ Everything surprising, inconsistent, or hazardous we found while systematically 
 3. `open "things:///update?id=<uuid>&auth-token=<token>&when=today"`
 
 **Expected:** an error (the item's schedule is owned by its repeat rule), like the AppleScript path produces.
-**Actual:** Things terminates immediately. ~1s after the `open` handoff the process dies; macOS writes a crash report to `~/Library/Logs/DiagnosticReports`.
+**Actual:** Things terminates immediately. ~1s after the `open` handoff the process dies; macOS writes a crash report to `~/Library/Logs/DiagnosticReports`. Crash signature: **`EXC_BREAKPOINT (SIGTRAP)`** ("Trace/BPT trap: 5") — a Swift runtime trap, consistent with an unguarded precondition/force-unwrap in the URL handler path (captured `.ips`: `Things3-2026-07-05-120202.ips`, banked by the harness).
 
 **Contrast — the app already knows how to refuse this.** AppleScript `schedule to do id "<uuid>" for (current date) + 1 * days` on the same row returns a clean scriptable error: `Things3 got an error: Cannot schedule to-do (302)`, exit 1, zero database changes. The guard exists; the URL handler bypasses it.
 

--- a/lab/guest/probe-runner.py
+++ b/lab/guest/probe-runner.py
@@ -325,9 +325,17 @@ def run_probe(probe: dict, resolver: Resolver, out_dir: str) -> dict:
         expected_running = probe["appState"] != "not-running" or any(
             "openUrl" in c or "osascript" in c for c in probe["commands"]
         )
+        pid_died = (not pid_alive) and expected_running and record["appRunningBefore"]
         new_ips = sorted(list_ips() - ips_before)
+        if pid_died and not new_ips:
+            # ReportCrash writes the .ips several seconds after process death;
+            # wait for it — the crash log is bug-report evidence.
+            deadline = time.time() + 25.0
+            while time.time() < deadline and not new_ips:
+                time.sleep(1.0)
+                new_ips = sorted(list_ips() - ips_before)
         record["crash"] = {
-            "pidDied": (not pid_alive) and expected_running and record["appRunningBefore"],
+            "pidDied": pid_died,
             "ipsFiles": new_ips,
         }
         for name in new_ips:

--- a/lab/scripts/regress.sh
+++ b/lab/scripts/regress.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Full regression sweep: every probe suite + the write-layer e2e smoke, each
+# against a fresh clone of the golden. One command, zero interaction, exit 0
+# only when everything is green (Lab-7 exit criterion).
+#
+#   npm run lab:regress
+#
+# Any verdict/tier delta means a Things/macOS update moved the automation
+# surface — see docs/lab/drift-runbook.md for the reconciliation workflow.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+source lab/scripts/env.sh
+
+# --- preflight: the golden's pinned date must sit inside its trial window.
+python3 - <<'EOF'
+import json, sys
+from datetime import datetime, timedelta
+meta = json.load(open("docs/lab/golden-v1-metadata.json"))
+first = datetime.strptime(meta["trialFirstLaunchIso"], "%Y-%m-%dT%H:%M:%SZ")
+pinned = datetime.strptime(meta["pinnedDate"], "%Y-%m-%d")
+expiry = first + timedelta(days=15)
+margin = (expiry - pinned).days
+if margin < 2:
+    sys.exit(f"PREFLIGHT FAIL: pinnedDate {meta['pinnedDate']} is within {margin} day(s) of "
+             f"trial expiry {expiry:%Y-%m-%d} — rebuild the golden (docs/lab/golden-runbook.md)")
+print(f"[regress] trial window ok: pinned {meta['pinnedDate']}, expiry {expiry:%Y-%m-%d} ({margin} days margin)")
+EOF
+
+for suite in u a x; do
+  echo "[regress] === suite: $suite ==="
+  npm run lab:run -- --suite "lab/suites/$suite-suite.json"
+done
+
+echo "[regress] === write-layer e2e smoke ==="
+bash lab/scripts/e2e-write-smoke.sh
+
+echo "[regress] ALL GREEN — automation surface unchanged"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lab:run": "node lab/runner/main.ts run",
     "lab:compare": "node lab/runner/main.ts compare",
     "lab:gc": "node lab/runner/main.ts gc",
+    "lab:regress": "bash lab/scripts/regress.sh",
     "check": "npm run typecheck && npm run lint && npm run fmt:check && npm run test"
   },
   "dependencies": {

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -5,6 +5,7 @@
 import { existsSync } from "node:fs";
 import type { Command } from "commander";
 
+import { loadConfig } from "../../config.ts";
 import { BASELINES } from "../../db/baselines/index.ts";
 import { openConnection, ThingsDbOpenError } from "../../db/connection.ts";
 import { locateThingsDb, ThingsDbNotFoundError } from "../../db/locate.ts";
@@ -22,7 +23,7 @@ export interface DoctorReport {
     databaseVersion: number | null;
   };
   fingerprint: {
-    status: "ok" | "drift" | "unknown-version";
+    status: "ok" | "drift" | "user-accepted" | "unknown-version";
     value: string;
     expected: string | null;
     detail: string[];
@@ -84,9 +85,18 @@ export function runDoctor(dbPath?: string): {
   try {
     const observation = observeSchema(conn.db);
     const status = compareToBaseline(observation, BASELINES);
-    const fingerprintStatus =
-      status.kind === "ok" ? "ok" : status.kind === "drift" ? "drift" : "unknown-version";
-    const writesEnabled = status.kind === "ok";
+    // The pipeline honors a user-accepted drifted fingerprint (loud escape
+    // hatch, design §6) — doctor must report what will actually happen.
+    const accepted =
+      status.kind === "drift" && loadConfig().acceptedFingerprint === observation.fingerprint;
+    const fingerprintStatus = accepted
+      ? "user-accepted"
+      : status.kind === "ok"
+        ? "ok"
+        : status.kind === "drift"
+          ? "drift"
+          : "unknown-version";
+    const writesEnabled = status.kind === "ok" || accepted;
     const extraColumns: Record<string, string[]> = {};
     for (const t of observation.tables) {
       if (t.extraColumns.length > 0) extraColumns[t.table] = t.extraColumns;
@@ -108,11 +118,14 @@ export function runDoctor(dbPath?: string): {
       app: { installed: existsSync(THINGS_APP) },
       writes: {
         enabled: writesEnabled,
-        reason: writesEnabled
-          ? "schema fingerprint matches shipped baseline"
-          : status.kind === "drift"
-            ? "schema fingerprint deviates from baseline — writes disabled until revalidated"
-            : "unknown databaseVersion — update things-api or revalidate",
+        reason: accepted
+          ? "DRIFTED fingerprint accepted by user config (accepted-fingerprint) — writes " +
+            "enabled AT YOUR OWN RISK; every audit record carries fingerprint:user-accepted"
+          : writesEnabled
+            ? "schema fingerprint matches shipped baseline"
+            : status.kind === "drift"
+              ? "schema fingerprint deviates from baseline — writes disabled until revalidated"
+              : "unknown databaseVersion — update things-api or revalidate",
       },
     };
     return {

--- a/test/cli/drift-workflow.test.ts
+++ b/test/cli/drift-workflow.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The full drift story, exercised end-to-end through the CLI:
+ * a schema change → doctor reports drift → writes hard-block (exit 5) →
+ * user accepts the observed fingerprint → doctor reports user-accepted →
+ * writes proceed again. (Design §6 — no silent auto-acceptance, ever.)
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { buildProgram } from "../../src/cli/main.ts";
+import { saveConfigKey } from "../../src/config.ts";
+import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
+import { seedTodo } from "../fixtures/seed.ts";
+
+let fixture: FixtureDb;
+let stateDir: string;
+let stdout: string[];
+const envBackup: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  fixture = buildFixtureDb();
+  // Drift that leaves every read query intact: drop a manifest column no
+  // SELECT touches.
+  fixture.db.exec("ALTER TABLE TMSettings DROP COLUMN groupTodayByParent;");
+  stateDir = mkdtempSync(join(tmpdir(), "things-api-drift-test-"));
+  for (const key of ["THINGS_DB", "THINGS_API_STATE_DIR", "THINGS_API_CONFIG_DIR"]) {
+    envBackup[key] = process.env[key];
+  }
+  process.env["THINGS_DB"] = fixture.path;
+  process.env["THINGS_API_STATE_DIR"] = stateDir;
+  process.env["THINGS_API_CONFIG_DIR"] = join(stateDir, "config");
+  stdout = [];
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    stdout.push(String(chunk));
+    return true;
+  });
+  vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  process.exitCode = undefined;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const [key, value] of Object.entries(envBackup)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  fixture.close();
+  rmSync(stateDir, { recursive: true, force: true });
+  process.exitCode = undefined;
+});
+
+async function run(argv: string[]): Promise<Record<string, unknown>> {
+  stdout = [];
+  const program = buildProgram();
+  program.exitOverride();
+  await program.parseAsync(["node", "things", ...argv]);
+  const line = stdout.join("").trim().split("\n").at(-1) ?? "null";
+  return JSON.parse(line) as Record<string, unknown>;
+}
+
+describe("drift workflow", () => {
+  it("doctor reports drift (exit 5) with the missing-column detail", async () => {
+    const env = await run(["doctor", "--json"]);
+    const report = env["data"] as Record<string, Record<string, unknown>>;
+    expect(report["fingerprint"]?.["status"]).toBe("drift");
+    expect(JSON.stringify(report["fingerprint"]?.["detail"])).toContain(
+      "TMSettings.groupTodayByParent",
+    );
+    expect(report["writes"]?.["enabled"]).toBe(false);
+    expect(process.exitCode).toBe(5);
+  });
+
+  it("writes hard-block on drift (exit 5) even for --dry-run", async () => {
+    const uuid = seedTodo(fixture.db, { title: "x" });
+    const env = await run(["todo", "update", uuid, "--title", "y", "--dry-run", "--json"]);
+    expect(env["ok"]).toBe(false);
+    expect((env["error"] as Record<string, unknown>)["code"]).toBe("blocked:drift");
+    expect(process.exitCode).toBe(5);
+  });
+
+  it("accepted-fingerprint escape hatch re-enables writes, loudly", async () => {
+    // Read the observed (drifted) fingerprint from doctor, accept it.
+    const doctorEnv = await run(["doctor", "--json"]);
+    const observed = (doctorEnv["data"] as Record<string, Record<string, unknown>>)[
+      "fingerprint"
+    ]?.["value"] as string;
+    expect(observed).toMatch(/^sha256:/);
+    saveConfigKey("acceptedFingerprint", observed);
+
+    const doctorAfter = await run(["doctor", "--json"]);
+    const report = doctorAfter["data"] as Record<string, Record<string, unknown>>;
+    expect(report["fingerprint"]?.["status"]).toBe("user-accepted");
+    expect(report["writes"]?.["enabled"]).toBe(true);
+    expect(String(report["writes"]?.["reason"])).toContain("AT YOUR OWN RISK");
+    expect(process.exitCode).toBe(0);
+
+    const uuid = seedTodo(fixture.db, { title: "x" });
+    const plan = await run(["todo", "update", uuid, "--title", "y", "--dry-run", "--json"]);
+    expect(plan["ok"]).toBe(true);
+    expect(plan["kind"]).toBe("mutation-plan");
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("acceptance of a DIFFERENT hash does not unlock anything", async () => {
+    saveConfigKey("acceptedFingerprint", "sha256:somebody-elses-hash");
+    const uuid = seedTodo(fixture.db, { title: "x" });
+    const env = await run(["todo", "update", uuid, "--title", "y", "--dry-run", "--json"]);
+    expect((env["error"] as Record<string, unknown>)["code"]).toBe("blocked:drift");
+    expect(process.exitCode).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

Lab-7/Phase-6 exit: **`npm run lab:regress` — one command, zero interaction, exit 0 only when the whole automation surface is unchanged.** Full sweep validated: U (22 probes), A (39), X (3), and the 18-step write-layer e2e, each against a fresh clone, gated by a trial-window preflight. Plus the drift workflow proven end-to-end in tests, and the report-ready app-oddities catalog.

## What's in here

- **`lab:regress`** (lab/scripts/regress.sh): trial-window preflight on the golden metadata (fails loudly when the pinned date nears trial expiry — rebuild signal), then u/a/x suites + e2e smoke. Acceptance run: all four stages GREEN (u-20260703-155221, a-…155443, x-…155806, e2e-…105847).
- **Drift workflow, end-to-end** (test/cli/drift-workflow.test.ts): schema change → doctor reports drift with column detail (exit 5) → writes hard-block even for --dry-run → `config set accepted-fingerprint <observed>` re-enables loudly → non-matching acceptance unlocks nothing. `doctor` now honestly reports `user-accepted` when the escape hatch is active (it previously claimed writes-disabled while the pipeline would proceed). Operational guide: docs/lab/drift-runbook.md.
- **docs/things-app-oddities.md** — the bug-report compilation: the repeating `when=` URL crash with captured crash signature **EXC_BREAKPOINT (SIGTRAP)** and the AppleScript error-302 guard contrast (the validation exists, the URL handler skips it); silent-failure hazards (unknown destinations/tags/headings); UI-vs-URL project-completion divergence; modal stacking + focus inconsistencies; automation-relevant observations. Each with repro steps, expected/actual, and probe-evidence refs — sections lift directly into a Cultured Code support email.
- **Crash-log capture**: probe-runner now waits for ReportCrash's `.ips` after a detected crash; the regression sweep banked `Things3-2026-07-05-120202.ips` as attachable evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)