### PR TITLE
Phase 9a: reminders + editing-completeness probe campaigns (R + E suites)

### DIFF
--- a/docs/atlas/schema-v26.md
+++ b/docs/atlas/schema-v26.md
@@ -52,7 +52,7 @@ One row per to-do, project, or heading. Cultured Code's own DDL comments record 
 | `start` | `0` Inbox · `1` Anytime/Today · `2` Someday | Coarse placement bucket. |
 | `startDate` | packed int or NULL | The "When" date. **Packing: `y<<16 \| m<<12 \| d<<7`** (verified: `132803712` → 2026-06-25). |
 | `startBucket` | `0` Today · `1` This Evening | Sub-placement within Today. things.py cannot see this; we expose it as `todaySection`. |
-| `reminderTime` | packed int or NULL | Time-of-day for the reminder. Bit layout TBD — samples (557842432, 589299712, …) suggest hour/minute in high bits. **Phase-1 codec TODO.** |
+| `reminderTime` | packed int or NULL | Time-of-day for the reminder. **Packing: `hour<<26 \| minute<<20`** (i.e. `(hour*64 + minute) << 20`; verified against 13 known-time lab samples, R-suite 2026-07-04 — e.g. `1207959552` → 18:00, `434110464` → 06:30, `15728640` → 00:15). Set/cleared via URL `when=<list>@<time>`; a bare `when=today` on update CLEARS it (R07). |
 | `deadline` | packed int or NULL | Hard due date, independent of `startDate`. Same packing. |
 | `deadlineSuppressionDate` | packed int | Suppresses deadline nagging after user dismissal. |
 | `todayIndexReferenceDate` | packed int | The day a `todayIndex` value is relative to (Today re-sorts daily). |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -15,21 +15,22 @@ Living register of Things-app capabilities that are missing, thin, or janky in t
 - What works: safe template edits (title/notes/checklist — U12B/T12), full editing of spawned instances (guards only block templates), reading rule presence + config via the private `json` property (A51).
 - **Path:** none. Document; guard (done); revisit per Things release.
 
-### 3. Reminders (time-of-day) — documented URL feature, never probed, unexposed
-- `when=today@18:00` style reminders exist in the URL docs; `TMTask.reminderTime` codec is an open atlas item.
-- **Path:** probe suite (encoding + set/clear semantics + repeating hazard interaction) → extend `when` vocabulary. Probably the most user-visible gap after headings. Check whether Shortcuts' Edit Items exposes a Reminder property while S-probing.
+### 3. Reminders (time-of-day) — PROBED 2026-07-04 (R-suite, 16 probes locked); implementation pending
+- Codec CLOSED: `reminderTime = hour<<26 | minute<<20`. Set on add/update via `when=<list>@<time>`; bare `when` on update CLEARS the reminder; repeating-template hazard confirmed (crashes, R09 — H-REPEAT-SCHEDULE already blocks).
+- Parser trap (oddity 2d): bare hours 1–11 get 12-hour "next upcoming" treatment — deterministic emitter derived (leading-zero 24h for 0–9, am/pm suffix for 10–11, literal for 12–23). See [docs/lab/r-suite-results.md](lab/r-suite-results.md).
+- **Path:** Phase 9b — extend the `when` vocabulary + verification with the codec.
 
-## Editing-completeness gaps (all cheap: AppleScript setters + one probe suite)
+## Editing-completeness gaps — PROBED 2026-07-04 (E-suite, 10 probes locked); implementation pending
 
-| Gap | Evidence/path |
+| Gap | Evidence (see [docs/lab/e-suite-results.md](lab/e-suite-results.md)) |
 |---|---|
-| `area.update` — rename; change tags post-creation | `set name of area` unprobed (standard setter); `set tag names of area` already validated (seeding). |
-| `tag.update` — rename, re-parent existing, keyboard shortcut | `set parent tag` validated at creation (A05); rename unprobed. |
-| Notes append/prepend | URL `append-notes`/`prepend-notes` params documented, unprobed; we only replace. |
-| Move to Inbox | `todo.move` covers project/area/heading only; AppleScript `move to list "Inbox"` unprobed. |
-| Duplicate to-do/project | Exists on all three surfaces (URL `duplicate=true`, AppleScript `duplicate`, Shortcuts); never probed. |
+| `area.update` — rename | `set name of area` works (E01). |
+| `tag.update` — rename, re-parent, keyboard shortcut | All three work; assignments survive rename (E02/E03/E10). |
+| Notes append/prepend | URL params work, newline separator (E04/E05). |
+| Move to Inbox | AppleScript `move to list "Inbox"` de-schedules cleanly (E06). |
+| Duplicate to-do | URL `duplicate=true` works (E07); AppleScript duplicate REFUSED by the app (E08) — URL is the only path. |
 | `log completed now` | Probed (A28), trivial to expose. |
