### PR TITLE
Phase 8: ordering — O-suite campaign + write.reorder (native experimental + verified bounce)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The CLI is designed to be driven by coding agents with no out-of-band knowledge.
 3. **Stable exit codes**: `0` ok · `2` usage · `3` verify-failed (mutation executed, expected delta never appeared) · `4` blocked (hazard guard or disruption policy; error carries `remediation`) · `5` drift-blocked · `6` unsupported · `7` environment.
 4. **Plan before executing**: every write supports `--dry-run` — compiled invocation (token-redacted), chosen vector, tier, hazards checked, expected delta. Nothing runs, nothing is audited.
 5. **No prompts, ever**: risky semantics are explicit flags — `--children require-resolved|auto-complete` (project completion cascades), `--acknowledge-checklist-reset` (checklist replacement destroys per-item state), `--acknowledge-project-reopen` (open child reopens a resolved project), `--dangerously-permanent` (area/tag delete and empty-trash skip the Trash).
+6. **Experimental surfaces are opt-in**: `things reorder` (ordering within Today/a project/an area) rides an undocumented AppleScript command that any Things update may remove. It requires `things config set allow-experimental true` and re-checks the app's sdef declaration before every dispatch; `things doctor` reports both gates. Evening reorders never touch it — they use verified `when=` round-trips (the "bounce", ≤10 items) instead.
 
 A typical mutation flow:
 

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -1,0 +1,54 @@
+# Capability gaps — what the API cannot do (yet), and why
+
+Living register of Things-app capabilities that are missing, thin, or janky in things-api, with evidence refs and the planned path (or the reason none exists). Assessed 2026-07-04, post-Phase-7, mid-Phase-8 (reorder in flight on `mg/phase8-reorder`).
+
+## Headline gaps
+
+### 1. Headings in existing projects — the big one; Shortcuts is the only path
+- Create works ONLY inside a brand-new project via the `things:///json` add-project payload — and `project.add` doesn't expose even that yet (small win available).
+- In an existing project: no create/rename/archive/delete on any validated surface (`heading=` never creates, T09/U09; json update op on headings errors, U10; AppleScript has no heading class, A31).
+- Native reorder RIPS headed children out of their headings (O06) — heading-scoped ordering is unautomatable.
+- **Path:** finish the L5 golden sitting (Find→act chain proxies, golden-runbook §5) → S-campaign → Shortcuts vector for `heading.add/rename/delete` (+ probe archive). This is the sole capability Shortcuts uniquely provides.
+
+### 2. Repeating items — creation and rule-editing are UI-only, permanently (until CC ships an API)
+- No surface creates a repeating item or edits a repeat rule: URL crashes on schedule-writes (the bug report), AppleScript refuses (error 302), Shortcuts actions expose no repeat parameters, and the rule plist must never be written directly.
+- What works: safe template edits (title/notes/checklist — U12B/T12), full editing of spawned instances (guards only block templates), reading rule presence + config via the private `json` property (A51).
+- **Path:** none. Document; guard (done); revisit per Things release.
+
+### 3. Reminders (time-of-day) — documented URL feature, never probed, unexposed
+- `when=today@18:00` style reminders exist in the URL docs; `TMTask.reminderTime` codec is an open atlas item.
+- **Path:** probe suite (encoding + set/clear semantics + repeating hazard interaction) → extend `when` vocabulary. Probably the most user-visible gap after headings. Check whether Shortcuts' Edit Items exposes a Reminder property while S-probing.
+
+## Editing-completeness gaps (all cheap: AppleScript setters + one probe suite)
+
+| Gap | Evidence/path |
+|---|---|
+| `area.update` — rename; change tags post-creation | `set name of area` unprobed (standard setter); `set tag names of area` already validated (seeding). |
+| `tag.update` — rename, re-parent existing, keyboard shortcut | `set parent tag` validated at creation (A05); rename unprobed. |
+| Notes append/prepend | URL `append-notes`/`prepend-notes` params documented, unprobed; we only replace. |
+| Move to Inbox | `todo.move` covers project/area/heading only; AppleScript `move to list "Inbox"` unprobed. |
+| Duplicate to-do/project | Exists on all three surfaces (URL `duplicate=true`, AppleScript `duplicate`, Shortcuts); never probed. |
+| `log completed now` | Probed (A28), trivial to expose. |
+| Project scheduling evidence | `project update --when` compiles but only `completed=true` was specifically probed (U08) — firm up with one probe. |
+
+## Ordering (Phase 8, in flight)
+
+- Landing now: Today (native, bucket-0 members only — O03: evening members get silently de-eveninged), project + area scopes (native, un-headed children only — O06), Evening via verified bounce (O07/O08).
+- Still unprobed: sidebar ordering (areas among areas; projects within an area), checklist-item order (likely unautomatable — no granular checklist surface anywhere).
+
+## Read-layer gaps
+
+| Gap | Detail |
+|---|---|
+| Tag-filtered list reads | The UI filters any list by tag INCLUDING inherited; our `read.*` views take no tag parameter. Inheritance model itself is correct (direct `tags` + computed `inheritedTags`, T18/U18/A13) — this is query surface only. |
+| Today ordering fidelity | `todayIndexReferenceDate` re-bucketing unresolved — our Today order can mismatch the UI for stale-referenceDate items. Matters more now that we WRITE order. |
+| Upcoming repeat occurrences | Templates' future instances aren't synthesized into `upcoming` (the UI shows them). |
+| Checklist state granularity | Read per-item state via private `json` (A51) not yet surfaced; writes stay wholesale-replace everywhere (app limitation, all surfaces). |
+
+## Deliberately excluded (not gaps)
+
+UI navigation (`show`, quick entry panel — tier 2–3, probed A53/A54); Things Cloud sync verification (out of scope); direct DB writes (forbidden, sync corruption); tombstone semantics with sync off (A25/A27 — sync artifact).
+
+## Shortcuts verdict (for planning)
+
+Fills: **headings in existing projects** (unique), maybe heading-archive + reminder property (S-probes). Does NOT fill: repeat rules, checklist granularity, area/tag editing (AppleScript already better at tier 0). Everything else it offers is redundant with validated tier-0 vectors.

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -52,3 +52,13 @@ UI navigation (`show`, quick entry panel — tier 2–3, probed A53/A54); Things
 ## Shortcuts verdict (for planning)
 
 Fills: **headings in existing projects** (unique), maybe heading-archive + reminder property (S-probes). Does NOT fill: repeat rules, checklist granularity, area/tag editing (AppleScript already better at tier 0). Everything else it offers is redundant with validated tier-0 vectors.
