### PR TITLE
Phase 7: agent ergonomics + release prep; L5 paused + golden re-validated

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,28 @@ Things 3 installed and launched once, Node ≥ 24, and a handful of one-time mac
 
 - **Reads** go directly to Things' local SQLite database (read-only, WAL-aware). **Writes** go exclusively through official app surfaces — URL scheme, AppleScript, Shortcuts — never direct DB writes (sync corruption).
 - **Every mutation is verified**: pre-read → hazard guards → execute → poll re-read until the expected delta appears. Silent no-ops are failures.
-- **Every mutation is audited**: JSONL trail with requested vs. observed deltas and rollback hints.
-- **Schema drift is detected**: table/column fingerprints keyed by Things' database version; writes hard-block on mismatch.
+- **Every mutation is audited**: JSONL trail (`~/.local/state/things-api/audit/`) with requested vs. observed deltas; auth tokens structurally redacted.
+- **Schema drift is detected**: table/column fingerprints keyed by Things' database version; writes hard-block on mismatch ([drift runbook](docs/lab/drift-runbook.md)).
 - **Disruption is explicit**: every operation×vector combination carries a disruption tier (0 = invisible → 3 = navigates UI/modals); disruptive operations require explicit opt-in flags.
 - **Nothing is developed against production data**: probing and integration tests run in disposable Tart macOS VMs.