-| Project scheduling evidence | `project update --when` compiles but only `completed=true` was specifically probed (U08) — firm up with one probe. |
+| Project scheduling evidence | `update-project?when=<date>` firm (E09). |
 
 ## Ordering (LANDED — Phase 8, `things reorder` / `write.reorder`)
 

--- a/docs/lab/e-suite-results.md
+++ b/docs/lab/e-suite-results.md
@@ -1,0 +1,24 @@
+# E-suite results — editing-completeness campaign
+
+Suite: [lab/suites/e-suite.json](../../lab/suites/e-suite.json) (10 probes, E01–E10). Locked 2026-07-04 after discovery (one adjustment: E08 → unsupported) + acceptance ×2 identical. All tier 0, app running in background, no crashes. Closes the "cheap editing gaps" batch from [docs/gaps.md](../gaps.md).
+
+| Probe | Finding | Verdict |
+|---|---|---|
+| E01 | `set name of area` renames; old title gone, uuid stable | supported |
+| E02 | `set name of tag` renames; **existing TMTaskTag assignments survive** | supported |
+| E03 | `set parent tag of tag` re-parents an existing root tag (creation-time parenting was A05) | supported |
+| E04 | URL `append-notes` appends with a **newline separator** (`BASE` + `TAIL` → `BASE\nTAIL`) | supported |
+| E05 | URL `prepend-notes` prepends, same newline separator (`HEAD\nBASE\nTAIL`) | supported |
+| E06 | AppleScript `move … to list "Inbox"` de-schedules: `start=0`, `startDate` NULL | supported |
+| E07 | **URL `duplicate=true` on update works**: exact copy (same title/notes), fresh uuid + creationDate | supported |
+| E08 | AppleScript `duplicate` is REFUSED: "Selected to dos can not be copied. (-1717)", zero delta — URL is the only duplicate path | unsupported |
+| E09 | `update-project?when=<future date>` schedules a project: `start=2`, `startDate` set (firms up the thin U08 evidence) | supported |
+| E10 | `set keyboard shortcut of tag` works; TMTag.shortcut stores the raw character (`"9"`) | supported |
+
+## Feed into Phase 9b
+
+New/extended operations, all tier 0 on already-validated vectors: `area.update` (rename — AppleScript), `tag.update` (rename/re-parent/shortcut — AppleScript), notes `append`/`prepend` modes on todo.update + project.update (URL), `todo.move` gains the Inbox destination (AppleScript), `todo.duplicate` (URL only), `project.update --when` now fully evidence-backed.
+
+## Not probed (still open)
+
+Sidebar ordering (areas among areas, projects within an area); `duplicate=true` on `update-project`; whether append-notes skips the newline when the existing note is empty (edge for the delta-assertion; verify at implementation time).

--- a/docs/lab/r-suite-results.md
+++ b/docs/lab/r-suite-results.md
@@ -1,0 +1,33 @@
+# R-suite results — reminders campaign
+
+Suite: [lab/suites/r-suite.json](../../lab/suites/r-suite.json) (16 probes, R01–R16). Locked 2026-07-04 after discovery + acceptance ×2 identical (`r-20260704-022520` / `r-20260704-022655`). All tier 0 except the quarantined crash probe. Every probe locks the EXACT stored `reminderTime` int, so any parser or codec change in a future Things build fails the suite loudly.
+
+## The codec (atlas item CLOSED)
+
+`TMTask.reminderTime = hour << 26 | minute << 20` — equivalently `(hour*64 + minute) << 20`. Verified against 13 known-time samples (e.g. `1207959552` → 18:00, `434110464` → 06:30, `15728640` → 00:15, `1425014784` → 21:15). Recorded in [docs/atlas/schema-v26.md](../atlas/schema-v26.md).
+
+## The time-parser rules (the surprise finding)
+
+`when=<list>@<time>` parses the time in three distinct lexical classes:
+
+| Input class | Behavior | Evidence |
+|---|---|---|
+| Leading-zero hour (`06:30`, `06:45`, `00:15`) | 24-hour LITERAL, stored exactly | R02, R03, R10 |
+| Hour ≥ 12 (`12:30`, `14:10`, `18:00`, `21:15`, `22:30`) | unambiguous, stored exactly | R01, R04, R11, R15, R16 |
+| **Bare hour 1–11** (`10:05`, `6:45`) | 12-hour + **"next upcoming occurrence"** vs. the current clock — at pinned noon both became PM (22:05, 18:45) | R06, R12, R13 |
+| Explicit suffix (`6pm`, `10:05am`) | honored deterministically | R05, R14 |
+
+Consequence: **10:xx / 11:xx AM are inexpressible without the `am` suffix** (no leading-zero spelling exists). Same on add and update. Filed as oddity 2d in [docs/things-app-oddities.md](../things-app-oddities.md).
+
+**Deterministic emitter for the write layer** (every branch evidence-backed): hour 0–9 → `0H:mm` (R02/R03); hour 10–11 → `H:mmam`/`H:mmpm` (R14/R05); hour 12–23 → `H:mm` (R16/R01/R11/R15).
+
+## Semantics
+
+- Reminder requires a scheduled `when` — set on add (`when=today@18:00`, R01) and on update (R06); `when=evening@21:15` works and lands in the evening bucket (R04).
+- **Clear**: a bare `when=today` on update NULLs `reminderTime` (R07) — so every schedule-preserving update must re-send the reminder or it's silently dropped; conversely this IS the clear operation.
+- The private `json` AppleScript property exposes the reminder on read (R08).
+- **HAZARD (R09)**: `when=today@18:00` on a repeating template crashes Things exactly like the bare `when=` (U12 family, EXC_BREAKPOINT). H-REPEAT-SCHEDULE already blocks this path in the write layer; oddity 1 updated.
+
+## Feed into Phase 9b
+
+Extend the `when` vocabulary with `{ when: "today", reminder: "18:00" }` (or `when: "today@18:00"` sugar), compile via the deterministic emitter, verify `reminderTime` with the codec; `reminder: null` compiles to the bare-when clear.