+
+## Roadmap (agreed 2026-07-04; tracked as tasks #23–#27)
+
+1. **Phase 8 (in flight)** — `write.reorder`: today (native, bucket-0 only), evening (bounce), project/area (native, un-headed only); experimental gate + sdef canary; H-REORDER-SCOPE guard. Task #23.
+2. **Phase 9a** — R-suite (reminders: `when=today@18:00` set/clear/encoding, repeating-template hazard, reminderTime codec) + E-suite (area/tag rename, tag re-parent, notes append/prepend, move-to-inbox, duplicate, log-completed-now, project-when firm-up, sidebar-ordering discovery). Task #24.
+3. **Phase 9b** — implement the ops the R+E evidence validates (reminder vocabulary, area.update, tag.update, notes modes, inbox move, duplicate, …). Task #25.
+4. **Phase 10** — read-layer batch, host-only: tag-filtered reads (incl. inherited), Today ordering fidelity (todayIndexReferenceDate), upcoming repeat occurrences, checklist per-item state. Task #26.
+5. **Phase 11 (blocked on Mike's L5 sitting)** — S-campaign → Shortcuts vector → heading ops in existing projects; plus `project.add` json-payload headings (small win, independent of Shortcuts). Task #27.
+
+Permanently out of reach (documented + guarded, revisit per Things release): repeat creation/rule-editing; checklist granular writes.

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -31,10 +31,10 @@ Living register of Things-app capabilities that are missing, thin, or janky in t
 | `log completed now` | Probed (A28), trivial to expose. |
 | Project scheduling evidence | `project update --when` compiles but only `completed=true` was specifically probed (U08) — firm up with one probe. |
 
-## Ordering (Phase 8, in flight)
+## Ordering (LANDED — Phase 8, `things reorder` / `write.reorder`)
 
-- Landing now: Today (native, bucket-0 members only — O03: evening members get silently de-eveninged), project + area scopes (native, un-headed children only — O06), Evening via verified bounce (O07/O08).
-- Still unprobed: sidebar ordering (areas among areas; projects within an area), checklist-item order (likely unautomatable — no granular checklist surface anywhere).
+- Shipped: Today (native, bucket-0 members incl. scheduled projects — O01/O12), project + area scopes (native, un-headed children only — O06), Evening via verified bounce (O07/O08). Native is experimental-gated (config `allow-experimental` + sdef canary); see [docs/lab/o-suite-results.md](lab/o-suite-results.md).
+- Remaining gaps: heading-scoped ordering (unautomatable, O06); sidebar ordering (areas among areas; projects within an area) unprobed; checklist-item order (likely unautomatable — no granular checklist surface anywhere).
 
 ## Read-layer gaps
 
@@ -55,7 +55,7 @@ Fills: **headings in existing projects** (unique), maybe heading-archive + remin
 
 ## Roadmap (agreed 2026-07-04; tracked as tasks #23–#27)
 
-1. **Phase 8 (in flight)** — `write.reorder`: today (native, bucket-0 only), evening (bounce), project/area (native, un-headed only); experimental gate + sdef canary; H-REORDER-SCOPE guard. Task #23.
+1. **Phase 8 (DONE 2026-07-04)** — `write.reorder` landed: today/project/area native + evening bounce, experimental gate + sdef canary, H-REORDER-SCOPE guard, e2e-validated in the VM.
 2. **Phase 9a** — R-suite (reminders: `when=today@18:00` set/clear/encoding, repeating-template hazard, reminderTime codec) + E-suite (area/tag rename, tag re-parent, notes append/prepend, move-to-inbox, duplicate, log-completed-now, project-when firm-up, sidebar-ordering discovery). Task #24.
 3. **Phase 9b** — implement the ops the R+E evidence validates (reminder vocabulary, area.update, tag.update, notes modes, inbox move, duplicate, …). Task #25.
 4. **Phase 10** — read-layer batch, host-only: tag-filtered reads (incl. inherited), Today ordering fidelity (todayIndexReferenceDate), upcoming repeat occurrences, checklist per-item state. Task #26.

--- a/docs/lab/o-suite-results.md
+++ b/docs/lab/o-suite-results.md
@@ -1,0 +1,34 @@
+# O-suite results — ordering campaign
+
+Suite: [lab/suites/o-suite.json](../../lab/suites/o-suite.json) (11 probes, O01–O12; no O02). Locked 2026-07-04 after discovery + acceptance ×2 with identical verdicts (runs `o-20260704-014924` / `o-20260704-015104`). All probes tier 0, app running in background, no crashes.
+
+Subject: the private AppleScript command `_private_experimental_ reorder to dos in <specifier> with ids "<uuid>,<uuid>,…"` (undocumented, declared in Things.sdef as of 3.22.11) plus the URL `when=` bounce primitive. Together these feed `write.reorder`.
+
+## Verdict summary
+
+| Probe | Finding | Verdict |
+|---|---|---|
+| O01 | Partial ids list in Today: listed items adopt the given order; unlisted members untouched | supported |
+| O03 | **DESTRUCTIVE**: an evening-bucket member included in a Today reorder gets its startBucket silently CLEARED (de-eveninged) — native reorder normalizes the bucket to the targeted list | partial |
+| O04 | Project specifier (by name) reorders project children natively | supported |
+| O05 | Area specifier (by name) reorders direct area to-dos natively | supported |
+| O06 | **DESTRUCTIVE**: project-scope reorder RIPS heading-contained children out of their heading (`heading → NULL`) when their uuids are listed | partial |
+| O07 | Bounce, Today: `when=evening → when=today` round-trip FRONT-inserts; neighbors' todayIndex + buckets untouched | supported |
+| O08 | Bounce, Evening: inverse round-trip front-inserts within the evening section | supported |
+| O09 | `project id "<uuid>"` specifier works (production form — name specifiers are ambiguity-prone) | supported |
+| O10 | `area id "<uuid>"` specifier works | supported |
+| O11 | Mixed project, full un-headed wire list: heading rows keep their `index`, headed children stay headed — the production wire-list shape is safe | supported |
+| O12 | A PROJECT row scheduled in Today is accepted in the ids list and reorders like a to-do (`project` inherits from `to do` in the sdef) | supported |
+
+## Consequences baked into `write.reorder`
+
+- **Scopes**: `today` (native; bucket-0 members incl. scheduled projects — O01/O12), `project`/`area` (native; un-headed open to-do children — O04/O05/O09–O11), `evening` (bounce ONLY — O03).
+- **H-REORDER-SCOPE guard** rejects: evening-bucket uuids in today scope (O03), headed children in project scope (O06), non-members, duplicates, stale evening items in evening scope.
+- **Wire list**: requests may be partial; the compiled ids list is always requested-order + every remaining eligible member in current order, so placement is deterministic (O01 proved partial sends work but leave the unlisted block's relative position underdetermined).
+- **Experimental gating**: the command is undocumented → `config allowExperimental` opt-in + a per-dispatch sdef canary (`Things.sdef` must still declare `command name="_private_experimental_ reorder to dos in"`); `things doctor` reports both.
+- **Bounce safeguards**: reverse-order bouncing (each round-trip front-inserts), every leg is a fully verified `todo.update`, membership re-checked between items, placed-prefix order re-verified after each item, ≤ 10 items, clean abort with placed/remaining detail. Note: a bounce rewrites `startDate` to today for stale-dated Today members (when= normalization) — semantics-preserving in every view, but it is a stored-field change.
+- **Heading-scoped ordering stays unautomatable** (O06) — tracked in [docs/gaps.md](../gaps.md).
+
+## Not probed (future work)
+
+Sidebar ordering (areas among areas; projects within an area), checklist-item order (no granular surface anywhere), reorder behavior on the Anytime/Someday `index` scale outside containers.

--- a/lab/guest/e2e-write-smoke.sh
+++ b/lab/guest/e2e-write-smoke.sh
@@ -57,6 +57,36 @@ echo "     created project uuid=$PROJ"
 run_step 4 "project complete requires children policy resolution" project complete "$PROJ" --children require-resolved
 run_step 0 "project complete with verified auto-complete cascade" project complete "$PROJ" --children auto-complete
 
+echo "== reorder (native experimental + bounce) =="
+run_step 0 "seed today R1" todo add "E2E-R1" --when today
+R1=$(json_get "d['data']['uuid']")
+run_step 0 "seed today R2" todo add "E2E-R2" --when today
+R2=$(json_get "d['data']['uuid']")
+run_step 0 "seed today R3" todo add "E2E-R3" --when today
+R3=$(json_get "d['data']['uuid']")
+run_step 6 "native reorder is gated until allow-experimental" reorder --scope today --strategy native "$R3" "$R1"
+STEP=$((STEP + 1))
+if things config set allow-experimental true >/dev/null 2>&1; then
+  echo "ok   [$STEP] enable allow-experimental"
+else
+  echo "FAIL [$STEP] enable allow-experimental"
+  FAILURES=$((FAILURES + 1))
+fi
+run_step 0 "native today reorder (partial list, verified ordering)" reorder --scope today "$R3" "$R1"
+run_step 0 "seed evening RE1" todo add "E2E-RE1" --when evening
+RE1=$(json_get "d['data']['uuid']")
+run_step 0 "seed evening RE2" todo add "E2E-RE2" --when evening
+RE2=$(json_get "d['data']['uuid']")
+run_step 4 "today reorder rejects evening members (O03 guard)" reorder --scope today "$RE1" "$R1"
+run_step 0 "evening bounce reorder (verified when= round-trips)" reorder --scope evening "$RE2" "$RE1"
+run_step 0 "seed project for ordering" project add "E2E-RPROJ"
+RPROJ=$(json_get "d['data']['uuid']")
+run_step 0 "seed project child P1" todo add "E2E-RP1" --project "$RPROJ"
+RP1=$(json_get "d['data']['uuid']")
+run_step 0 "seed project child P2" todo add "E2E-RP2" --project "$RPROJ"
+RP2=$(json_get "d['data']['uuid']")
+run_step 0 "native project reorder (uuid specifier)" reorder --scope project --project "$RPROJ" "$RP2" "$RP1"
+
 echo "== deletes =="
 run_step 0 "todo delete -> trash (applescript)" todo delete "$UUID"
 run_step 0 "area add (applescript)" area add "E2E-AREA"

--- a/lab/scripts/regress.sh
+++ b/lab/scripts/regress.sh
@@ -26,7 +26,7 @@ if margin < 2:
 print(f"[regress] trial window ok: pinned {meta['pinnedDate']}, expiry {expiry:%Y-%m-%d} ({margin} days margin)")
 EOF
 
-for suite in u a x; do
+for suite in u a x o; do
   echo "[regress] === suite: $suite ==="
   npm run lab:run -- --suite "lab/suites/$suite-suite.json"
 done

--- a/lab/suites/o-suite.json
+++ b/lab/suites/o-suite.json
@@ -1,0 +1,407 @@
+{
+  "suite": "o",
+  "description": "Ordering campaign: semantics of the private `_private_experimental_ reorder to dos in` command across scopes (Today partial lists, evening-bucket interaction, projects, areas, heading-contained children) plus regression locks for the URL bounce primitive (Today + Evening). Feeds write.reorder (experimental native strategy + verified bounce fallback).",
+  "probes": [
+    {
+      "id": "O01",
+      "title": "private reorder with a PARTIAL ids list in Today: listed items adopt the given order; what happens to unlisted members is the finding",
+      "vector": "applescript",
+      "operation": "order.today-partial",
+      "appState": "running-background",
+      "setup": [
+        {
+          "openUrl": "things:///add?title=O-A&when=today"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='O-A'"
+        },
+        {
+          "openUrl": "things:///add?title=O-B&when=today"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='O-B'"
+        },
+        {
+          "openUrl": "things:///add?title=O-C&when=today"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='O-C'"
+        }
+      ],
+      "commands": [
+        {
+          "osascript": "tell application \"Things3\" to _private_experimental_ reorder to dos in list \"Today\" with ids \"{uuid:O-C},{uuid:O-B},{uuid:O-A}\""
+        },
+        {
+          "waitSql": "SELECT 1 WHERE (SELECT todayIndex FROM TMTask WHERE title='O-C') < (SELECT todayIndex FROM TMTask WHERE title='O-B')"
+        },
+        {
+          "waitSql": "SELECT 1 WHERE (SELECT todayIndex FROM TMTask WHERE title='O-B') < (SELECT todayIndex FROM TMTask WHERE title='O-A')"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "uuid": "@seed:LAB-TODAY-1"
+            },
+            "fields": ["startBucket", "start", "startDate"]
+          },
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "title": "O-A"
+            },
+            "fields": ["startBucket", "start", "startDate", "status"]
+          }
+        ]
+      }
+    },
+    {
+      "id": "O03",
+      "title": "DESTRUCTIVE FINDING: including an Evening member in a Today reorder CLEARS its startBucket (silently de-evenings it) \u2014 native reorder normalizes bucket to the targeted list; evening scope is bounce-only and the today-scope guard must reject bucket-1 members",
+      "vector": "applescript",
+      "operation": "order.evening-interaction",
+      "appState": "running-background",
+      "setup": [
+        {
+          "openUrl": "things:///add?title=O-E&when=evening"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='O-E' AND startBucket=1"
+        },
+        {
+          "openUrl": "things:///add?title=O-F&when=today"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='O-F'"
+        }
+      ],
+      "commands": [
+        {
+          "osascript": "tell application \"Things3\" to _private_experimental_ reorder to dos in list \"Today\" with ids \"{uuid:O-E},{uuid:O-F}\""
+        },
+        {
+          "waitSql": "SELECT 1 WHERE (SELECT todayIndex FROM TMTask WHERE title='O-E') < (SELECT todayIndex FROM TMTask WHERE title='O-F')"
+        }
+      ],
+      "expect": {
+        "verdict": "partial",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "O-E"
+            },
+            "field": "startBucket",
+            "value": 0
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "O-F"
+            },
+            "field": "startBucket",
+            "value": 0
+          }
+        ]
+      }
+    },
+    {
+      "id": "O04",
+      "title": "private reorder against a PROJECT specifier \u2014 native project-child reordering?",
+      "vector": "applescript",
+      "operation": "order.project",
+      "appState": "running-background",
+      "commands": [
+        {
+          "osascript": "tell application \"Things3\" to _private_experimental_ reorder to dos in project \"LAB-PROJ-PLAIN\" with ids \"{seed:LAB-P-3},{seed:LAB-P-1}\""
+        },
+        {
+          "waitSql": "SELECT 1 WHERE (SELECT \"index\" FROM TMTask WHERE uuid='{seed:LAB-P-3}') < (SELECT \"index\" FROM TMTask WHERE uuid='{seed:LAB-P-1}')"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "uuid": "@seed:LAB-P-1"
+            },
+            "fields": ["project", "status", "start"]
+          },
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "uuid": "@seed:LAB-P-3"
+            },
+            "fields": ["project", "status", "start"]
+          }
+        ]
+      }
+    },
+    {
+      "id": "O05",
+      "title": "private reorder against an AREA specifier (direct area to-dos)",
+      "vector": "applescript",
+      "operation": "order.area",
+      "appState": "running-background",
+      "setup": [
+        {
+          "openUrl": "things:///add?title=O-AA1&when=anytime&list-id={seed:LAB-AREA-A}"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='O-AA1' AND area='{seed:LAB-AREA-A}'"
+        },
+        {
+          "openUrl": "things:///add?title=O-AA2&when=anytime&list-id={seed:LAB-AREA-A}"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='O-AA2' AND area='{seed:LAB-AREA-A}'"
+        }
+      ],
+      "commands": [
+        {
+          "osascript": "tell application \"Things3\" to _private_experimental_ reorder to dos in area \"LAB-AREA-A\" with ids \"{uuid:O-AA2},{uuid:O-AA1}\""
+        },
+        {
+          "waitSql": "SELECT 1 WHERE (SELECT \"index\" FROM TMTask WHERE title='O-AA2') < (SELECT \"index\" FROM TMTask WHERE title='O-AA1')"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "O-AA1"
+            },
+            "field": "area",
+            "value": "@seed:LAB-AREA-A"
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "O-AA2"
+            },
+            "field": "area",
+            "value": "@seed:LAB-AREA-A"
+          }
+        ]
+      }
+    },
+    {
+      "id": "O06",
+      "title": "DESTRUCTIVE FINDING: project-scope reorder RIPS heading-contained children out of their heading (heading -> NULL) \u2014 guards must reject headed uuids; heading-scoped ordering remains unautomatable",
+      "vector": "applescript",
+      "operation": "order.heading-children",
+      "appState": "running-background",
+      "commands": [
+        {
+          "osascript": "tell application \"Things3\" to _private_experimental_ reorder to dos in project \"LAB-PROJ-HEADINGS\" with ids \"{seed:LAB-H-A2},{seed:LAB-H-A1}\""
+        },
+        {
+          "waitSql": "SELECT 1 WHERE (SELECT \"index\" FROM TMTask WHERE uuid='{seed:LAB-H-A2}') < (SELECT \"index\" FROM TMTask WHERE uuid='{seed:LAB-H-A1}')"
+        }
+      ],
+      "expect": {
+        "verdict": "partial",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "uuid": "@seed:LAB-H-A1"
+            },
+            "field": "heading",
+            "value": null
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "uuid": "@seed:LAB-H-A2"
+            },
+            "field": "heading",
+            "value": null
+          }
+        ]
+      }
+    },
+    {
+      "id": "O07",
+      "title": "bounce primitive, Today: evening->today round-trip front-inserts; neighbors untouched (regression lock for the fallback strategy)",
+      "vector": "url",
+      "operation": "order.bounce-today",
+      "appState": "running-background",
+      "setup": [
+        {
+          "openUrl": "things:///add?title=O-BN1&when=today"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='O-BN1'"
+        },
+        {
+          "openUrl": "things:///add?title=O-BN2&when=today"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='O-BN2'"
+        },
+        {
+          "openUrl": "things:///add?title=O-BN3&when=today"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='O-BN3'"
+        }
+      ],
+      "commands": [
+        {
+          "openUrl": "things:///update?id={uuid:O-BN3}&auth-token={ctx:token}&when=evening"
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTask WHERE title='O-BN3' AND startBucket=1"
+        },
+        {
+          "openUrl": "things:///update?id={uuid:O-BN3}&auth-token={ctx:token}&when=today"
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTask WHERE title='O-BN3' AND startBucket=0"
+        },
+        {
+          "waitSql": "SELECT 1 WHERE (SELECT todayIndex FROM TMTask WHERE title='O-BN3') < (SELECT todayIndex FROM TMTask WHERE title='O-BN1') AND (SELECT todayIndex FROM TMTask WHERE title='O-BN3') < (SELECT todayIndex FROM TMTask WHERE title='O-BN2')"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "O-BN3"
+            },
+            "field": "startBucket",
+            "value": 0
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "O-BN3"
+            },
+            "field": "start",
+            "value": 1
+          },
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "title": "O-BN1"
+            },
+            "fields": ["todayIndex", "startBucket"]
+          },
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "title": "O-BN2"
+            },
+            "fields": ["todayIndex", "startBucket"]
+          }
+        ]
+      }
+    },
+    {
+      "id": "O08",
+      "title": "bounce primitive, Evening: today->evening round-trip front-inserts within the evening section",
+      "vector": "url",
+      "operation": "order.bounce-evening",
+      "appState": "running-background",
+      "setup": [
+        {
+          "openUrl": "things:///add?title=O-BE1&when=evening"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='O-BE1' AND startBucket=1"
+        },
+        {
+          "openUrl": "things:///add?title=O-BE2&when=evening"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='O-BE2' AND startBucket=1"
+        },
+        {
+          "openUrl": "things:///add?title=O-BE3&when=evening"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='O-BE3' AND startBucket=1"
+        }
+      ],
+      "commands": [
+        {
+          "openUrl": "things:///update?id={uuid:O-BE3}&auth-token={ctx:token}&when=today"
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTask WHERE title='O-BE3' AND startBucket=0"
+        },
+        {
+          "openUrl": "things:///update?id={uuid:O-BE3}&auth-token={ctx:token}&when=evening"
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTask WHERE title='O-BE3' AND startBucket=1"
+        },
+        {
+          "waitSql": "SELECT 1 WHERE (SELECT todayIndex FROM TMTask WHERE title='O-BE3') < (SELECT todayIndex FROM TMTask WHERE title='O-BE1') AND (SELECT todayIndex FROM TMTask WHERE title='O-BE3') < (SELECT todayIndex FROM TMTask WHERE title='O-BE2')"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "O-BE3"
+            },
+            "field": "startBucket",
+            "value": 1
+          },
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "title": "O-BE1"
+            },
+            "fields": ["todayIndex", "startBucket"]
+          },
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "title": "O-BE2"
+            },
+            "fields": ["todayIndex", "startBucket"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/lab/suites/o-suite.json
+++ b/lab/suites/o-suite.json
@@ -402,6 +402,181 @@
           }
         ]
       }