+
+## For agents
+
+The CLI is designed to be driven by coding agents with no out-of-band knowledge. The contract:
+
+1. **Discovery**: `things --help` (ends with AGENT NOTES), per-command `--help` (states each write's vector, disruption tier, hazards, and exact acknowledgement flag names — regression-tested as API), and `things capabilities [--op <op>] --json` (the lab-validated operation × vector support matrix, with probe-evidence ids).
+2. **Structured output**: every command takes `--json` → versioned envelope `{ apiVersion, ok, kind, data|error, meta }` on stdout; human chatter goes to stderr only.
+3. **Stable exit codes**: `0` ok · `2` usage · `3` verify-failed (mutation executed, expected delta never appeared) · `4` blocked (hazard guard or disruption policy; error carries `remediation`) · `5` drift-blocked · `6` unsupported · `7` environment.
+4. **Plan before executing**: every write supports `--dry-run` — compiled invocation (token-redacted), chosen vector, tier, hazards checked, expected delta. Nothing runs, nothing is audited.
+5. **No prompts, ever**: risky semantics are explicit flags — `--children require-resolved|auto-complete` (project completion cascades), `--acknowledge-checklist-reset` (checklist replacement destroys per-item state), `--acknowledge-project-reopen` (open child reopens a resolved project), `--dangerously-permanent` (area/tag delete and empty-trash skip the Trash).
+
+A typical mutation flow:
+
+```sh
+things capabilities --op todo.move --json      # is it possible, which vector, what tier?
+things search "Buy milk" --json                # resolve the uuid
+things todo move <uuid> --project "Errands" --dry-run --json   # inspect the plan
+things todo move <uuid> --project "Errands" --json             # execute, verified
+```
+
+Failure modes are first-class: a `verify-failed:silent-noop` means the app accepted the command and did nothing (a real Things behavior the guards mostly prevent — see [docs/things-app-oddities.md](docs/things-app-oddities.md)); `blocked:*` responses include machine-readable remediation.

--- a/docs/lab/golden-runbook.md
+++ b/docs/lab/golden-runbook.md
@@ -69,11 +69,59 @@ Installed and verified emitting in the Aqua session:
 lab/scripts/install-monitor-agent.sh    # bootstrap + kickstart + emission check
 ```
 
-## 5. Proxy shortcuts — **[CLICK]** (deferred OK)
+## 5. Proxy shortcuts — **[CLICK]** (the L5 sitting, ~30–45 min)
 
-Building the ~8 parameterized proxy shortcuts in Shortcuts.app is only needed for the Lab-5 Shortcuts campaign — **you can defer this to a second short session**. When ready: build each proxy per `docs/design/lab.md` §4.4, run each once (absorb consents), then export signed copies back into the repo (`shortcuts sign`).
+Scoped to the one gap only Shortcuts fills — the **heading lifecycle in existing projects** — plus a structured-output read probe. Four proxies, built by hand in the golden's Shortcuts.app (Apple provides no programmatic import; runtime execution via `shortcuts run` is fully scriptable afterwards).
 
-Minimum for now: **[CLICK]** open Shortcuts.app once, dismiss any first-run dialog, Settings → Advanced → enable **Allow Running Scripts**.
+### 5.1 First-run + settings **[CLICK]**
+
+1. In the golden (Screen Sharing): open **Shortcuts.app**; dismiss any welcome/first-run dialog. Ignore/decline any iCloud sign-in nag — shortcuts stay local.
+2. Shortcuts → Settings → **Advanced** → check **Allow Running Scripts**.
+
+### L5 status (paused 2026-07-03, resume checklist below)
+
+First sitting done through §5.1 + first-draft proxies. **Key finding:** the Things actions' Items/Project fields are **app-entity parameters** — the field's popover is a live picker of existing Things records and does **not** accept a raw string variable (screenshots in session notes). The established pattern is a **Find → act chain**: a `Find Items` action resolves name→entity and its *output* binds into the entity field. The four proxies exist in the golden in draft state (`shortcuts list` confirms) but with picker-bound/static entity fields — **they need restructuring per §5.2, not rebuilding**. Also noted: browsing those pickers launches Things in the golden (entity queries go through the app), so the golden's task data ran one maintenance pass at guest 2026-07-03 — post-sitting `lab:regress` re-validated the golden green. Resume: restructure the three mutation proxies with Find-chains (gestures in §5.2a), check whether Find Items offers an **ID** filter (upgrades addressing from name to uuid), then §5.3 consent runs.
+
+### 5.2 Build the four proxies **[CLICK]**
+
+Each proxy: File → New Shortcut, name it EXACTLY as shown, add the actions listed in order. The pattern is always: take a JSON dictionary as input → feed fields into one Things action → return the result. In each action's field, insert the **Shortcut Input** variable and pick **Get Value for Key** (or insert a "Get Dictionary Value" action) for the named key.
+
+Entity fields (Items/Project) never take raw string variables — always resolve through a **Find Items** action and bind its output (the "Items" magic variable) into the entity field.
+
+**§5.2a — inserting the magic variable into an entity field** (first gesture that works, use everywhere):
+1. Click the field → look at the very top of the popover, above the entity list (empty row = variable slot), scroll up for a "Select Variable" entry.
+2. Right-click (ctrl-click) the blue field chip → "Select Variable"/"Insert Variable".
+3. Click the Find Items action so its result token is visible, then drag the "Items" pill onto the entity field below.
+
+**`things-proxy-create-heading`** — input `{"title": …, "project": …}`
+1. *Get Dictionary from Input*
+2. **Find Items**: (Show More) Type = Project, Name is ← dictionary `project`, Limit 1
+3. **Create Heading**: Title ← dictionary `title`; Project ← step 2's output
+4. Output the result
+
+**`things-proxy-edit-title`** — input `{"find": …, "title": …}`
+1. *Get Dictionary from Input*
+2. **Find Items**: Name is ← dictionary `find`, Limit 1
+3. **Set Title of** ← step 2's output **to** ← dictionary `title`
+4. Output the result
+
+**`things-proxy-delete-items`** — input `{"find": …}`
+1. *Get Dictionary from Input*
+2. **Find Items**: Name is ← dictionary `find`, Limit 1
+3. **Delete** ← step 2's output (leave any "immediately delete" toggle OFF — Trash, not hard delete)
+4. Output the result
+
+**`things-proxy-find-items`** — input `{"search": …}` — built ✓ (search key bound; no filters/sort). The S-campaign inspects what identifiers its structured output carries.
+
+While editing: check whether Find Items' filter list offers **ID** as a filter field and note it. If even Find-chained output refuses to bind into an entity field, stop — that finding means parameterized proxies are infeasible (headings stay UI-only; document and shrink the campaign).
+
+### 5.3 Consent absorption + export (scripted assist)
+
+Run each proxy once so macOS's per-shortcut consents fire; click **Allow** on each prompt in Screen Sharing. The driver creates a sacrificial `L5-CONSENT-PROJ` in Things for the runs and trashes it afterwards (residue: one trashed project — probe assertions tolerate it; recorded in metadata). Then it exports signed copies to `lab/shortcuts/` in the repo.
+
+### 5.4 Freeze checklist (scripted)
+
+Quit Shortcuts + Things, verify `shortcuts list` shows the four proxies, truncate `~/things-lab/events.ndjson`, update `golden-v1-metadata.json` (humanLayersDone += L5, note consent residue), `tart stop`.
 
 ## 6. Seed dataset
 

--- a/docs/lab/golden-v1-metadata.json
+++ b/docs/lab/golden-v1-metadata.json
@@ -38,5 +38,21 @@
   },
   "deferred": [
     "L5: Shortcuts first-run + Allow Running Scripts + proxy imports (second sitting, before S-probe campaign)"
-  ]
+  ],
+  "l5Progress": {
+    "sittingPaused": "2026-07-03",
+    "done": [
+      "Shortcuts first-run dismissed",
+      "Allow Running Scripts enabled",
+      "four draft proxies exist (create-heading, edit-title, delete-items, find-items)"
+    ],
+    "finding": "Things-action entity fields (Items/Project) are app-entity pickers; raw string variables refused \u2014 restructure with Find Items -> bind output (golden-runbook \u00a75.2)",
+    "note": "entity pickers launched Things during the sitting (guest 2026-07-03) \u2014 one app-maintenance pass ran on golden task data; post-sitting lab:regress validated green",
+    "remaining": [
+      "restructure 3 mutation proxies with Find-chains",
+      "check ID filter on Find Items",
+      "\u00a75.3 consent runs + signed exports",
+      "\u00a75.4 freeze checklist"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "things-api",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "description": "Typed TypeScript library + CLI for Things 3 (Cultured Code) — verified writes, audit trail, schema-drift detection",
   "license": "UNLICENSED",
@@ -20,6 +20,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "prepublishOnly": "npm run check && npm run build",
+    "smoke:pack": "bash scripts/pack-smoke.sh",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint",
     "fmt": "oxfmt",

--- a/scripts/pack-smoke.sh
+++ b/scripts/pack-smoke.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Release smoke: pack the tarball, install it into a scratch project, and
+# prove the installed `things` bin works end-to-end against a throwaway
+# fixture DB (no Things install needed). Guards the files/exports/bin wiring
+# that unit tests can't see.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO=$(pwd)
+
+npm run build >/dev/null
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+TARBALL=$(npm pack --pack-destination "$WORK" 2>/dev/null | tail -1)
+echo "[pack-smoke] packed $TARBALL"
+
+cd "$WORK"
+npm init -y >/dev/null 2>&1
+npm install "./$TARBALL" >/dev/null 2>&1
+
+# Build the fixture and KEEP THE HANDLE OPEN while the CLI runs: read-only
+# WAL opens require the -wal/-shm sidecars, which a clean close checkpoints
+# away (same reason doctor tells users to launch Things once).
+REPO="$REPO" node --input-type=module -e "
+import { DatabaseSync } from 'node:sqlite';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+const ddl = readFileSync(process.env.REPO + '/test/fixtures/schema-v26.sql', 'utf8');
+const db = new DatabaseSync('fixture.sqlite');
+db.exec('PRAGMA journal_mode = WAL;');
+db.exec(ddl);
+db.prepare(\"INSERT INTO Meta (key, value) VALUES ('databaseVersion', ?)\").run(
+  '<?xml version=\"1.0\" encoding=\"UTF-8\"?><plist version=\"1.0\"><integer>26</integer></plist>');
+
+const bin = 'node_modules/.bin/things';
+const run = (args) => execFileSync(bin, args, { encoding: 'utf8' });
+run(['--help']);
+const doctor = run(['doctor', '--db', 'fixture.sqlite', '--json']);
+if (!doctor.includes('\"status\":\"ok\"')) throw new Error('doctor fingerprint not ok: ' + doctor);
+const today = run(['today', '--db', 'fixture.sqlite', '--json']);
+if (!today.includes('\"ok\":true')) throw new Error('today read failed: ' + today);
+const caps = run(['capabilities', '--op', 'todo.add', '--json']);
+if (!caps.includes('\"support\":\"yes\"')) throw new Error('capabilities missing: ' + caps);
+db.close();
+console.log('[pack-smoke] GREEN — tarball installs and the bin works');
+"

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -6,6 +6,8 @@
  * (writes). Contracts that already bind: exit codes (./exit-codes.ts) and
  * the --json envelope (./output.ts).
  */
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { Command } from "commander";
 
 import { registerDoctor } from "./commands/doctor.ts";
@@ -23,6 +25,11 @@ AGENT NOTES:
     5 drift-blocked, 6 unsupported, 7 environment.
   - No command ever prompts interactively; risky operations require explicit
     acknowledgement flags documented in their --help.
+  - Discover the operation x vector support matrix with: things capabilities --json
+  - Every write supports --dry-run: inspect the compiled invocation, disruption
+    tier, hazards, and expected delta without executing anything.
+  - Every mutation is verified by read-after-write and recorded in the audit
+    trail (~/.local/state/things-api/audit/); blocked errors carry remediation.
 `;
 
 export function buildProgram(): Command {
@@ -41,7 +48,19 @@ export function buildProgram(): Command {
   return program;
 }
 
-const isDirectRun = process.argv[1]?.endsWith("main.ts") || process.argv[1]?.endsWith("main.js");
+// Direct-run detection must survive the npm .bin symlink (argv[1] ends with
+// "things", not "main.js") — resolve through realpath and compare to this
+// module. Caught by scripts/pack-smoke.sh: a name-suffix check made the
+// installed bin a silent no-op.
+const isDirectRun = ((): boolean => {
+  const invoked = process.argv[1];
+  if (invoked === undefined) return false;
+  try {
+    return realpathSync(invoked) === fileURLToPath(import.meta.url);
+  } catch {
+    return false;
+  }
+})();
 if (isDirectRun) {
   const program = buildProgram();
   program.exitOverride((err) => {

--- a/test/cli/help-contract.test.ts
+++ b/test/cli/help-contract.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Help text is the agent API contract (design §3): agents discover the tool
+ * through --help, so its load-bearing statements — hazards, ack flag names,
+ * vectors, tiers, exit codes — are regression-tested here. These assert the
+ * CONTRACT lines, not the full rendering, so cosmetic rewording stays cheap
+ * while contract drift fails loudly.
+ */
+import { describe, expect, it } from "vitest";
+
+import { buildProgram } from "../../src/cli/main.ts";
+
+function helpFor(...path: string[]): string {
+  const program = buildProgram();
+  let cmd = program as ReturnType<typeof buildProgram>;
+  for (const name of path) {
+    const next = cmd.commands.find((c) => c.name() === name);
+    if (next === undefined) throw new Error(`no command: ${path.join(" ")}`);
+    cmd = next;
+  }
+  // Commander wraps to terminal width; collapse whitespace so contract
+  // substrings match regardless of where lines break.
+  return cmd.helpInformation().replace(/\s+/g, " ");
+}
+
+describe("root help", () => {
+  it("carries the agent notes: --json, stable exit codes, no prompts", () => {
+    const program = buildProgram();
+    // AGENT NOTES lives in addHelpText(after); commander exposes it on render.
+    let rendered = "";
+    program.configureOutput({ writeOut: (s) => void (rendered += s) });
+    program.exitOverride();
+    try {
+      program.parse(["node", "things", "--help"]);
+    } catch {
+      // exitOverride throws after help renders — expected
+    }
+    expect(rendered).toContain("AGENT NOTES");
+    expect(rendered).toContain("0 ok, 2 usage, 3 verify-failed, 4 blocked");
+    expect(rendered).toContain("5 drift-blocked, 6 unsupported, 7 environment");
+    expect(rendered).toContain("No command ever prompts interactively");
+  });
+});
+
+describe("write-command help states the contract", () => {
+  it("todo add: vector, tier, hazards, ack flag", () => {
+    const help = helpFor("todo", "add");
+    expect(help).toContain("vector: url-scheme");
+    expect(help).toContain("tier 0");
+    expect(help).toContain("H-UNKNOWN-TAG");
+    expect(help).toContain("H-REOPEN-RESOLVED-PROJECT");
+    expect(help).toContain("--acknowledge-project-reopen");
+    expect(help).toContain("--dry-run");
+  });
+
+  it("todo update: repeating-template hard-block is documented", () => {
+    const help = helpFor("todo", "update");
+    expect(help).toContain("H-REPEAT-SCHEDULE");
+    expect(help).toContain("crashes Things");
+  });
+
+  it("todo checklist: destructive semantics + exact ack flag", () => {
+    const help = helpFor("todo", "checklist");
+    expect(help).toContain("H-CHECKLIST-REPLACE");
+    expect(help).toContain("--acknowledge-checklist-reset");
+    expect(help).toContain("Destroys per-item completion state");
+  });
+
+  it("project complete: mandatory children policy + verified cascade", () => {
+    const help = helpFor("project", "complete");
+    expect(help).toContain("--children <policy>");
+    expect(help).toContain("auto-completes open");
+    expect(help).toContain("verified");
+  });
+
+  it("permanent deletes require --dangerously-permanent", () => {
+    for (const path of [
+      ["area", "delete"],
+      ["tag", "delete"],
+      ["trash", "empty"],
+    ]) {
+      const help = helpFor(...(path as [string, string]));
+      expect(help).toContain("PERMANENTLY");
+      expect(help).toContain("--dangerously-permanent");
+    }
+  });
+
+  it("doctor: exit-code contract", () => {
+    const help = helpFor("doctor");
+    expect(help).toContain("Exit 0 healthy; 5 schema drift");
+  });
+
+  it("capabilities: discovery command exists and mentions vectors", () => {
+    const help = helpFor("capabilities");
+    expect(help).toContain("vector");
+    expect(help).toContain("--op");
+  });
+});


### PR DESCRIPTION
## Summary

Phase 7 (agent ergonomics + release prep), plus the paused Shortcuts L5 sitting documented and the golden re-validated after it.

## Agent ergonomics

- **Help-contract tests**: the statements agents rely on — hazard ids, exact ack flag names, vectors, tiers, exit codes — are regression-tested across the key `--help` screens. Help text is API; now it can't silently drift.
- **README "For agents"**: the discovery → dry-run → execute flow, envelope/exit-code contract, and the explicit-acknowledgement catalog. AGENT_NOTES epilog now points at `capabilities`, `--dry-run`, and the audit trail.

## Release prep

- v0.1.0, `prepublishOnly` (check + build), and `scripts/pack-smoke.sh`: pack → install the tarball into a scratch project → drive the **installed bin** against a fixture DB.
- The smoke immediately paid for itself: **the installed CLI was a silent no-op** — direct-run detection keyed on a `main.js` name suffix, which the npm `.bin/things` symlink never matches. Now realpath-compared to the module. (The VM e2e had masked this by invoking `dist/cli/main.js` directly.)

## Shortcuts L5 (paused, documented)

Sitting findings in golden-runbook §5 + metadata `l5Progress`: Things-action entity fields (Items/Project) are app-entity pickers that refuse raw string variables — the proxies need **Find → act chains** (recipes updated; four draft proxies exist in the golden awaiting restructure). Browsing the entity pickers launched Things once in the golden (one app-maintenance pass on task data); a full post-sitting `lab:regress` came back **ALL GREEN** (u-20260703-200400, a-…200622, x-…200936, e2e 18/18), so the golden remains valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)