--- a/docs/things-app-oddities.md
+++ b/docs/things-app-oddities.md
@@ -24,7 +24,7 @@ Everything surprising, inconsistent, or hazardous we found while systematically 
 
 **Also affected:** non-scheduling updates on the same repeating item work fine (`title`, checklist items), so the crash is specific to schedule-class fields via URL.
 
-**Evidence:** first isolated 2026-03-12 on the MAS build (validation notes T12, reproducible across repeat configs); re-reproduced deterministically 2026-07-03 in clean-room VMs on the trial build — probe `U12` (crash detector: process death + `.ips` capture + row-unchanged assertion, green in every acceptance run), guard contrast probe `A21`. Repo refs: `docs/research/validation-notes-step3.md` (T12), `docs/lab/u-suite-results.md`, `docs/lab/a-suite-results.md`, `lab/suites/u-suite.json` (U12), `lab/suites/a-suite.json` (A21).
+**Evidence:** first isolated 2026-03-12 on the MAS build (validation notes T12, reproducible across repeat configs); re-reproduced deterministically 2026-07-03 in clean-room VMs on the trial build — probe `U12` (crash detector: process death + `.ips` capture + row-unchanged assertion, green in every acceptance run), guard contrast probe `A21`. The reminder-flavored form `when=today@18:00` crashes identically (probe `R09`, 2026-07-04) — the whole `when=` family is affected. Repo refs: `docs/research/validation-notes-step3.md` (T12), `docs/lab/u-suite-results.md`, `docs/lab/a-suite-results.md`, `lab/suites/u-suite.json` (U12), `lab/suites/a-suite.json` (A21), `lab/suites/r-suite.json` (R09).
 
 ---
 