+    },
+    {
+      "id": "O09",
+      "title": "private reorder with a PROJECT ID specifier (production form: uuid addressing avoids title-collision ambiguity; O04 only proved the name form)",
+      "vector": "applescript",
+      "operation": "order.project-id-specifier",
+      "appState": "running-background",
+      "commands": [
+        {
+          "osascript": "tell application \"Things3\" to _private_experimental_ reorder to dos in project id \"{seed:LAB-PROJ-PLAIN}\" with ids \"{seed:LAB-P-1},{seed:LAB-P-3}\""
+        },
+        {
+          "waitSql": "SELECT 1 WHERE (SELECT \"index\" FROM TMTask WHERE uuid='{seed:LAB-P-1}') < (SELECT \"index\" FROM TMTask WHERE uuid='{seed:LAB-P-3}')"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "uuid": "@seed:LAB-P-1"
+            },
+            "fields": ["project", "status", "start", "heading"]
+          },
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "uuid": "@seed:LAB-P-3"
+            },
+            "fields": ["project", "status", "start", "heading"]
+          }
+        ]
+      }
+    },
+    {
+      "id": "O10",
+      "title": "private reorder with an AREA ID specifier (production form: uuid addressing; O05 only proved the name form)",
+      "vector": "applescript",
+      "operation": "order.area-id-specifier",
+      "appState": "running-background",
+      "commands": [
+        {
+          "osascript": "tell application \"Things3\" to _private_experimental_ reorder to dos in area id \"{seed:LAB-AREA-A}\" with ids \"{uuid:O-AA1},{uuid:O-AA2}\""
+        },
+        {
+          "waitSql": "SELECT 1 WHERE (SELECT \"index\" FROM TMTask WHERE title='O-AA1') < (SELECT \"index\" FROM TMTask WHERE title='O-AA2')"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "O-AA1"
+            },
+            "field": "area",
+            "value": "@seed:LAB-AREA-A"
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "O-AA2"
+            },
+            "field": "area",
+            "value": "@seed:LAB-AREA-A"
+          }
+        ]
+      }
+    },
+    {
+      "id": "O11",
+      "title": "production wire-list shape in a MIXED project: full un-headed-children ids list (headings + headed children excluded) — heading rows and headed children must be untouched. Depends on post-O06 state (LAB-H-A1/A2 are un-headed by now).",
+      "vector": "applescript",
+      "operation": "order.project-mixed-unheaded",
+      "appState": "running-background",
+      "commands": [
+        {
+          "osascript": "tell application \"Things3\" to _private_experimental_ reorder to dos in project id \"{seed:LAB-PROJ-HEADINGS}\" with ids \"{seed:LAB-H-A2},{seed:LAB-H-FLAT},{seed:LAB-H-A1}\""
+        },
+        {
+          "waitSql": "SELECT 1 WHERE (SELECT \"index\" FROM TMTask WHERE uuid='{seed:LAB-H-A2}') < (SELECT \"index\" FROM TMTask WHERE uuid='{seed:LAB-H-FLAT}') AND (SELECT \"index\" FROM TMTask WHERE uuid='{seed:LAB-H-FLAT}') < (SELECT \"index\" FROM TMTask WHERE uuid='{seed:LAB-H-A1}')"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "uuid": "@seed:Alpha"
+            },
+            "fields": ["project", "status", "trashed", "index"]
+          },
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "uuid": "@seed:Beta"
+            },
+            "fields": ["project", "status", "trashed", "index"]
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "uuid": "@seed:LAB-H-B1"
+            },
+            "field": "heading",
+            "value": "@seed:Beta"
+          },
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "uuid": "@seed:LAB-H-B1"
+            },
+            "fields": ["index", "status", "start"]
+          }
+        ]
+      }
+    },
+    {
+      "id": "O12",
+      "title": "PROJECT rows in Today: the ids list accepts a project uuid (project inherits from `to do` in the sdef) — required so the today-scope wire list can pin scheduled projects instead of leaving their placement underdetermined",
+      "vector": "applescript",
+      "operation": "order.today-project-row",
+      "appState": "running-background",
+      "setup": [
+        {
+          "openUrl": "things:///add-project?title=O-PROJ-TODAY&when=today"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='O-PROJ-TODAY' AND type=1"
+        }
+      ],
+      "commands": [
+        {
+          "osascript": "tell application \"Things3\" to _private_experimental_ reorder to dos in list \"Today\" with ids \"{uuid:O-PROJ-TODAY},{uuid:O-A}\""
+        },
+        {
+          "waitSql": "SELECT 1 WHERE (SELECT todayIndex FROM TMTask WHERE title='O-PROJ-TODAY') < (SELECT todayIndex FROM TMTask WHERE title='O-A')"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "title": "O-PROJ-TODAY"
+            },
+            "fields": ["start", "startDate", "startBucket", "status", "trashed", "area", "type"]
+          },
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "title": "O-B"
+            },
+            "fields": ["todayIndex", "startBucket"]
+          }
+        ]
+      }
     }
   ]
 }

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -10,6 +10,7 @@ import { BASELINES } from "../../db/baselines/index.ts";
 import { openConnection, ThingsDbOpenError } from "../../db/connection.ts";
 import { locateThingsDb, ThingsDbNotFoundError } from "../../db/locate.ts";
 import { compareToBaseline, observeSchema } from "../../db/fingerprint.ts";
+import { sdefDeclaresPrivateReorder } from "../../write/experimental.ts";
 import { ExitCode } from "../exit-codes.ts";
 import { errorEnvelope, okEnvelope, type EnvelopeMeta } from "../output.ts";
 
@@ -34,6 +35,13 @@ export interface DoctorReport {
   };
   writes: {
     enabled: boolean;
+    reason: string;
+  };
+  experimental: {
+    /** config allowExperimental (opt-in for private-surface capabilities). */
+    enabled: boolean;
+    /** sdef canary: the private reorder command is still declared. */
+    sdefDeclaresReorder: boolean;
     reason: string;
   };
 }
@@ -87,8 +95,9 @@ export function runDoctor(dbPath?: string): {
     const status = compareToBaseline(observation, BASELINES);
     // The pipeline honors a user-accepted drifted fingerprint (loud escape
     // hatch, design §6) — doctor must report what will actually happen.
+    const config = loadConfig();
     const accepted =
-      status.kind === "drift" && loadConfig().acceptedFingerprint === observation.fingerprint;
+      status.kind === "drift" && config.acceptedFingerprint === observation.fingerprint;
     const fingerprintStatus = accepted
       ? "user-accepted"
       : status.kind === "ok"
@@ -97,6 +106,7 @@ export function runDoctor(dbPath?: string): {
           ? "drift"
           : "unknown-version";
     const writesEnabled = status.kind === "ok" || accepted;
+    const sdefCanary = sdefDeclaresPrivateReorder();
     const extraColumns: Record<string, string[]> = {};
     for (const t of observation.tables) {
       if (t.extraColumns.length > 0) extraColumns[t.table] = t.extraColumns;
@@ -126,6 +136,16 @@ export function runDoctor(dbPath?: string): {
             : status.kind === "drift"
               ? "schema fingerprint deviates from baseline — writes disabled until revalidated"
               : "unknown databaseVersion — update things-api or revalidate",
+      },
+      experimental: {
+        enabled: config.allowExperimental,
+        sdefDeclaresReorder: sdefCanary,
+        reason: !config.allowExperimental
+          ? "off — native reorder disabled (`things config set allow-experimental true` to opt in)"
+          : sdefCanary
+            ? "on — private reorder command still declared in the app sdef"
+            : "on BUT the app sdef no longer declares the private reorder command (removed by " +
+              "an update?) — native reorder is blocked by the canary",
       },
     };
     return {
@@ -168,6 +188,7 @@ export function registerDoctor(program: Command): void {
           ...report.fingerprint.detail.map((d) => `  drift: ${d}`),
           `app:         ${report.app.installed ? "installed" : "NOT INSTALLED"}`,
           `writes:      ${report.writes.enabled ? "enabled" : "DISABLED"} — ${report.writes.reason}`,
+          `experimental: ${report.experimental.reason}`,
         ];
         process.stdout.write(`${lines.join("\n")}\n`);
       } else if (error) {

--- a/src/cli/commands/writes.ts
+++ b/src/cli/commands/writes.ts
@@ -9,8 +9,14 @@ import { openThings, type ThingsClient } from "../../client.ts";
 import { saveConfigKey, type DisruptionTier } from "../../config.ts";
 import { ThingsDbNotFoundError } from "../../db/locate.ts";
 import { ThingsDbOpenError } from "../../db/connection.ts";
-import { OPERATION_KINDS, type OperationKind } from "../../write/operations.ts";
-import type { MutationResult, WriteOptions } from "../../write/pipeline.ts";
+import {
+  OPERATION_KINDS,
+  type OperationKind,
+  type ReorderScope,
+  type ReorderStrategy,
+} from "../../write/operations.ts";
+import type { WriteOptions } from "../../write/pipeline.ts";
+import { BOUNCE_MAX_ITEMS, type ReorderResult } from "../../write/reorder.ts";
 import { defaultVectors } from "../../write/vectors/registry.ts";
 import type { VectorId } from "../../write/vectors/types.ts";
 import { ExitCode } from "../exit-codes.ts";
@@ -72,7 +78,7 @@ function splitCsv(value: string | undefined): string[] | undefined {
 
 async function runWrite(
   opts: WriteFlagOpts,
-  fn: (client: ThingsClient) => Promise<MutationResult>,
+  fn: (client: ThingsClient) => Promise<ReorderResult>,
 ): Promise<void> {
   const started = Date.now();
   let client: ThingsClient | null = null;
@@ -107,8 +113,32 @@ async function runWrite(
   }
 }
 
-function emitResult(result: MutationResult, opts: WriteFlagOpts, meta: EnvelopeMeta): void {
+function emitResult(result: ReorderResult, opts: WriteFlagOpts, meta: EnvelopeMeta): void {
   switch (result.kind) {
+    case "bounce-aborted": {
+      if (opts.json) {
+        process.stdout.write(
+          `${JSON.stringify(
+            errorEnvelope(
+              {
+                code: "bounce-aborted",
+                message: result.detail,
+                detail: { placed: result.placed, remaining: result.remaining, cause: result.cause },
+              },
+              meta,
+            ),
+          )}\n`,
+        );
+      } else {
+        process.stderr.write(
+          `BOUNCE ABORTED: ${result.detail}\n` +
+            `  placed (now at the top, in order): ${result.placed.join(", ") || "none"}\n` +
+            `  not placed: ${result.remaining.join(", ")}\n`,
+        );
+      }
+      process.exitCode = ExitCode.VerifyFailed;
+      return;
+    }
     case "ok": {
       if (opts.json) {
         process.stdout.write(`${JSON.stringify(okEnvelope("mutation-result", result, meta))}\n`);
@@ -592,6 +622,42 @@ export function registerWriteCommands(program: Command): void {
     );
   });
 
+  addWriteFlags(
+    program
+      .command("reorder <uuids...>")
+      .description(
+        "Reorder items within Today, This Evening, a project, or an area — uuids are placed " +
+          "at the TOP in the given order; unlisted members keep their relative order below. " +
+          "Strategies: native (private sdef command — EXPERIMENTAL, requires `things config " +
+          "set allow-experimental true`; today/project/area) and bounce (verified when= " +
+          `round-trips; today/evening, max ${BOUNCE_MAX_ITEMS} items). Evening is bounce-only: ` +
+          "the native command silently de-evenings items (O03). Headed project children are " +
+          "rejected (O06). Hazard: H-REORDER-SCOPE.",
+      )
+      .requiredOption("--scope <scope>", "today | evening | project | area")
+      .option("--project <ref>", "project (uuid or unique name) — scope=project")
+      .option("--area <ref>", "area (uuid or unique name) — scope=area")
+      .option("--strategy <name>", "force native | bounce (default: per-scope)"),
+  ).action(async (uuids: string[], opts: WriteFlagOpts & Record<string, unknown>) => {
+    const scope = opts["scope"] as ReorderScope;
+    const container = containerRef(
+      (opts["project"] as string | undefined) ?? (opts["area"] as string | undefined),
+    );
+    await runWrite(opts, (c) =>
+      c.write.reorder(
+        {
+          scope,
+          uuids,
+          ...(container !== undefined && { container }),
+          ...(opts["strategy"] !== undefined && {
+            strategy: opts["strategy"] as ReorderStrategy,
+          }),
+        },
+        writeOptionsFrom(opts),
+      ),
+    );
+  });
+
   program
     .command("capabilities")
     .description(
@@ -652,7 +718,8 @@ export function registerWriteCommands(program: Command): void {
   config
     .command("set <key> <value>")
     .description(
-      "Persist a config key: profile | maxDisruption | actor | auditEnabled | accepted-fingerprint",
+      "Persist a config key: profile | maxDisruption | actor | auditEnabled | " +
+        "accepted-fingerprint | allow-experimental",
     )
     .action((key: string, value: string) => {
       const map: Record<string, string> = {
@@ -661,6 +728,7 @@ export function registerWriteCommands(program: Command): void {
         actor: "actor",
         auditEnabled: "auditEnabled",
         "accepted-fingerprint": "acceptedFingerprint",
+        "allow-experimental": "allowExperimental",
       };
       const target = map[key];
       if (target === undefined) {
@@ -671,7 +739,7 @@ export function registerWriteCommands(program: Command): void {
       const parsed: string | number | boolean =
         target === "maxDisruption"
           ? Number(value)
-          : target === "auditEnabled"
+          : target === "auditEnabled" || target === "allowExperimental"
             ? value === "true"
             : value;
       saveConfigKey(target as never, parsed);

--- a/src/client.ts
+++ b/src/client.ts
@@ -35,6 +35,7 @@ import type {
   ProjectAddParams,
   ProjectCompleteParams,
   ProjectUpdateParams,
+  ReorderParams,
   TagAddParams,
   TodoAddParams,
   TodoMoveParams,
@@ -47,6 +48,7 @@ import {
   type WriteDeps,
   type WriteOptions,
 } from "./write/pipeline.ts";
+import { runReorder, type ReorderResult } from "./write/reorder.ts";
 import { defaultVectors } from "./write/vectors/registry.ts";
 import type { WriteVector } from "./write/vectors/types.ts";
 import type { PollerDeps } from "./write/verify/poller.ts";
@@ -65,6 +67,7 @@ export interface OpenOptions {
     isAppRunning?: () => boolean;
     poller?: PollerDeps;
     audit?: AuditWriter;
+    sdefProbe?: () => boolean;
   };
 }
 
@@ -136,6 +139,11 @@ export interface ThingsClient {
     addTag(params: TagAddParams, options?: WriteOptions): Promise<MutationResult>;
     deleteTag(target: string, options?: WriteOptions): Promise<MutationResult>;
     emptyTrash(options?: WriteOptions): Promise<MutationResult>;
+    /**
+     * Reorder within Today / This Evening / a project / an area. Partial
+     * uuid lists are placed on top; the rest keep their current order.
+     */
+    reorder(params: ReorderParams, options?: WriteOptions): Promise<ReorderResult>;
   };
   close(): void;
 }
@@ -177,6 +185,9 @@ export function openThings(options: OpenOptions = {}): ThingsClient {
     }),
     ...(options.writeOverrides?.poller !== undefined && {
       poller: options.writeOverrides.poller,
+    }),
+    ...(options.writeOverrides?.sdefProbe !== undefined && {
+      sdefProbe: options.writeOverrides.sdefProbe,
     }),
   };
 
@@ -234,6 +245,7 @@ export function openThings(options: OpenOptions = {}): ThingsClient {
       addTag: (params, o) => run("tag.add", params, o),
       deleteTag: (target, o) => run("tag.delete", { target }, o),
       emptyTrash: (o) => run("trash.empty", {}, o),
+      reorder: (params, o) => runReorder(writeDeps, params, o ?? {}),
     },
     close: () => conn.close(),
   };

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,11 @@ export interface ThingsApiConfig {
   auditEnabled: boolean;
   /** User-accepted drifted fingerprint (loud escape hatch; see design §6). */
   acceptedFingerprint: string | null;
+  /**
+   * Opt-in to capabilities riding undocumented app surfaces (the private
+   * sdef reorder command). Guarded further by the pipeline's sdef canary.
+   */
+  allowExperimental: boolean;
   host: string;
 }
 
@@ -38,6 +43,7 @@ interface ConfigFile {
   actor?: string;
   auditEnabled?: boolean;
   acceptedFingerprint?: string;
+  allowExperimental?: boolean;
 }
 
 function configFilePath(env: NodeJS.ProcessEnv): string {
@@ -80,6 +86,8 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ThingsApiConfi
     actor: env["THINGS_API_ACTOR"] ?? file.actor ?? `${username}@cli`,
     auditEnabled: env["THINGS_API_AUDIT"] === "off" ? false : (file.auditEnabled ?? true),
     acceptedFingerprint: file.acceptedFingerprint ?? null,
+    allowExperimental:
+      env["THINGS_API_ALLOW_EXPERIMENTAL"] === "true" || file.allowExperimental === true,
     host: hostname(),
   };
 }

--- a/src/write/commands.ts
+++ b/src/write/commands.ts
@@ -10,6 +10,7 @@ import type { IsoDate } from "../model/dates.ts";
 import type { HazardId } from "./guards.ts";
 import type { ContainerRef, OperationKind, OperationParamsMap, WhenValue } from "./operations.ts";
 import {
+  computeReorderPre,
   emptyPreState,
   loadTarget,
   missingTagTitles,
@@ -22,6 +23,7 @@ import {
   trashedCount,
   type PreState,
 } from "./pre-state.ts";
+import { PRIVATE_REORDER_COMMAND } from "./experimental.ts";
 import { escapeAppleScript } from "./vectors/applescript.ts";
 import type { CompiledInvocation, VectorId } from "./vectors/types.ts";
 import type { DeltaSpec, FieldAssertion } from "./verify/delta.ts";
@@ -40,7 +42,7 @@ export interface DeltaCtx {
 export interface CommandSpec<K extends OperationKind = OperationKind> {
   op: K;
   hazards: HazardId[];
-  preRead(db: DatabaseSync, params: OperationParamsMap[K]): PreState;
+  preRead(db: DatabaseSync, params: OperationParamsMap[K], now: Date): PreState;
   expectedDelta(pre: PreState, params: OperationParamsMap[K], ctx: DeltaCtx): DeltaSpec;
   compile(
     params: OperationParamsMap[K],
@@ -625,6 +627,48 @@ const tagDelete: CommandSpec<"tag.delete"> = {
   },
 };
 
+const reorder: CommandSpec<"reorder"> = {
+  op: "reorder",
+  hazards: ["H-UNKNOWN-DESTINATION", "H-REORDER-SCOPE"],
+  preRead(db, params, now) {
+    const pre = emptyPreState();
+    let containerUuid: string | null = null;
+    if (params.scope === "project") {
+      pre.destProject = resolveProject(db, params.container ?? {});
+      containerUuid = pre.destProject.resolved?.uuid ?? null;
+    }
+    if (params.scope === "area") {
+      pre.destArea = resolveArea(db, params.container ?? {});
+      containerUuid = pre.destArea.resolved?.uuid ?? null;
+    }
+    pre.reorder = computeReorderPre(db, params, containerUuid, now);
+    return pre;
+  },
+  expectedDelta(pre, params) {
+    // Verify the REQUESTED sequence (strictly ascending ranks). The wire
+    // list pins the unrequested tail too, but the caller's contract is the
+    // requested prefix; tail members are covered by pre-rank tripwires.
+    return {
+      mode: "ordering",
+      key:
+        pre.reorder?.key ??
+        (params.scope === "project" || params.scope === "area" ? "index" : "todayIndex"),
+      sequence: params.uuids,
+    };
+  },
+  compile(params, vector, pre) {
+    if (vector !== "applescript") unsupportedVector(this.op, vector);
+    const specifier =
+      params.scope === "project"
+        ? `project id ${q(pre.destProject?.resolved?.uuid ?? "")}`
+        : params.scope === "area"
+          ? `area id ${q(pre.destArea?.resolved?.uuid ?? "")}`
+          : `list "Today"`;
+    const ids = (pre.reorder?.wireList ?? params.uuids).join(",");
+    return osa(`${PRIVATE_REORDER_COMMAND} ${specifier} with ids ${q(ids)}`);
+  },
+};
+
 const trashEmpty: CommandSpec<"trash.empty"> = {
   op: "trash.empty",
   hazards: ["H-PERMANENT-DELETE"],
@@ -661,4 +705,5 @@ export const COMMANDS: { [K in OperationKind]: CommandSpec<K> } = {
   "tag.add": tagAdd,
   "tag.delete": tagDelete,
   "trash.empty": trashEmpty,
+  reorder,
 };

--- a/src/write/experimental.ts
+++ b/src/write/experimental.ts
@@ -1,0 +1,37 @@
+/**
+ * Canary for `experimental: true` capabilities: the private reorder command
+ * is UNDOCUMENTED and can vanish in any Things update, so before every use
+ * the pipeline re-checks that the app's sdef still declares it. A missing
+ * declaration blocks the write loudly instead of dispatching a command the
+ * app may now reject — or reinterpret.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const PRIVATE_REORDER_COMMAND = "_private_experimental_ reorder to dos in";
+
+const SDEF_NEEDLE = `command name="${PRIVATE_REORDER_COMMAND}"`;
+const RESOURCES_DIR = "/Applications/Things3.app/Contents/Resources";
+
+/**
+ * True when the installed Things sdef still declares the private reorder
+ * command (Things 3.22.11 ships it as Resources/Things.sdef — scan every
+ * .sdef in the bundle so a rename alone doesn't false-negative).
+ */
+export function sdefDeclaresPrivateReorder(resourcesDir: string = RESOURCES_DIR): boolean {
+  let entries: string[];
+  try {
+    entries = readdirSync(resourcesDir);
+  } catch {
+    return false;
+  }
+  for (const entry of entries) {
+    if (!entry.endsWith(".sdef")) continue;
+    try {
+      if (readFileSync(join(resourcesDir, entry), "utf8").includes(SDEF_NEEDLE)) return true;
+    } catch {
+      // unreadable sdef → keep scanning; all-fail means "not declared"
+    }
+  }
+  return false;
+}

--- a/src/write/guards.ts
+++ b/src/write/guards.ts
@@ -15,6 +15,7 @@ export const HAZARD_IDS = [
   "H-UNKNOWN-DESTINATION",
   "H-AMBIGUOUS-HEADING",
   "H-PERMANENT-DELETE",
+  "H-REORDER-SCOPE",
 ] as const;
 
 export type HazardId = (typeof HAZARD_IDS)[number];
@@ -144,6 +145,49 @@ const GUARDS: Record<HazardId, GuardFn> = {
           ? "multiple headings with that name exist in the destination project"
           : "heading not found in the destination project (the heading param never creates one — T09/U09)",
       remediation: "rename the duplicate headings, or omit --heading",
+    };
+  },
+  "H-REORDER-SCOPE": ({ op, params, pre }) => {
+    if (op !== "reorder" || pre.reorder === null) return null;
+    const problems: string[] = [];
+    // The `reorder` operation IS the native private command. Evening must
+    // never reach it: a native reorder normalizes startBucket to the Today
+    // list, silently de-evening-ing members (O03). The evening scope is
+    // served by the bounce orchestrator in reorder.ts instead.
+    if (params["scope"] === "evening") {
+      return {
+        hazard: "H-REORDER-SCOPE",
+        detail:
+          "evening reorder is bounce-only: the native command would silently clear " +
+          "startBucket on every listed item (O03)",
+        remediation: "use write.reorder / `things reorder --scope evening` (bounce strategy)",
+      };
+    }
+    if (
+      (params["scope"] === "today" || params["scope"] === "evening") &&
+      params["container"] !== undefined
+    ) {
+      problems.push("container is only valid for project/area scopes");
+    }
+    const uuids = params["uuids"];
+    if (!Array.isArray(uuids) || uuids.length === 0) {
+      problems.push("no uuids given");
+    }
+    if (pre.reorder.duplicates.length > 0) {
+      problems.push(`duplicated uuid(s): ${pre.reorder.duplicates.join(", ")}`);
+    }
+    for (const r of pre.reorder.rejected) {
+      problems.push(`${r.uuid} ${r.reason}`);
+    }
+    if (problems.length === 0) return null;
+    return {
+      hazard: "H-REORDER-SCOPE",
+      detail:
+        `reorder request rejected — every uuid must be an eligible member of the scope, ` +
+        `exactly once: ${problems.join("; ")}`,
+      remediation:
+        "read the scope first (things today / things project-view / things area) and pass " +
+        "only its eligible members in the desired order",
     };
   },
   "H-PERMANENT-DELETE": ({ op, acks }) => {

--- a/src/write/operations.ts
+++ b/src/write/operations.ts
@@ -24,6 +24,7 @@ export const OPERATION_KINDS = [
   "tag.add",
   "tag.delete",
   "trash.empty",
+  "reorder",
 ] as const;
 
 export type OperationKind = (typeof OPERATION_KINDS)[number];
@@ -123,6 +124,30 @@ export interface NameOrUuidParams {
   target: string;
 }
 
+export type ReorderScope = "today" | "evening" | "project" | "area";
+export type ReorderStrategy = "native" | "bounce";
+
+export interface ReorderParams {
+  scope: ReorderScope;
+  /** Required for project/area scopes; must be omitted for today/evening. */
+  container?: ContainerRef;
+  /**
+   * Desired order, top-first. May be a SUBSET of the scope's members: the
+   * requested uuids are placed at the top in this order and every remaining
+   * member keeps its current relative order below them (the wire list sent
+   * to the app is always the full member list — O01 proved partial sends
+   * work but leave placement underdetermined).
+   */
+  uuids: string[];
+  /**
+   * Omit for the default per scope: native for today/project/area (requires
+   * allowExperimental + the sdef canary), bounce for evening. Today accepts
+   * an explicit "bounce" fallback; project/area are native-only; evening is
+   * bounce-only (O03: native reorder silently de-evenings bucket-1 members).
+   */
+  strategy?: ReorderStrategy;
+}
+
 export type EmptyParams = Record<string, never>;
 
 export interface OperationParamsMap {
@@ -144,6 +169,7 @@ export interface OperationParamsMap {
   "tag.add": TagAddParams;
   "tag.delete": NameOrUuidParams;
   "trash.empty": EmptyParams;
+  reorder: ReorderParams;
 }
 
 /** Explicit acknowledgements for guarded operations (never defaulted). */

--- a/src/write/pipeline.ts
+++ b/src/write/pipeline.ts
@@ -12,6 +12,7 @@ import type { DisruptionTier, ThingsApiConfig } from "../config.ts";
 import type { FingerprintStatus } from "../db/fingerprint.ts";
 import { localToday } from "../model/dates.ts";
 import { COMMANDS, type CommandSpec } from "./commands.ts";
+import { sdefDeclaresPrivateReorder } from "./experimental.ts";
 import { evaluateGuards, type GuardBlock, type HazardId } from "./guards.ts";
 import { acquireMutationLock, MutationLockError } from "./lock.ts";
 import type { Acknowledgements, OperationKind, OperationParamsMap } from "./operations.ts";
@@ -90,6 +91,8 @@ export interface WriteDeps {
   /** Injectable for tests/lab: returns true when Things is up (launching if needed). */
   ensureRunning?: (alreadyRunning: boolean) => Promise<boolean>;
   isAppRunning?: () => boolean;
+  /** Canary seam: does the installed sdef still declare the private command? */
+  sdefProbe?: () => boolean;
   now?: () => Date;
   poller?: PollerDeps;
   pkgVersion?: string;
@@ -250,7 +253,7 @@ export async function runMutation<K extends OperationKind>(
 
   try {
     // 3. Pre-read + guards.
-    const pre = spec.preRead(deps.db, params);
+    const pre = spec.preRead(deps.db, params, deps.now?.() ?? new Date());
     const acks: Acknowledgements = {
       ...(options.acknowledgeChecklistReset !== undefined && {
         acknowledgeChecklistReset: options.acknowledgeChecklistReset,
@@ -285,6 +288,7 @@ export async function runMutation<K extends OperationKind>(
     const plan = planVector(op, deps.vectors, {
       maxDisruption,
       appRunning,
+      allowExperimental: config.allowExperimental,
       ...(options.vector !== undefined && { forcedVector: options.vector }),
     });
     if (plan.kind === "unsupported") {
@@ -305,6 +309,26 @@ export async function runMutation<K extends OperationKind>(
       };
     }
     const { vector, effectiveTier } = plan.candidate;
+
+    // 4b. Experimental canary: the private sdef command can vanish in any
+    // Things update — re-check the declaration before every dispatch.
+    if (plan.candidate.support.experimental === true) {
+      const declared = (deps.sdefProbe ?? sdefDeclaresPrivateReorder)();
+      if (!declared) {
+        audit({ result: "blocked:environment" });
+        return {
+          kind: "blocked",
+          op,
+          reason: "environment",
+          detail:
+            "the installed Things no longer declares the private reorder command in its " +
+            "sdef — the experimental surface has likely been removed by an app update",
+          remediation:
+            "check `things doctor`, file/track the change, and fall back to the bounce " +
+            "strategy where available",
+        };
+      }
+    }
 
     // 5. Compile + expected delta.
     const nowEpoch = Math.floor((deps.now?.() ?? new Date()).getTime() / 1000);
@@ -416,7 +440,7 @@ export async function runMutation<K extends OperationKind>(
   }
 }
 
-function fingerprintLabel(
+export function fingerprintLabel(
   fp: FingerprintStatus,
   config: ThingsApiConfig,
 ): "ok" | "drift" | "user-accepted" | "unknown" {

--- a/src/write/pipeline.ts
+++ b/src/write/pipeline.ts
@@ -160,6 +160,11 @@ function capturePre(
       for (const c of spec.cascade) captureFor(c.uuid, c.assert);
     }
   }
+  if (spec.mode === "ordering") {
+    const preRanks: Record<string, unknown> = {};
+    for (const uuid of spec.sequence) preRanks[uuid] = reader.rankOf(uuid, spec.key);
+    fields["__ordering__"] = preRanks;
+  }
   if (spec.mode === "trash-emptied") {
     return { modDates, fields, trashedCount: pre.trashedCount };
   }

--- a/src/write/planner.ts
+++ b/src/write/planner.ts
@@ -32,6 +32,8 @@ export function planVector(
     maxDisruption: DisruptionTier;
     appRunning: boolean;
     forcedVector?: VectorId;
+    /** Config gate for `experimental: true` matrix entries (default off). */
+    allowExperimental?: boolean;
   },
 ): Plan {
   const considered: { vector: VectorId; why: string }[] = [];
@@ -55,6 +57,15 @@ export function planVector(
       considered.push({
         vector: vector.id,
         why: `capability is ${support.validation} — not lab-validated`,
+      });
+      continue;
+    }
+    if (support.experimental === true && options.allowExperimental !== true) {
+      considered.push({
+        vector: vector.id,
+        why:
+          "rides an undocumented app surface — enable it with " +
+          "`things config set allow-experimental true`",
       });
       continue;
     }

--- a/src/write/pre-state.ts
+++ b/src/write/pre-state.ts
@@ -4,10 +4,11 @@
  */
 import type { DatabaseSync } from "node:sqlite";
 
+import { encodePackedDate, localToday } from "../model/dates.ts";
 import type { AnyTask, Project, TaskStatus, Todo } from "../model/entities.ts";
 import { TASK_STATUS_FROM_DB } from "../model/entities.ts";
 import { byUuid } from "../read/detail.ts";
-import type { ContainerRef } from "./operations.ts";
+import type { ContainerRef, ReorderParams } from "./operations.ts";
 
 export interface ResolvedContainer {
   uuid: string;
@@ -18,6 +19,32 @@ export interface ContainerResolution {
   resolved: ResolvedContainer | null;
   /** 0 = not found, 1 = ok, >1 = ambiguous title. */
   matches: number;
+}
+
+export interface ReorderMember {
+  uuid: string;
+  title: string;
+  /** Current rank on the scope's ordering key (todayIndex or "index"). */
+  rank: number;
+  /** Raw startBucket (0 = today, 1 = evening); today/evening scopes only. */
+  startBucket: number | null;
+  /** 0 = to-do, 1 = project. */
+  type: number;
+}
+
+export interface ReorderPre {
+  /** Ordering key the scope ranks on. */
+  key: "index" | "todayIndex";
+  /** Eligible members in current order (wire-list extension source). */
+  members: ReorderMember[];
+  /** Requested uuids that are not eligible members, with the reason. */
+  rejected: { uuid: string; reason: string }[];
+  /** Requested uuids appearing more than once. */
+  duplicates: string[];
+  /** Requested project-type members (bounce cannot move projects). */
+  projectMembers: string[];
+  /** Full wire list: requested order first, remaining members after. */
+  wireList: string[];
 }
 
 export interface PreState {
@@ -42,6 +69,8 @@ export interface PreState {
   trashedCount: number;
   /** Pre-existing uuids for entity-created probes. */
   existingEntityUuids: string[];
+  /** Scope membership + wire list for the reorder operation. */
+  reorder: ReorderPre | null;
 }
 
 export function emptyPreState(): PreState {
@@ -59,6 +88,7 @@ export function emptyPreState(): PreState {
     checklistCount: 0,
     trashedCount: 0,
     existingEntityUuids: [],
+    reorder: null,
   };
 }
 
@@ -166,6 +196,172 @@ export function trashedCount(db: DatabaseSync): number {
 
 export function isRepeatingTemplate(task: AnyTask | null): boolean {
   return task !== null && task.type !== "heading" && task.repeating.isTemplate;
+}
+
+const NOT_TEMPLATE_ROW = "(rt1_recurrenceRule IS NULL AND repeater IS NULL)";
+
+interface MemberRow {
+  uuid: string;
+  title: string;
+  rank: number;
+  startBucket: number | null;
+  type: number;
+}
+
+/**
+ * Scope membership + full wire list for `reorder`. Eligibility mirrors the
+ * lab evidence exactly:
+ *  - today:   Today members with raw startBucket=0, to-dos AND projects
+ *             (O01/O03/O12), by todayIndex. Bucket-1 members are listed as
+ *             rejected candidates — including one silently de-evenings it
+ *             (O03), so the guard refuses.
+ *  - evening: raw startBucket=1 AND startDate == today exactly (evening
+ *             membership expires daily), by todayIndex. Bounce-only (O03).
+ *  - project: un-headed open to-do children, by "index" (O04/O09/O11);
+ *             headed children are rejected candidates (O06 rips them out).
+ *  - area:    direct open area to-dos, by "index" (O05/O10).
+ */
+export function computeReorderPre(
+  db: DatabaseSync,
+  params: ReorderParams,
+  containerUuid: string | null,
+  now: Date,
+): ReorderPre {
+  const todayIso = localToday(now);
+  const packedToday = encodePackedDate(todayIso);
+  const key: "index" | "todayIndex" =
+    params.scope === "today" || params.scope === "evening" ? "todayIndex" : "index";
+
+  const select = (where: string, binds: (string | number)[], rankCol: string): MemberRow[] =>
+    db
+      .prepare(
+        `SELECT uuid, title, ${rankCol} AS rank, startBucket, type FROM TMTask
+         WHERE trashed = 0 AND status = 0 AND ${NOT_TEMPLATE_ROW} AND ${where}
+         ORDER BY ${rankCol} ASC`,
+      )
+      .all(...binds) as unknown as MemberRow[];
+
+  let members: MemberRow[] = [];
+  const rejectedCandidates = new Map<string, string>();
+
+  switch (params.scope) {
+    case "today":
+    case "evening": {
+      const all = select(
+        "type IN (0, 1) AND startDate IS NOT NULL AND startDate <= ? AND start IN (1, 2)",
+        [packedToday],
+        "todayIndex",
+      );
+      if (params.scope === "today") {
+        members = all.filter((m) => m.startBucket === 0);
+        for (const m of all) {
+          if (m.startBucket === 1) {
+            rejectedCandidates.set(
+              m.uuid,
+              "is an evening-bucket item — a native Today reorder would silently de-evening " +
+                "it (O03); use scope 'evening' for it instead",
+            );
+          }
+        }
+      } else {
+        // Evening membership expires daily: only exact-today bucket-1 rows.
+        members = all.filter(
+          (m) => m.startBucket === 1 && rowStartDate(db, m.uuid) === packedToday,
+        );
+        for (const m of all) {
+          if (!members.some((e) => e.uuid === m.uuid)) {
+            rejectedCandidates.set(
+              m.uuid,
+              m.startBucket === 1
+                ? "is a STALE evening item (startDate in the past) — it renders in Today " +
+                    "proper; re-schedule it before reordering"
+                : "is in the Today section, not This Evening — use scope 'today'",
+            );
+          }
+        }
+      }
+      break;
+    }
+    case "project": {
+      members = select(
+        "type = 0 AND heading IS NULL AND project = ?",
+        [containerUuid ?? ""],
+        `"index"`,
+      );
+      const headed = db
+        .prepare(
+          `SELECT t.uuid FROM TMTask t JOIN TMTask h ON t.heading = h.uuid
+           WHERE t.trashed = 0 AND t.type = 0 AND h.project = ?`,
+        )
+        .all(containerUuid ?? "") as { uuid: string }[];
+      for (const r of headed) {
+        rejectedCandidates.set(
+          r.uuid,
+          "is inside a heading — a project-scope reorder RIPS headed children out of " +
+            "their heading (O06); heading-scoped ordering is not automatable",
+        );
+      }
+      break;
+    }
+    case "area": {
+      members = select(
+        "type = 0 AND heading IS NULL AND area = ?",
+        [containerUuid ?? ""],
+        `"index"`,
+      );
+      break;
+    }
+  }
+
+  const seen = new Set<string>();
+  const duplicates: string[] = [];
+  for (const uuid of params.uuids) {
+    if (seen.has(uuid) && !duplicates.includes(uuid)) duplicates.push(uuid);
+    seen.add(uuid);
+  }
+
+  const memberSet = new Map(members.map((m) => [m.uuid, m]));
+  const rejected: { uuid: string; reason: string }[] = [];
+  const projectMembers: string[] = [];
+  for (const uuid of params.uuids) {
+    const member = memberSet.get(uuid);
+    if (member === undefined) {
+      rejected.push({
+        uuid,
+        reason: rejectedCandidates.get(uuid) ?? "is not an open member of this scope",
+      });
+      continue;
+    }
+    if (member.type === 1) projectMembers.push(uuid);
+  }
+
+  const requested = new Set(params.uuids);
+  const wireList = [
+    ...params.uuids,
+    ...members.filter((m) => !requested.has(m.uuid)).map((m) => m.uuid),
+  ];
+
+  return {
+    key,
+    members: members.map((m) => ({
+      uuid: m.uuid,
+      title: m.title,
+      rank: m.rank,
+      startBucket: m.startBucket,
+      type: m.type,
+    })),
+    rejected,
+    duplicates,
+    projectMembers,
+    wireList,
+  };
+}
+
+function rowStartDate(db: DatabaseSync, uuid: string): number | null {
+  const row = db.prepare("SELECT startDate FROM TMTask WHERE uuid = ?").get(uuid) as
+    | { startDate: number | null }
+    | undefined;
+  return row?.startDate ?? null;
 }
 
 export function projectOf(task: AnyTask | null): Project | null {

--- a/src/write/reorder.ts
+++ b/src/write/reorder.ts
@@ -1,0 +1,367 @@
+/**
+ * write.reorder orchestrator — two strategies, both lab-derived:
+ *
+ * native  — one `_private_experimental_ reorder` AppleScript call through
+ *           the standard pipeline (drift gate → guards → canary → execute →
+ *           ordering verification). Scopes: today (bucket-0 members, O01/
+ *           O03/O12), project/area (un-headed children, O04/O05/O09–O11).
+ *           Gated by config.allowExperimental AND the sdef canary.
+ *
+ * bounce  — verified `when=` round-trips (O07/O08): re-scheduling an item
+ *           away and back FRONT-INSERTS it in its section, so bouncing the
+ *           requested uuids in reverse order places them top-first. Each leg
+ *           is a full verified todo.update mutation; between items the live
+ *           state is re-checked so a user editing Things concurrently causes
+ *           a clean abort with partial-progress detail, never a fight.
+ *           Scopes: today (fallback), evening (the ONLY way — O03).
+ *
+ * The requested uuid list may be a subset of the scope: for native, the wire
+ * list is extended with every remaining member in current order (placement
+ * stays deterministic); for bounce, unrequested members simply stay put
+ * below the bounced block (O07/O08: neighbors untouched).
+ */
+import type { AuditRecord } from "../audit/schema.ts";
+import { localToday, encodePackedDate } from "../model/dates.ts";
+import type { ReorderParams, ReorderStrategy } from "./operations.ts";
+import { computeReorderPre, resolveArea, resolveProject } from "./pre-state.ts";
+import { sdefDeclaresPrivateReorder } from "./experimental.ts";
+import {
+  fingerprintLabel,
+  runMutation,
+  type MutationResult,
+  type WriteDeps,
+  type WriteOptions,
+} from "./pipeline.ts";
+import { createDbReader, evaluateDelta } from "./verify/delta.ts";
+import { pollUntilVerified } from "./verify/poller.ts";
+
+/**
+ * Bounce cost is 2 verified mutations per item; beyond this the today scope
+ * should use the native strategy and the evening scope should be re-thought.
+ */
+export const BOUNCE_MAX_ITEMS = 10;
+
+export type ReorderResult =
+  | MutationResult
+  | {
+      kind: "bounce-aborted";
+      op: "reorder";
+      detail: string;
+      /** Uuids already placed (they ARE at the top, in requested order). */
+      placed: string[];
+      /** Uuids not yet placed (still in their prior positions). */
+      remaining: string[];
+      /** The failing leg's result when a mutation failed (null = state check). */
+      cause: MutationResult | null;
+    };
+
+export async function runReorder(
+  deps: WriteDeps,
+  params: ReorderParams,
+  options: WriteOptions = {},
+): Promise<ReorderResult> {
+  const strategy = resolveStrategy(deps, params);
+  if (strategy.kind === "blocked") return strategy.result;
+
+  if (strategy.strategy === "native") {
+    return runMutation(deps, "reorder", params, { ...options, vector: "applescript" });
+  }
+  return runBounce(deps, params, options);
+}
+
+function resolveStrategy(
+  deps: WriteDeps,
+  params: ReorderParams,
+): { kind: "ok"; strategy: ReorderStrategy } | { kind: "blocked"; result: MutationResult } {
+  const blocked = (
+    detail: string,
+    remediation: string,
+  ): { kind: "blocked"; result: MutationResult } => ({
+    kind: "blocked",
+    result: {
+      kind: "blocked",
+      op: "reorder",
+      reason: "hazard",
+      hazard: "H-REORDER-SCOPE",
+      detail,
+      remediation,
+    },
+  });
+
+  const nativeAvailable =
+    deps.config.allowExperimental && (deps.sdefProbe ?? sdefDeclaresPrivateReorder)();
+
+  if (params.strategy === "native") {
+    if (params.scope === "evening") {
+      return blocked(
+        "evening reorder is bounce-only: the native command silently clears startBucket on " +
+          "every listed item (O03)",
+        "omit --strategy (evening defaults to bounce)",
+      );
+    }
+    return { kind: "ok", strategy: "native" };
+  }
+  if (params.strategy === "bounce") {
+    if (params.scope === "project" || params.scope === "area") {
+      return blocked(
+        "bounce can only reorder the Today/Evening sections — its primitive is a when= " +
+          "round-trip, which moves todayIndex, not project/area order (O07/O08)",
+        "use the native strategy (requires `things config set allow-experimental true`)",
+      );
+    }
+    return { kind: "ok", strategy: "bounce" };
+  }
+
+  // Default per scope.
+  switch (params.scope) {
+    case "evening":
+      return { kind: "ok", strategy: "bounce" };
+    case "today":
+      return { kind: "ok", strategy: nativeAvailable ? "native" : "bounce" };
+    case "project":
+    case "area":
+      // Native-only scopes: let the pipeline explain precisely why native is
+      // unavailable (planner: experimental gate; canary: sdef change).
+      return { kind: "ok", strategy: "native" };
+  }
+}
+
+// ------------------------------------------------------------------- bounce
+
+async function runBounce(
+  deps: WriteDeps,
+  params: ReorderParams,
+  options: WriteOptions,
+): Promise<ReorderResult> {
+  const startedAt = deps.now?.() ?? new Date();
+  const now = deps.now ?? (() => new Date());
+  const scope = params.scope as "today" | "evening";
+
+  // Scope/membership guard — same data the native path's guard uses.
+  const pre = computeReorderPre(deps.db, params, resolveContainerUuid(deps, params), now());
+  const problems: string[] = [];
+  if (params.container !== undefined)
+    problems.push("container is only valid for project/area scopes");
+  if (params.uuids.length === 0) problems.push("no uuids given");
+  if (pre.duplicates.length > 0) problems.push(`duplicated uuid(s): ${pre.duplicates.join(", ")}`);
+  for (const r of pre.rejected) problems.push(`${r.uuid} ${r.reason}`);
+  for (const uuid of pre.projectMembers) {
+    problems.push(
+      `${uuid} is a project — bounce re-schedules via todo.update, which is only validated ` +
+        "for to-dos; use the native strategy for Today lists containing projects",
+    );
+  }
+  if (params.uuids.length > BOUNCE_MAX_ITEMS) {
+    problems.push(
+      `${params.uuids.length} items exceeds the bounce cap of ${BOUNCE_MAX_ITEMS} ` +
+        "(each item costs two verified mutations)",
+    );
+  }
+  if (problems.length > 0) {
+    const result: MutationResult = {
+      kind: "blocked",
+      op: "reorder",
+      reason: "hazard",
+      hazard: "H-REORDER-SCOPE",
+      detail: `reorder request rejected: ${problems.join("; ")}`,
+      remediation:
+        "read the scope first (things today) and pass only its eligible members, " +
+        `at most ${BOUNCE_MAX_ITEMS} for the bounce strategy`,
+    };
+    auditSummary(deps, params, startedAt, "blocked:H-REORDER-SCOPE", null);
+    return result;
+  }
+
+  const away = scope === "today" ? "evening" : "today";
+  if (options.dryRun === true) {
+    return {
+      kind: "dry-run",
+      op: "reorder",
+      plan: {
+        op: "reorder",
+        vector: "url-scheme",
+        tier: 0,
+        invocation:
+          `bounce ×${params.uuids.length} (reverse order): ` +
+          `things:///update?id=<uuid>&when=${away} → verified → when=${scope} → verified; ` +
+          "state re-checked between items",
+        expectedDelta: { mode: "ordering", key: "todayIndex", sequence: params.uuids },
+        hazardsChecked: ["H-REORDER-SCOPE"],
+      },
+    };
+  }
+
+  // Bounce in REVERSE: each round-trip front-inserts (O07/O08), so placing
+  // the last item first leaves the requested order on top.
+  const placed: string[] = [];
+  for (let i = params.uuids.length - 1; i >= 0; i--) {
+    const uuid = params.uuids[i] as string;
+
+    // Concurrent-edit re-check: the item must still be an eligible member.
+    const memberProblem = checkStillMember(deps, uuid, scope, now());
+    if (memberProblem !== null) {
+      const detail =
+        `aborted before bouncing ${uuid}: ${memberProblem} (Things was likely edited ` +
+        "concurrently); already-placed items keep their new positions";
+      auditSummary(deps, params, startedAt, "verify-failed:mismatch", { placed: [...placed] });
+      return {
+        kind: "bounce-aborted",
+        op: "reorder",
+        detail,
+        placed: [...placed],
+        remaining: params.uuids.slice(0, i + 1),
+        cause: null,
+      };
+    }
+
+    const leg1 = await runMutation(deps, "todo.update", { uuid, when: away }, legOptions(options));
+    if (leg1.kind !== "ok") {
+      auditSummary(deps, params, startedAt, "verify-failed:mismatch", { placed: [...placed] });
+      return {
+        kind: "bounce-aborted",
+        op: "reorder",
+        detail: `bounce leg 1 (when=${away}) failed for ${uuid} — the item was NOT moved`,
+        placed: [...placed],
+        remaining: params.uuids.slice(0, i + 1),
+        cause: leg1,
+      };
+    }
+    const leg2 = await runMutation(deps, "todo.update", { uuid, when: scope }, legOptions(options));
+    if (leg2.kind !== "ok") {
+      auditSummary(deps, params, startedAt, "verify-failed:mismatch", { placed: [...placed] });
+      return {
+        kind: "bounce-aborted",
+        op: "reorder",
+        detail:
+          `bounce leg 2 (when=${scope}) failed for ${uuid} — THE ITEM IS STRANDED IN ` +
+          `${away.toUpperCase()}; re-schedule it (things todo update --when ${scope}) or fix in the app`,
+        placed: [...placed],
+        remaining: params.uuids.slice(0, i + 1),
+        cause: leg2,
+      };
+    }
+    placed.unshift(uuid);
+
+    // Placed-prefix invariant: everything bounced so far must read back in
+    // requested relative order — anything else means a concurrent reshuffle.
+    const prefixCheck = await pollUntilVerified(
+      () =>
+        evaluateDelta(
+          { mode: "ordering", key: "todayIndex", sequence: [...placed] },
+          createDbReader(deps.db),
+          { modDates: {}, fields: {} },
+        ),
+      options.verifyTimeoutMs ?? 4000,
+      deps.poller ?? {},
+    );
+    if (prefixCheck.kind !== "ok") {
+      auditSummary(deps, params, startedAt, "verify-failed:mismatch", { placed: [...placed] });
+      return {
+        kind: "bounce-aborted",
+        op: "reorder",
+        detail:
+          `placed items fell out of order after bouncing ${uuid} (concurrent edit?); ` +
+          "re-run the reorder once Things is idle",
+        placed: [...placed],
+        remaining: params.uuids.slice(0, i),
+        cause: null,
+      };
+    }
+  }
+
+  const reader = createDbReader(deps.db);
+  const observed: Record<string, unknown> = {};
+  for (const uuid of params.uuids) observed[uuid] = reader.rankOf(uuid, "todayIndex");
+  auditSummary(deps, params, startedAt, "ok", observed);
+  return {
+    kind: "ok",
+    op: "reorder",
+    uuid: null,
+    observed,
+    vector: "url-scheme",
+    tier: 0,
+  };
+}
+
+function legOptions(options: WriteOptions): WriteOptions {
+  const legs: WriteOptions = {};
+  if (options.maxDisruption !== undefined) legs.maxDisruption = options.maxDisruption;
+  if (options.verifyTimeoutMs !== undefined) legs.verifyTimeoutMs = options.verifyTimeoutMs;
+  if (options.actor !== undefined) legs.actor = options.actor;
+  return legs;
+}
+
+function resolveContainerUuid(deps: WriteDeps, params: ReorderParams): string | null {
+  if (params.scope === "project") {
+    return resolveProject(deps.db, params.container ?? {}).resolved?.uuid ?? null;
+  }
+  if (params.scope === "area") {
+    return resolveArea(deps.db, params.container ?? {}).resolved?.uuid ?? null;
+  }
+  return null;
+}
+
+/** null = still eligible; otherwise a human-readable problem. */
+function checkStillMember(
+  deps: WriteDeps,
+  uuid: string,
+  scope: "today" | "evening",
+  now: Date,
+): string | null {
+  const packedToday = encodePackedDate(localToday(now));
+  const row = deps.db
+    .prepare("SELECT status, trashed, startBucket, startDate, start FROM TMTask WHERE uuid = ?")
+    .get(uuid) as
+    | {
+        status: number;
+        trashed: number;
+        startBucket: number;
+        startDate: number | null;
+        start: number;
+      }
+    | undefined;
+  if (row === undefined) return "the item no longer exists";
+  if (row.trashed !== 0) return "the item was trashed";
+  if (row.status !== 0) return "the item is no longer open";
+  const inToday =
+    row.startDate !== null && row.startDate <= packedToday && (row.start === 1 || row.start === 2);
+  if (!inToday) return "the item left the Today list";
+  if (scope === "today" && row.startBucket !== 0) return "the item moved to This Evening";
+  if (scope === "evening" && (row.startBucket !== 1 || row.startDate !== packedToday)) {
+    return "the item left This Evening";
+  }
+  return null;
+}
+
+function auditSummary(
+  deps: WriteDeps,
+  params: ReorderParams,
+  startedAt: Date,
+  result: AuditRecord["result"],
+  observed: Record<string, unknown> | null,
+): void {
+  const fp = deps.fingerprint();
+  const record: AuditRecord = {
+    v: 1,
+    ts: startedAt.toISOString(),
+    actor: deps.config.actor,
+    host: deps.config.host,
+    op: "reorder",
+    uuid: null,
+    vector: "url-scheme",
+    disruption: 0,
+    invocation: `bounce(${params.scope}) ×${params.uuids.length}`,
+    requested: params as unknown as Record<string, unknown>,
+    pre: null,
+    observed,
+    result,
+    verify: null,
+    durationMs: (deps.now?.() ?? new Date()).getTime() - startedAt.getTime(),
+    env: {
+      pkg: deps.pkgVersion ?? "0.0.1",
+      dbVersion: fp.observation.databaseVersion,
+      fingerprint: fingerprintLabel(fp, deps.config),
+    },
+  };
+  deps.audit.append(record);
+}

--- a/src/write/vectors/applescript.ts
+++ b/src/write/vectors/applescript.ts
@@ -97,6 +97,16 @@ export const APPLESCRIPT_MATRIX: VectorMatrix = {
     evidence: ["A27"],
     notes: "PERMANENT — hard-deletes every trashed row",
   },
+  reorder: {
+    support: "partial",
+    disruption: 0,
+    validation: "validated",
+    evidence: ["O01", "O03", "O04", "O05", "O06", "O09", "O10", "O11", "O12"],
+    experimental: true,
+    notes:
+      "`_private_experimental_ reorder to dos in` — today (bucket-0 members), project/area " +
+      "(un-headed children only, O06); evening is bounce-only (O03 de-evenings bucket-1 members)",
+  },
 };
 
 /** Escape a string literal for embedding in AppleScript source. */

--- a/src/write/vectors/types.ts
+++ b/src/write/vectors/types.ts
@@ -28,6 +28,12 @@ export interface VectorSupport {
   validation: "validated" | "assumed" | "unvalidated";
   /** Probe ids backing this entry (u-suite / a-suite evidence). */
   evidence?: string[];
+  /**
+   * Rides an UNDOCUMENTED app surface (e.g. `_private_experimental_` sdef
+   * commands). Requires config allowExperimental AND the pipeline's sdef
+   * canary — the surface can vanish in any Things update.
+   */
+  experimental?: boolean;
   notes?: string;
 }
 

--- a/src/write/verify/delta.ts
+++ b/src/write/verify/delta.ts
@@ -43,7 +43,12 @@ export type DeltaSpec =
       /** For tags: expected parent uuid (null = must be root). */
       parentUuid?: string | null;
     }
-  | { mode: "trash-emptied" };
+  | { mode: "trash-emptied" }
+  /**
+   * Ordering: the given uuids must read back in strictly ascending rank on
+   * the named key (todayIndex for Today/Evening scopes, index elsewhere).
+   */
+  | { mode: "ordering"; key: "index" | "todayIndex"; sequence: string[] };
 
 /** Movement tripwires captured by the pre-read, keyed by uuid. */
 export type PreModDates = Record<string, number | null>;
@@ -66,6 +71,7 @@ export interface VerifyReader {
   tagExists(uuid: string): boolean;
   areasByTitle(title: string): { uuid: string }[];
   tagsByTitle(title: string): { uuid: string; parent: string | null }[];
+  rankOf(uuid: string, key: "index" | "todayIndex"): number | null;
   trashedCount(): number;
   findCreated(probe: CreateProbe): AnyTask[];
   modDateOf(uuid: string): number | null;
@@ -89,6 +95,13 @@ export function createDbReader(db: DatabaseSync): VerifyReader {
       return db
         .prepare("SELECT uuid, parent FROM TMTag WHERE title = ? COLLATE NOCASE")
         .all(title) as { uuid: string; parent: string | null }[];
+    },
+    rankOf(uuid, key) {
+      const column = key === "todayIndex" ? "todayIndex" : `"index"`;
+      const row = db.prepare(`SELECT ${column} AS rank FROM TMTask WHERE uuid = ?`).get(uuid) as
+        | { rank: number | null }
+        | undefined;
+      return row?.rank ?? null;
     },
     trashedCount() {
       const row = db.prepare("SELECT COUNT(*) AS n FROM TMTask WHERE trashed = 1").get() as {
@@ -258,6 +271,37 @@ export function evaluateDelta(
         movement: fresh.length > 0,
         assertedMovement: fresh.length > 0,
         observed: null,
+      };
+    }
+    case "ordering": {
+      const ranks = spec.sequence.map((uuid) => ({ uuid, rank: reader.rankOf(uuid, spec.key) }));
+      const observed: Record<string, unknown> = {};
+      for (const r of ranks) observed[r.uuid] = r.rank;
+      const missing = ranks.some((r) => r.rank === null);
+      let sorted = !missing;
+      for (let i = 1; i < ranks.length && sorted; i++) {
+        const prev = ranks[i - 1]?.rank;
+        const curr = ranks[i]?.rank;
+        if (
+          prev === null ||
+          prev === undefined ||
+          curr === null ||
+          curr === undefined ||
+          prev >= curr
+        ) {
+          sorted = false;
+        }
+      }
+      // Movement: any rank differs from the captured pre-state.
+      const preRanks = pre.fields["__ordering__"] ?? {};
+      const moved = ranks.some(
+        (r) => preRanks[r.uuid] !== undefined && preRanks[r.uuid] !== r.rank,
+      );
+      return {
+        satisfied: sorted,
+        movement: moved,
+        assertedMovement: moved,
+        observed,
       };
     }
     case "trash-emptied": {

--- a/test/cli/help-contract.test.ts
+++ b/test/cli/help-contract.test.ts
@@ -94,4 +94,16 @@ describe("write-command help states the contract", () => {
     expect(help).toContain("vector");
     expect(help).toContain("--op");
   });
+
+  it("reorder: experimental gate, bounce cap, scope hazards", () => {
+    const help = helpFor("reorder");
+    expect(help).toContain("EXPERIMENTAL");
+    expect(help).toContain("allow-experimental");
+    expect(help).toContain("bounce");
+    expect(help).toContain("Evening is bounce-only");
+    expect(help).toContain("H-REORDER-SCOPE");
+    expect(help).toContain("--scope <scope>");
+    expect(help).toContain("--strategy <name>");
+    expect(help).toContain("--dry-run");
+  });
 });

--- a/test/engine/write-pipeline.test.ts
+++ b/test/engine/write-pipeline.test.ts
@@ -77,6 +77,7 @@ const CONFIG: ThingsApiConfig = {
   actor: "test-actor",
   auditEnabled: true,
   acceptedFingerprint: null,
+  allowExperimental: false,
   host: "test-host",
 };
 

--- a/test/engine/write-reorder.test.ts
+++ b/test/engine/write-reorder.test.ts
@@ -1,0 +1,458 @@
+/**
+ * write.reorder engine tests. The native path rides the standard pipeline
+ * (experimental gate → sdef canary → guards → ordering verification); the
+ * bounce path is the orchestrator (verified when= legs + between-step state
+ * re-checks). FakeVectors simulate the app's validated semantics: the native
+ * reorder assigns ascending ranks to the wire list (O01/O04/O05), a when=
+ * round-trip FRONT-inserts into the target section (O07/O08).
+ */
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { AuditRecord } from "../../src/audit/schema.ts";
+import type { ThingsApiConfig } from "../../src/config.ts";
+import type { FingerprintStatus } from "../../src/db/fingerprint.ts";
+import { encodePackedDate } from "../../src/model/dates.ts";
+import type { WriteDeps } from "../../src/write/pipeline.ts";
+import { computeReorderPre } from "../../src/write/pre-state.ts";
+import { BOUNCE_MAX_ITEMS, runReorder } from "../../src/write/reorder.ts";
+import type { WriteVector } from "../../src/write/vectors/types.ts";
+import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
+import { seedHeading, seedProject, seedTodo } from "../fixtures/seed.ts";
+
+const NOW = new Date("2026-07-05T12:00:00Z");
+const TODAY_ISO = "2026-07-05";
+const PACKED_TODAY = encodePackedDate(TODAY_ISO);
+
+let fixture: FixtureDb;
+let auditRecords: AuditRecord[];
+let lockSeq = 0;
+let modClock = 1_790_000_000;
+
+beforeEach(() => {
+  fixture = buildFixtureDb();
+  auditRecords = [];
+});
+afterEach(() => {
+  fixture.close();
+});
+
+function okFingerprint(): FingerprintStatus {
+  return {
+    kind: "ok",
+    observation: { databaseVersion: 26, tables: [], fingerprint: "sha256:test" },
+  };
+}
+
+function config(allowExperimental: boolean): ThingsApiConfig {
+  return {
+    profile: "workstation",
+    maxDisruption: 1,
+    actor: "test-actor",
+    auditEnabled: true,
+    acceptedFingerprint: null,
+    allowExperimental,
+    host: "test-host",
+  };
+}
+
+function deps(vectors: WriteVector[], overrides: Partial<WriteDeps> = {}): WriteDeps {
+  return {
+    db: fixture.db,
+    vectors,
+    config: config(true),
+    audit: { append: (r) => auditRecords.push(r) },
+    fingerprint: okFingerprint,
+    lockPath: join(tmpdir(), `things-api-reorder-lock-${process.pid}-${lockSeq++}`),
+    isAppRunning: () => true,
+    ensureRunning: async () => true,
+    now: () => NOW,
+    sdefProbe: () => true,
+    ...overrides,
+  };
+}
+
+/** Native sim: parse the ids list and assign ascending ranks (O01 semantics). */
+function nativeVector(rankColumn: "todayIndex" | `"index"` = "todayIndex") {
+  const calls: string[] = [];
+  const vector: WriteVector = {
+    id: "applescript",
+    matrix: {
+      reorder: { support: "partial", disruption: 0, validation: "validated", experimental: true },
+    },
+    async execute(invocation) {
+      calls.push(invocation.payload);
+      const ids = /with ids "([^"]+)"/.exec(invocation.payload)?.[1]?.split(",") ?? [];
+      let rank = 1;
+      for (const uuid of ids) {
+        fixture.db
+          .prepare(`UPDATE TMTask SET ${rankColumn} = ?, userModificationDate = ? WHERE uuid = ?`)
+          .run(rank++, modClock++, uuid);
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    },
+  };
+  return { vector, calls };
+}
+
+/** Bounce sim: when= round-trips FRONT-insert into the section (O07/O08). */
+function bounceVector(hooks: { afterLeg?: (payload: string, db: DatabaseSync) => void } = {}) {
+  const calls: string[] = [];
+  const vector: WriteVector = {
+    id: "url-scheme",
+    matrix: { "todo.update": { support: "yes", disruption: 0, validation: "validated" } },
+    async execute(invocation) {
+      calls.push(invocation.payload);
+      const url = new URL(invocation.payload);
+      const id = url.searchParams.get("id") ?? "";
+      const when = url.searchParams.get("when") ?? "";
+      const bucket = when === "evening" ? 1 : 0;
+      const min = fixture.db
+        .prepare(
+          `SELECT MIN(todayIndex) AS m FROM TMTask WHERE trashed = 0 AND status = 0
+           AND startBucket = ? AND startDate IS NOT NULL AND startDate <= ?`,
+        )
+        .get(bucket, PACKED_TODAY) as { m: number | null };
+      fixture.db
+        .prepare(
+          `UPDATE TMTask SET start = 1, startDate = ?, startBucket = ?, todayIndex = ?,
+           userModificationDate = ? WHERE uuid = ?`,
+        )
+        .run(PACKED_TODAY, bucket, (min.m ?? 0) - 1, modClock++, id);
+      hooks.afterLeg?.(invocation.payload, fixture.db);
+      return { exitCode: 0, stdout: "", stderr: "" };
+    },
+  };
+  return { vector, calls };
+}
+
+function seedToday(title: string, todayIndex: number, opts: { evening?: boolean } = {}): string {
+  return seedTodo(fixture.db, {
+    title,
+    start: "active",
+    startDate: TODAY_ISO,
+    todayIndex,
+    ...(opts.evening !== undefined && { evening: opts.evening }),
+  });
+}
+
+function ranks(uuids: string[], column: "todayIndex" | `"index"` = "todayIndex"): number[] {
+  return uuids.map(
+    (uuid) =>
+      (
+        fixture.db.prepare(`SELECT ${column} AS r FROM TMTask WHERE uuid = ?`).get(uuid) as {
+          r: number;
+        }
+      ).r,
+  );
+}
+
+describe("native reorder (private command through the pipeline)", () => {
+  it("today scope: extends a partial request to the full wire list and verifies", async () => {
+    const a = seedToday("A", 10);
+    const b = seedToday("B", 20);
+    const c = seedToday("C", 30);
+    const { vector, calls } = nativeVector();
+    const result = await runReorder(deps([vector]), { scope: "today", uuids: [c, a] });
+    expect(result.kind).toBe("ok");
+    // Wire list = requested first, remaining member (b) after, in one call.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain(`list "Today"`);
+    expect(calls[0]).toContain(`with ids "${c},${a},${b}"`);
+    const [rc, ra, rb] = ranks([c, a, b]);
+    expect(rc).toBeLessThan(ra as number);
+    expect(ra).toBeLessThan(rb as number);
+  });
+
+  it("project scope: uuid specifier, un-headed children only", async () => {
+    const proj = seedProject(fixture.db, { title: "P" });
+    const one = seedTodo(fixture.db, { title: "one", project: proj, index: 1 });
+    const two = seedTodo(fixture.db, { title: "two", project: proj, index: 2 });
+    const { vector, calls } = nativeVector(`"index"`);
+    const result = await runReorder(deps([vector]), {
+      scope: "project",
+      container: { uuid: proj },
+      uuids: [two, one],
+    });
+    expect(result.kind).toBe("ok");
+    expect(calls[0]).toContain(`project id "${proj}"`);
+    expect(calls[0]).toContain(`with ids "${two},${one}"`);
+  });
+
+  it("is gated by config.allowExperimental (planner refuses the matrix entry)", async () => {
+    const a = seedToday("A", 10);
+    const { vector, calls } = nativeVector();
+    const result = await runReorder(deps([vector], { config: config(false) }), {
+      scope: "today",
+      uuids: [a],
+      strategy: "native",
+    });
+    expect(result.kind).toBe("unsupported");
+    if (result.kind === "unsupported") {
+      expect(result.considered[0]?.why).toContain("allow-experimental");
+    }
+    expect(calls).toHaveLength(0);
+  });
+
+  it("is blocked by the sdef canary when the private command vanishes", async () => {
+    const a = seedToday("A", 10);
+    const { vector, calls } = nativeVector();
+    const result = await runReorder(deps([vector], { sdefProbe: () => false }), {
+      scope: "today",
+      uuids: [a],
+      strategy: "native",
+    });
+    expect(result.kind).toBe("blocked");
+    if (result.kind === "blocked") {
+      expect(result.reason).toBe("environment");
+      expect(result.detail).toContain("sdef");
+    }
+    expect(calls).toHaveLength(0);
+  });
+
+  it("H-REORDER-SCOPE rejects evening-bucket members in a today reorder (O03)", async () => {
+    const a = seedToday("A", 10);
+    const ev = seedToday("EV", 20, { evening: true });
+    const { vector, calls } = nativeVector();
+    const result = await runReorder(deps([vector]), { scope: "today", uuids: [ev, a] });
+    expect(result.kind).toBe("blocked");
+    if (result.kind === "blocked") {
+      expect(result.hazard).toBe("H-REORDER-SCOPE");
+      expect(result.detail).toContain("de-evening");
+    }
+    expect(calls).toHaveLength(0);
+  });
+
+  it("H-REORDER-SCOPE rejects headed children in a project reorder (O06)", async () => {
+    const proj = seedProject(fixture.db, { title: "P" });
+    const heading = seedHeading(fixture.db, { title: "H", project: proj });
+    const flat = seedTodo(fixture.db, { title: "flat", project: proj, index: 1 });
+    const headed = seedTodo(fixture.db, { title: "headed", heading, index: 1 });
+    const { vector } = nativeVector(`"index"`);
+    const result = await runReorder(deps([vector]), {
+      scope: "project",
+      container: { uuid: proj },
+      uuids: [headed, flat],
+    });
+    expect(result.kind).toBe("blocked");
+    if (result.kind === "blocked") {
+      expect(result.hazard).toBe("H-REORDER-SCOPE");
+      expect(result.detail).toContain("heading");
+    }
+  });
+
+  it("explicit native strategy on the evening scope is refused (O03)", async () => {
+    const ev = seedToday("EV", 10, { evening: true });
+    const { vector, calls } = nativeVector();
+    const result = await runReorder(deps([vector]), {
+      scope: "evening",
+      uuids: [ev],
+      strategy: "native",
+    });
+    expect(result.kind).toBe("blocked");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("verify-failed mismatch when the app applies a contradicting order", async () => {
+    const a = seedToday("A", 10);
+    const b = seedToday("B", 20);
+    const wrongOrder: WriteVector = {
+      id: "applescript",
+      matrix: {
+        reorder: { support: "partial", disruption: 0, validation: "validated", experimental: true },
+      },
+      async execute() {
+        // Apply the OPPOSITE of the request: b before a.
+        fixture.db
+          .prepare("UPDATE TMTask SET todayIndex = 1, userModificationDate = ? WHERE uuid = ?")
+          .run(modClock++, a);
+        fixture.db
+          .prepare("UPDATE TMTask SET todayIndex = 0, userModificationDate = ? WHERE uuid = ?")
+          .run(modClock++, b);
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+    };
+    const result = await runReorder(
+      deps([wrongOrder]),
+      { scope: "today", uuids: [a, b], strategy: "native" },
+      { verifyTimeoutMs: 300 },
+    );
+    // a's rank moved away from its pre-state without satisfying the sequence.
+    expect(result.kind).toBe("verify-failed");
+    if (result.kind === "verify-failed") expect(result.reason).toBe("mismatch");
+  });
+});
+
+describe("bounce reorder (verified when= round-trips)", () => {
+  it("evening scope defaults to bounce and places items front-first", async () => {
+    const e1 = seedToday("E1", 10, { evening: true });
+    const e2 = seedToday("E2", 20, { evening: true });
+    seedToday("T1", 5); // today-proper neighbor, untouched
+    const { vector, calls } = bounceVector();
+    const result = await runReorder(deps([vector]), { scope: "evening", uuids: [e2, e1] });
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") expect(result.vector).toBe("url-scheme");
+    // Two legs per item, reverse order: e1 bounced first, then e2.
+    expect(calls).toHaveLength(4);
+    expect(calls[0]).toContain(`id=${e1}`);
+    expect(calls[0]).toContain("when=today");
+    expect(calls[1]).toContain(`id=${e1}`);
+    expect(calls[1]).toContain("when=evening");
+    expect(calls[2]).toContain(`id=${e2}`);
+    const [r2, r1] = ranks([e2, e1]);
+    expect(r2).toBeLessThan(r1 as number);
+    // Summary audit record for the whole reorder, plus one per leg.
+    const summary = auditRecords.filter((r) => r.op === "reorder");
+    expect(summary).toHaveLength(1);
+    expect(summary[0]?.result).toBe("ok");
+    expect(auditRecords.filter((r) => r.op === "todo.update")).toHaveLength(4);
+  });
+
+  it("today scope falls back to bounce when experimental is off", async () => {
+    const a = seedToday("A", 10);
+    const b = seedToday("B", 20);
+    const { vector, calls } = bounceVector();
+    const result = await runReorder(deps([vector], { config: config(false) }), {
+      scope: "today",
+      uuids: [b, a],
+    });
+    expect(result.kind).toBe("ok");
+    expect(calls).toHaveLength(4);
+    expect(calls[0]).toContain("when=evening"); // leg 1 bounces AWAY from today
+    const [rb, ra] = ranks([b, a]);
+    expect(rb).toBeLessThan(ra as number);
+  });
+
+  it("aborts cleanly with partial progress when an item vanishes mid-run", async () => {
+    const e1 = seedToday("E1", 10, { evening: true });
+    const e2 = seedToday("E2", 20, { evening: true });
+    // Simulate a concurrent user edit: while e2 (bounced FIRST — reverse
+    // order) completes its round trip, e1 gets completed in the app.
+    const { vector } = bounceVector({
+      afterLeg: (payload, db) => {
+        if (payload.includes(`id=${e2}`) && payload.includes("when=evening")) {
+          db.prepare("UPDATE TMTask SET status = 3, userModificationDate = ? WHERE uuid = ?").run(
+            modClock++,
+            e1,
+          );
+        }
+      },
+    });
+    const result = await runReorder(deps([vector]), { scope: "evening", uuids: [e1, e2] });
+    expect(result.kind).toBe("bounce-aborted");
+    if (result.kind === "bounce-aborted") {
+      expect(result.placed).toEqual([e2]);
+      expect(result.remaining).toEqual([e1]);
+      expect(result.detail).toContain("no longer open");
+      expect(result.cause).toBeNull();
+    }
+    const summary = auditRecords.filter((r) => r.op === "reorder");
+    expect(summary[0]?.result).toBe("verify-failed:mismatch");
+  });
+
+  it("reports a stranded item when leg 2 fails", async () => {
+    const e1 = seedToday("E1", 10, { evening: true });
+    let legs = 0;
+    const failing: WriteVector = {
+      id: "url-scheme",
+      matrix: { "todo.update": { support: "yes", disruption: 0, validation: "validated" } },
+      async execute(invocation) {
+        legs += 1;
+        if (legs === 2) return { exitCode: 1, stdout: "", stderr: "boom" };
+        const url = new URL(invocation.payload);
+        fixture.db
+          .prepare(
+            "UPDATE TMTask SET startBucket = 0, todayIndex = -1, userModificationDate = ? WHERE uuid = ?",
+          )
+          .run(modClock++, url.searchParams.get("id") ?? "");
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+    };
+    const result = await runReorder(deps([failing]), { scope: "evening", uuids: [e1] });
+    expect(result.kind).toBe("bounce-aborted");
+    if (result.kind === "bounce-aborted") {
+      expect(result.detail).toContain("STRANDED");
+      expect(result.cause?.kind).toBe("verify-failed");
+    }
+  });
+
+  it("caps the item count", async () => {
+    const uuids = Array.from({ length: BOUNCE_MAX_ITEMS + 1 }, (_, i) =>
+      seedToday(`E${i}`, i + 1, { evening: true }),
+    );
+    const { vector, calls } = bounceVector();
+    const result = await runReorder(deps([vector]), { scope: "evening", uuids });
+    expect(result.kind).toBe("blocked");
+    if (result.kind === "blocked") expect(result.detail).toContain("cap");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("refuses project/area scopes", async () => {
+    const proj = seedProject(fixture.db, { title: "P" });
+    const one = seedTodo(fixture.db, { title: "one", project: proj, index: 1 });
+    const { vector } = bounceVector();
+    const result = await runReorder(deps([vector]), {
+      scope: "project",
+      container: { uuid: proj },
+      uuids: [one],
+      strategy: "bounce",
+    });
+    expect(result.kind).toBe("blocked");
+    if (result.kind === "blocked") expect(result.detail).toContain("when= round-trip");
+  });
+
+  it("dry-run describes the legs without executing", async () => {
+    const e1 = seedToday("E1", 10, { evening: true });
+    const { vector, calls } = bounceVector();
+    const result = await runReorder(
+      deps([vector]),
+      { scope: "evening", uuids: [e1] },
+      {
+        dryRun: true,
+      },
+    );
+    expect(result.kind).toBe("dry-run");
+    if (result.kind === "dry-run") {
+      expect(result.plan.invocation).toContain("bounce ×1");
+      expect(result.plan.expectedDelta).toMatchObject({ mode: "ordering", key: "todayIndex" });
+    }
+    expect(calls).toHaveLength(0);
+    expect(auditRecords).toHaveLength(0);
+  });
+});
+
+describe("computeReorderPre wire lists", () => {
+  it("keeps unrequested members' current order after the requested block", () => {
+    const a = seedToday("A", 30);
+    const b = seedToday("B", 10);
+    const c = seedToday("C", 20);
+    const pre = computeReorderPre(fixture.db, { scope: "today", uuids: [a] }, null, NOW);
+    // Current order by todayIndex is b(10), c(20), a(30) → wire = a, b, c.
+    expect(pre.wireList).toEqual([a, b, c]);
+    expect(pre.key).toBe("todayIndex");
+    expect(pre.rejected).toEqual([]);
+  });
+
+  it("includes scheduled projects as today members (O12)", () => {
+    const p = seedProject(fixture.db, {
+      title: "ProjToday",
+      start: "active",
+      startDate: TODAY_ISO,
+      todayIndex: 5,
+    });
+    const t = seedToday("T", 10);
+    const pre = computeReorderPre(fixture.db, { scope: "today", uuids: [p, t] }, null, NOW);
+    expect(pre.rejected).toEqual([]);
+    expect(pre.projectMembers).toEqual([p]);
+    expect(pre.wireList).toEqual([p, t]);
+  });
+
+  it("flags duplicates and strangers", () => {
+    const a = seedToday("A", 10);
+    const pre = computeReorderPre(fixture.db, { scope: "today", uuids: [a, a, "nope"] }, null, NOW);
+    expect(pre.duplicates).toEqual([a]);
+    expect(pre.rejected.map((r) => r.uuid)).toEqual(["nope"]);
+  });
+});

--- a/test/unit/write-guards.test.ts
+++ b/test/unit/write-guards.test.ts
@@ -24,7 +24,7 @@ function check<K extends OperationKind>(
   acks: Acknowledgements = {},
 ): GuardBlock | null {
   const spec = COMMANDS[op];
-  const pre = spec.preRead(fixture.db, params);
+  const pre = spec.preRead(fixture.db, params, new Date());
   return evaluateGuards(spec.hazards, {
     op,
     params: params as Record<string, unknown>,


### PR DESCRIPTION
## Lab evidence (O-suite, 11 probes, double-green with identical verdicts)

- **O01/O12** — private `_private_experimental_ reorder to dos in` works on Today with partial ids lists; unlisted members untouched; scheduled PROJECT rows are accepted in the ids list (`project` inherits from `to do`).
- **O03 (destructive)** — an evening-bucket member listed in a Today reorder gets its `startBucket` silently CLEARED → evening scope is bounce-only, today scope rejects bucket-1 uuids.
- **O04/O05/O09/O10** — project + area scopes reorder natively; `project id "<uuid>"` / `area id "<uuid>"` specifiers validated (production form).
- **O06 (destructive)** — listing heading-contained children RIPS them out of their heading → guard rejects headed uuids; heading-scoped ordering stays unautomatable.
- **O11** — the production wire-list shape (full un-headed list in a MIXED project) leaves heading rows and headed children untouched.
- **O07/O08** — `when=` round-trip bounce front-inserts in Today and Evening; neighbors untouched.

Results doc: `docs/lab/o-suite-results.md`.

## write.reorder

- **Native strategy** rides the standard pipeline (drift gate → H-REORDER-SCOPE guard → planner → **sdef canary** → execute → ordering verification with pre-rank tripwires). Double-gated: `things config set allow-experimental true` AND the app's sdef must still declare the private command on every dispatch (`things doctor` reports both).
- **Bounce strategy** (today fallback, evening only path): reverse-order verified `todo.update` when= round-trips; membership re-checked between items; placed-prefix order re-verified after each item; ≤10 items; clean abort with placed/remaining + stranded-item detail on any failure.
- Partial uuid requests are extended to the full member wire list from the live pre-read → deterministic placement (requested block on top, everything else keeps its order).
- New `ordering` DeltaSpec mode (strictly-ascending rank verification), `H-REORDER-SCOPE` hazard, `reorder` operation kind, CLI `things reorder`, capabilities/doctor/config integration.

## Verification

- `npm test`: 137 passing (19 new: native/bounce engine tests, wire-list units, help contract).
- **E2E in VM clone: 32/32 green** — includes the experimental gate (exit 6 pre-opt-in), native today reorder, O03 guard rejection (exit 4), real evening bounce round-trips, native project reorder via uuid specifier.
- O-suite acceptance ×2 identical (`o-20260704-014924` / `o-20260704-015104`).
- Full `lab:regress` sweep running pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)