@@ -42,6 +42,10 @@ Commands that fail *silently* — the caller gets no signal that nothing (or onl
 On `add`, a `heading=` value that doesn't match an existing heading in the target project is dropped: the to-do is created un-headed. Heading placement works only against pre-existing headings (and matching is by name, so duplicate heading names are ambiguous). *(T09/U09)*
 
 ---
+
+### 2d. Reminder times with bare hours 1–11 are silently reinterpreted
+
+`when=today@10:05` does not set a 10:05 AM reminder — it sets **22:05**. The parser treats an hour of 1–11 *without* an am/pm suffix as a 12-hour time and resolves it to the next upcoming occurrence relative to the current clock (at a noon wall-clock, `10:05` → 22:05 and `6:45` → 18:45, both verified). Meanwhile a **leading-zero** hour is taken as a 24-hour literal (`06:45` → 06:45 exactly), hours ≥ 12 are literal (`14:10`, `22:30`), and explicit suffixes are honored (`10:05am` → 10:05, `6pm` → 18:00). Because `10` and `11` have no leading-zero spelling, **10:xx/11:xx AM cannot be expressed without the `am` suffix** — a caller composing "HH:mm" strings gets a silently different reminder for two hours of the day. Same behavior on `add` and `update`. Evidence: probes R01–R16 (13 known-time samples), 2026-07-04.
 
 ## 3. UI vs. URL behavioral divergence: project completion
 

--- a/lab/scripts/regress.sh
+++ b/lab/scripts/regress.sh
@@ -26,7 +26,7 @@ if margin < 2:
 print(f"[regress] trial window ok: pinned {meta['pinnedDate']}, expiry {expiry:%Y-%m-%d} ({margin} days margin)")
 EOF
 
-for suite in u a x o; do
+for suite in u a x o r e; do
   echo "[regress] === suite: $suite ==="
   npm run lab:run -- --suite "lab/suites/$suite-suite.json"
 done

--- a/lab/suites/e-suite.json
+++ b/lab/suites/e-suite.json
@@ -1,0 +1,393 @@
+{
+  "suite": "e",
+  "description": "Editing-completeness campaign: the cheap gaps from docs/gaps.md — area/tag rename, tag re-parent + keyboard shortcut, URL append-/prepend-notes, move-to-inbox, duplicate (URL + AppleScript), project scheduling firm-up. All fresh entities are created in setup so seed records other probes rely on stay pristine.",
+  "probes": [
+    {
+      "id": "E01",
+      "title": "area rename via `set name of area` — standard setter, previously unprobed",
+      "vector": "applescript",
+      "operation": "area.rename",
+      "appState": "running-background",
+      "setup": [
+        {
+          "osascript": "tell application \"Things3\" to make new area with properties {name:\"E-AREA-RN\"}"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMArea WHERE title='E-AREA-RN'"
+        }
+      ],
+      "commands": [
+        {
+          "osascript": "tell application \"Things3\" to set name of area \"E-AREA-RN\" to \"E-AREA-RN2\""
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMArea WHERE title='E-AREA-RN2'"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "rowExists",
+            "table": "TMArea",
+            "where": {
+              "title": "E-AREA-RN2"
+            }
+          },
+          {
+            "kind": "rowAbsent",
+            "table": "TMArea",
+            "where": {
+              "title": "E-AREA-RN"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "E02",
+      "title": "tag rename via `set name of tag` — do existing assignments survive the rename?",
+      "vector": "applescript",
+      "operation": "tag.rename",
+      "appState": "running-background",
+      "setup": [
+        {
+          "osascript": "tell application \"Things3\" to make new tag with properties {name:\"E-TAG-RN\"}"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTag WHERE title='E-TAG-RN'"
+        },
+        {
+          "osascript": "tell application \"Things3\" to set tag names of to do id \"{seed:LAB-INBOX-1}\" to \"E-TAG-RN\""
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTaskTag tt JOIN TMTag t ON tt.tags=t.uuid WHERE t.title='E-TAG-RN' AND tt.tasks='{seed:LAB-INBOX-1}'"
+        }
+      ],
+      "commands": [
+        {
+          "osascript": "tell application \"Things3\" to set name of tag \"E-TAG-RN\" to \"E-TAG-RN2\""
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTaskTag tt JOIN TMTag t ON tt.tags=t.uuid WHERE t.title='E-TAG-RN2' AND tt.tasks='{seed:LAB-INBOX-1}'"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "rowExists",
+            "table": "TMTag",
+            "where": {
+              "title": "E-TAG-RN2"
+            }
+          },
+          {
+            "kind": "rowAbsent",
+            "table": "TMTag",
+            "where": {
+              "title": "E-TAG-RN"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "E03",
+      "title": "re-parent an EXISTING root tag via `set parent tag` (only creation-time parenting was validated, A05)",
+      "vector": "applescript",
+      "operation": "tag.reparent",
+      "appState": "running-background",
+      "setup": [
+        {
+          "osascript": "tell application \"Things3\" to make new tag with properties {name:\"E-TAG-P\"}"
+        },
+        {
+          "osascript": "tell application \"Things3\" to make new tag with properties {name:\"E-TAG-C\"}"
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTag WHERE title='E-TAG-C' AND parent IS NULL"
+        }
+      ],
+      "commands": [
+        {
+          "osascript": "tell application \"Things3\" to set parent tag of tag \"E-TAG-C\" to tag \"E-TAG-P\""
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTag c JOIN TMTag p ON c.parent=p.uuid WHERE c.title='E-TAG-C' AND p.title='E-TAG-P'"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "rowExists",
+            "table": "TMTag",
+            "where": {
+              "title": "E-TAG-C"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "E04",
+      "title": "URL append-notes — documented param, unprobed; separator behavior is the finding",
+      "vector": "url",
+      "operation": "notes.append",
+      "appState": "running-background",
+      "setup": [
+        {
+          "openUrl": "things:///add?title=E-NOTES&notes=BASE"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='E-NOTES' AND notes='BASE'"
+        }
+      ],
+      "commands": [
+        {
+          "openUrl": "things:///update?id={uuid:E-NOTES}&auth-token={ctx:token}&append-notes=TAIL"
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTask WHERE title='E-NOTES' AND notes LIKE 'BASE%TAIL'"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "title": "E-NOTES"
+            },
+            "fields": ["title", "status", "start"]
+          }
+        ]
+      }
+    },
+    {
+      "id": "E05",
+      "title": "URL prepend-notes on the same item",
+      "vector": "url",
+      "operation": "notes.prepend",
+      "appState": "running-background",
+      "commands": [
+        {
+          "openUrl": "things:///update?id={uuid:E-NOTES}&auth-token={ctx:token}&prepend-notes=HEAD"
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTask WHERE title='E-NOTES' AND notes LIKE 'HEAD%BASE%TAIL'"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "title": "E-NOTES"
+            },
+            "fields": ["title", "status", "start"]
+          }
+        ]
+      }
+    },
+    {
+      "id": "E06",
+      "title": "move a scheduled to-do back to the Inbox via AppleScript `move ... to list \"Inbox\"`",
+      "vector": "applescript",
+      "operation": "todo.move-inbox",
+      "appState": "running-background",
+      "setup": [
+        {
+          "openUrl": "things:///add?title=E-INBOXMV&when=today"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='E-INBOXMV' AND start=1"
+        }
+      ],
+      "commands": [
+        {
+          "osascript": "tell application \"Things3\" to move to do id \"{uuid:E-INBOXMV}\" to list \"Inbox\""
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTask WHERE title='E-INBOXMV' AND start=0"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "E-INBOXMV"
+            },
+            "field": "start",
+            "value": 0
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "E-INBOXMV"
+            },
+            "field": "startDate",
+            "value": null
+          }
+        ]
+      }
+    },
+    {
+      "id": "E07",
+      "title": "URL duplicate=true on update — does the documented-ish duplicate param exist?",
+      "vector": "url",
+      "operation": "todo.duplicate-url",
+      "appState": "running-background",
+      "setup": [
+        {
+          "openUrl": "things:///add?title=E-DUP&notes=DUPBODY"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='E-DUP'"
+        }
+      ],
+      "commands": [
+        {
+          "openUrl": "things:///update?id={uuid:E-DUP}&auth-token={ctx:token}&duplicate=true"
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTask GROUP BY title HAVING title='E-DUP' AND COUNT(*)=2"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "rowCount",
+            "table": "TMTask",
+            "where": {
+              "title": "E-DUP"
+            },
+            "count": 2
+          }
+        ]
+      }
+    },
+    {
+      "id": "E08",
+      "title": "AppleScript `duplicate to do` is REFUSED by the app: 'Selected to dos can not be copied. (-1717)' — the URL duplicate=true param (E07) is the only automation path",
+      "vector": "applescript",
+      "operation": "todo.duplicate-applescript",
+      "appState": "running-background",
+      "setup": [
+        {
+          "openUrl": "things:///add?title=E-DUP2&notes=DUP2BODY"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='E-DUP2'"
+        }
+      ],
+      "commands": [
+        {
+          "osascript": "tell application \"Things3\" to duplicate to do id \"{uuid:E-DUP2}\""
+        },
+        {
+          "sleep": 2
+        }
+      ],
+      "expect": {
+        "verdict": "unsupported",
+        "tier": 0,
+        "allowNonzeroExit": true,
+        "assertions": [
+          {
+            "kind": "rowCount",
+            "table": "TMTask",
+            "where": {
+              "title": "E-DUP2"
+            },
+            "count": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "E09",
+      "title": "project scheduling firm-up: update-project when=<future date> (only completed=true was probed on projects, U08)",
+      "vector": "url",
+      "operation": "project.schedule",
+      "appState": "running-background",
+      "setup": [
+        {
+          "openUrl": "things:///add-project?title=E-PROJ-WHEN"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='E-PROJ-WHEN' AND type=1"
+        }
+      ],
+      "commands": [
+        {
+          "openUrl": "things:///update-project?id={uuid:E-PROJ-WHEN}&auth-token={ctx:token}&when=2026-07-08"
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTask WHERE title='E-PROJ-WHEN' AND start=2 AND startDate IS NOT NULL"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "E-PROJ-WHEN"
+            },
+            "field": "start",
+            "value": 2
+          }
+        ]
+      }
+    },
+    {
+      "id": "E10",
+      "title": "tag keyboard shortcut setter — does the sdef expose `keyboard shortcut` for tags? (pure discovery)",
+      "vector": "applescript",
+      "operation": "tag.shortcut",
+      "appState": "running-background",
+      "commands": [
+        {
+          "osascript": "tell application \"Things3\" to set keyboard shortcut of tag \"E-TAG-P\" to \"9\""
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTag WHERE title='E-TAG-P' AND shortcut IS NOT NULL"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldEquals",
+            "table": "TMTag",
+            "where": {
+              "title": "E-TAG-P"
+            },
+            "field": "shortcut",
+            "value": "9"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/lab/suites/r-suite.json
+++ b/lab/suites/r-suite.json
@@ -1,0 +1,631 @@
+{
+  "suite": "r",
+  "description": "Reminders campaign: the documented-but-unprobed URL `when=<list>@<time>` reminder syntax. Goals: (1) which forms parse (24h, leading zero, 12h suffix, evening combo), (2) set/clear semantics on update, (3) raw TMTask.reminderTime samples at known times to derive the packed codec (atlas open item), (4) private-json cross-check, (5) the repeating-template hazard (schedule-adjacent URL writes crash Things — quarantined last).",
+  "probes": [
+    {
+      "id": "R01",
+      "title": "add with when=today@18:00 — reminder set at a known time (codec sample 18:00)",
+      "vector": "url",
+      "operation": "reminder.add-today-1800",
+      "appState": "running-background",
+      "commands": [
+        {
+          "openUrl": "things:///add?title=R-T1800&when=today@18:00"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='R-T1800' AND reminderTime=1207959552 AND startBucket=0 AND startDate IS NOT NULL"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "inserted",
+            "table": "TMTask",
+            "where": {
+              "title": "R-T1800"
+            }
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-T1800"
+            },
+            "field": "start",
+            "value": 1
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-T1800"
+            },
+            "field": "reminderTime",
+            "value": 1207959552
+          }
+        ]
+      }
+    },
+    {
+      "id": "R02",
+      "title": "add with when=today@06:30 — leading-zero hour + half-hour minutes (codec sample 06:30)",
+      "vector": "url",
+      "operation": "reminder.add-today-0630",
+      "appState": "running-background",
+      "commands": [
+        {
+          "openUrl": "things:///add?title=R-T0630&when=today@06:30"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='R-T0630' AND reminderTime=434110464"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "inserted",
+            "table": "TMTask",
+            "where": {
+              "title": "R-T0630"
+            }
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-T0630"
+            },
+            "field": "reminderTime",
+            "value": 434110464
+          }
+        ]
+      }
+    },
+    {
+      "id": "R03",
+      "title": "add with when=today@00:15 — midnight-hour edge (codec sample 00:15)",
+      "vector": "url",
+      "operation": "reminder.add-today-0015",
+      "appState": "running-background",
+      "commands": [
+        {
+          "openUrl": "things:///add?title=R-T0015&when=today@00:15"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='R-T0015' AND reminderTime=15728640"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "inserted",
+            "table": "TMTask",
+            "where": {
+              "title": "R-T0015"
+            }
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-T0015"
+            },
+            "field": "reminderTime",
+            "value": 15728640
+          }
+        ]
+      }
+    },
+    {
+      "id": "R04",
+      "title": "add with when=evening@21:15 — does the evening keyword accept a reminder time? (codec sample 21:15)",
+      "vector": "url",
+      "operation": "reminder.add-evening-2115",
+      "appState": "running-background",
+      "commands": [
+        {
+          "openUrl": "things:///add?title=R-E2115&when=evening@21:15"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='R-E2115' AND reminderTime=1425014784 AND startBucket=1"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "inserted",
+            "table": "TMTask",
+            "where": {
+              "title": "R-E2115"
+            }
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-E2115"
+            },
+            "field": "startBucket",
+            "value": 1
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-E2115"
+            },
+            "field": "reminderTime",
+            "value": 1425014784
+          }
+        ]
+      }
+    },
+    {
+      "id": "R05",
+      "title": "add with 12-hour form when=today@6pm — documented tolerance? Should equal the 18:00 sample if parsed",
+      "vector": "url",
+      "operation": "reminder.add-today-6pm",
+      "appState": "running-background",
+      "commands": [
+        {
+          "openUrl": "things:///add?title=R-T6PM&when=today@6pm"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='R-T6PM' AND reminderTime=1207959552 AND reminderTime=(SELECT reminderTime FROM TMTask WHERE title='R-T1800')"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "inserted",
+            "table": "TMTask",
+            "where": {
+              "title": "R-T6PM"
+            }
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-T6PM"
+            },
+            "field": "reminderTime",
+            "value": 1207959552
+          }
+        ]
+      }
+    },
+    {
+      "id": "R06",
+      "title": "update an existing scheduled to-do with when=today@10:05 — reminder SET on update; other fields untouched (codec sample 10:05)",
+      "vector": "url",
+      "operation": "reminder.update-set",
+      "appState": "running-background",
+      "setup": [
+        {
+          "openUrl": "things:///add?title=R-UPD&when=today"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='R-UPD' AND reminderTime IS NULL"
+        }
+      ],
+      "commands": [
+        {
+          "openUrl": "things:///update?id={uuid:R-UPD}&auth-token={ctx:token}&when=today@10:05"
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTask WHERE title='R-UPD' AND reminderTime=1481637888"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-UPD"
+            },
+            "field": "startBucket",
+            "value": 0
+          },
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "title": "R-UPD"
+            },
+            "fields": ["title", "status", "notes"]
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-UPD"
+            },
+            "field": "reminderTime",
+            "value": 1481637888
+          }
+        ]
+      }
+    },
+    {
+      "id": "R07",
+      "title": "update the same to-do with a bare when=today — does the reminder CLEAR, or persist? (clear-semantics finding)",
+      "vector": "url",
+      "operation": "reminder.update-clear",
+      "appState": "running-background",
+      "commands": [
+        {
+          "openUrl": "things:///update?id={uuid:R-UPD}&auth-token={ctx:token}&when=today"
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTask WHERE title='R-UPD' AND reminderTime IS NULL"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-UPD"
+            },
+            "field": "reminderTime",
+            "value": null
+          }
+        ]
+      }
+    },
+    {
+      "id": "R08",
+      "title": "private json of a reminder-bearing to-do — does the payload expose the reminder time in readable form? (codec cross-check)",
+      "vector": "applescript",
+      "operation": "reminder.private-json-read",
+      "appState": "running-background",
+      "commands": [
+        {
+          "osascript": "tell application \"Things3\" to _private_experimental_ json of to do id \"{uuid:R-T1800}\""
+        }
+      ],
+      "settleSeconds": 1,
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "stdoutMatches",
+            "command": 0,
+            "pattern": "R-T1800"
+          },
+          {
+            "kind": "deltaEmpty"
+          }
+        ]
+      }
+    },
+    {
+      "id": "R10",
+      "title": "FINDING chase: update with a PAST morning time (06:45 at pinned-noon) — R06 stored 22:05 for 10:05, hypothesis: update shifts past times to the upcoming PM counterpart",
+      "vector": "url",
+      "operation": "reminder.update-past-am",
+      "appState": "running-background",
+      "setup": [
+        {
+          "openUrl": "things:///add?title=R-UPD2&when=today"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='R-UPD2'"
+        }
+      ],
+      "commands": [
+        {
+          "openUrl": "things:///update?id={uuid:R-UPD2}&auth-token={ctx:token}&when=today@06:45"
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTask WHERE title='R-UPD2' AND reminderTime=449839104"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "title": "R-UPD2"
+            },
+            "fields": ["title", "status", "startBucket"]
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-UPD2"
+            },
+            "field": "reminderTime",
+            "value": 449839104
+          }
+        ]
+      }
+    },
+    {
+      "id": "R11",
+      "title": "FINDING chase: update with an unambiguous 24h afternoon time (14:10, future at pinned-noon) — expect exact storage",
+      "vector": "url",
+      "operation": "reminder.update-future-24h",
+      "appState": "running-background",
+      "setup": [
+        {
+          "openUrl": "things:///add?title=R-UPD3&when=today"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='R-UPD3'"
+        }
+      ],
+      "commands": [
+        {
+          "openUrl": "things:///update?id={uuid:R-UPD3}&auth-token={ctx:token}&when=today@14:10"
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTask WHERE title='R-UPD3' AND reminderTime=950009856"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "title": "R-UPD3"
+            },
+            "fields": ["title", "status", "startBucket"]
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-UPD3"
+            },
+            "field": "reminderTime",
+            "value": 950009856
+          }
+        ]
+      }
+    },
+    {
+      "id": "R12",
+      "title": "FINDING chase: ADD with the same past time R06 used (10:05) — control for add-vs-update parser asymmetry",
+      "vector": "url",
+      "operation": "reminder.add-past-am-control",
+      "appState": "running-background",
+      "commands": [
+        {
+          "openUrl": "things:///add?title=R-ADD1005&when=today@10:05"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='R-ADD1005' AND reminderTime=1481637888"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "inserted",
+            "table": "TMTask",
+            "where": {
+              "title": "R-ADD1005"
+            }
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-ADD1005"
+            },
+            "field": "reminderTime",
+            "value": 1481637888
+          }
+        ]
+      }
+    },
+    {
+      "id": "R13",
+      "title": "RULE pin: add today@6:45 (no leading zero, past-AM at pinned noon) — 12h heuristic predicts 18:45, 24h literal predicts 06:45",
+      "vector": "url",
+      "operation": "reminder.add-bare-645",
+      "appState": "running-background",
+      "commands": [
+        {
+          "openUrl": "things:///add?title=R-B645&when=today@6:45"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='R-B645' AND reminderTime=1255145472"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "inserted",
+            "table": "TMTask",
+            "where": {
+              "title": "R-B645"
+            }
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-B645"
+            },
+            "field": "reminderTime",
+            "value": 1255145472
+          }
+        ]
+      }
+    },
+    {
+      "id": "R14",
+      "title": "RULE pin: add today@10:05am (explicit am suffix) — the deterministic escape hatch for morning times?",
+      "vector": "url",
+      "operation": "reminder.add-explicit-am",
+      "appState": "running-background",
+      "commands": [
+        {
+          "openUrl": "things:///add?title=R-AM1005&when=today@10:05am"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='R-AM1005' AND reminderTime=676331520"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "inserted",
+            "table": "TMTask",
+            "where": {
+              "title": "R-AM1005"
+            }
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-AM1005"
+            },
+            "field": "reminderTime",
+            "value": 676331520
+          }
+        ]
+      }
+    },
+    {
+      "id": "R15",
+      "title": "RULE pin: add today@22:30 (unambiguous 24h evening literal, future at noon) — control",
+      "vector": "url",
+      "operation": "reminder.add-2230",
+      "appState": "running-background",
+      "commands": [
+        {
+          "openUrl": "things:///add?title=R-T2230&when=today@22:30"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='R-T2230' AND reminderTime=1507852288"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "inserted",
+            "table": "TMTask",
+            "where": {
+              "title": "R-T2230"
+            }
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-T2230"
+            },
+            "field": "reminderTime",
+            "value": 1507852288
+          }
+        ]
+      }
+    },
+    {
+      "id": "R16",
+      "title": "RULE pin: add today@12:30 (noon-hour edge at pinned 12:00) — 12h heuristic vs 24h literal both say 12:30, but a past-shift rule could say 00:30 next day",
+      "vector": "url",
+      "operation": "reminder.add-1230",
+      "appState": "running-background",
+      "commands": [
+        {
+          "openUrl": "things:///add?title=R-T1230&when=today@12:30"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='R-T1230' AND reminderTime=836763648"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "inserted",
+            "table": "TMTask",
+            "where": {
+              "title": "R-T1230"
+            }
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-T1230"
+            },
+            "field": "reminderTime",
+            "value": 836763648
+          }
+        ]
+      }
+    },
+    {
+      "id": "R09",
+      "title": "HAZARD: when=today@18:00 on a REPEATING TEMPLATE — expect the schedule-write crash (same family as U12); template untouched",
+      "vector": "url",
+      "operation": "reminder.update-repeating-template",
+      "appState": "running-background",
+      "group": "hazard",
+      "commands": [
+        {
+          "openUrl": "things:///update?id={seed:LAB-REPEAT-DAILY}&auth-token={ctx:token}&when=today@18:00"
+        },
+        {
+          "waitCrash": true,
+          "timeoutSeconds": 20
+        }
+      ],
+      "settleSeconds": 3,
+      "expect": {
+        "verdict": "crash",
+        "tier": 0,
+        "crash": true,
+        "assertions": [
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "uuid": "@seed:LAB-REPEAT-DAILY"
+            },
+            "fields": ["rt1_recurrenceRule", "start", "startDate", "status", "reminderTime"]
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Probe-only PR — no write-layer code changes (that's Phase 9b, next).

## R-suite: reminders (16 probes, exact-value locks, acceptance ×2 identical)

- **`TMTask.reminderTime` codec CLOSED** (open atlas item): `hour<<26 | minute<<20`, verified against 13 known-time samples. Atlas updated.
- **Time-parser rules pinned** — the surprise: bare hours 1–11 (`10:05`, `6:45`) are parsed as 12-hour and shifted to the *next upcoming occurrence* (at pinned noon: 22:05, 18:45), while leading-zero hours (`06:45`) are 24-hour literals and hours ≥12 are exact. `10:xx`/`11:xx` AM are inexpressible without an explicit `am` suffix → filed as oddity 2d. A deterministic emitter for the write layer is derived and evidence-backed per hour range.
- Set on add + update, `evening@21:15` works, bare `when=today` on update **clears** the reminder, private json exposes it on read.
- R09: `when=today@18:00` on a repeating template crashes Things — same EXC_BREAKPOINT family as U12; bug-report doc extended.
- Every probe locks the exact stored int, so a future Things parser/codec change fails the suite loudly.

## E-suite: editing completeness (10 probes, acceptance ×2 identical)

area rename ✓ · tag rename (assignments survive) ✓ · tag re-parent ✓ · tag keyboard shortcut ✓ · URL append-/prepend-notes (newline separator) ✓ · move-to-Inbox (de-schedules cleanly) ✓ · URL `duplicate=true` (exact copy) ✓ · AppleScript `duplicate` REFUSED by the app (−1717, locked unsupported) · `update-project?when=` firm ✓

## Housekeeping

Both suites added to `lab:regress`; results docs (`docs/lab/{r,e}-suite-results.md`); gaps register updated (reminders + editing batch now "probed, implementation pending").

🤖 Generated with [Claude Code](https://claude.com/claude-code)