### PR TITLE
Phase 9b: reminders, notes modes, duplicate, area/tag updates

### DIFF
--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -15,12 +15,10 @@ Living register of Things-app capabilities that are missing, thin, or janky in t
 - What works: safe template edits (title/notes/checklist — U12B/T12), full editing of spawned instances (guards only block templates), reading rule presence + config via the private `json` property (A51).
 - **Path:** none. Document; guard (done); revisit per Things release.
 
-### 3. Reminders (time-of-day) — PROBED 2026-07-04 (R-suite, 16 probes locked); implementation pending
-- Codec CLOSED: `reminderTime = hour<<26 | minute<<20`. Set on add/update via `when=<list>@<time>`; bare `when` on update CLEARS the reminder; repeating-template hazard confirmed (crashes, R09 — H-REPEAT-SCHEDULE already blocks).
-- Parser trap (oddity 2d): bare hours 1–11 get 12-hour "next upcoming" treatment — deterministic emitter derived (leading-zero 24h for 0–9, am/pm suffix for 10–11, literal for 12–23). See [docs/lab/r-suite-results.md](lab/r-suite-results.md).
-- **Path:** Phase 9b — extend the `when` vocabulary + verification with the codec.
+### 3. Reminders (time-of-day) — SHIPPED 2026-07-04 (Phase 9b)
+- `--reminder HH:mm` on todo add/update (when today|evening only — H-REMINDER-SCOPE), auto-preserve on re-schedule, `--clear-reminder`; codec-verified read-after-write; e2e-validated. Remaining edge: reminders on date-scheduled items (`when=2026-07-08@time`) unprobed — guard rejects.
 
-## Editing-completeness gaps — PROBED 2026-07-04 (E-suite, 10 probes locked); implementation pending
+## Editing-completeness gaps — SHIPPED 2026-07-04 (Phase 9b: area update, tag update, notes append/prepend, move-to-inbox, todo duplicate; `log completed now` still unexposed — DB delta unclear, low value)
 
 | Gap | Evidence (see [docs/lab/e-suite-results.md](lab/e-suite-results.md)) |
 |---|---|
@@ -57,8 +55,8 @@ Fills: **headings in existing projects** (unique), maybe heading-archive + remin
 ## Roadmap (agreed 2026-07-04; tracked as tasks #23–#27)
 
 1. **Phase 8 (DONE 2026-07-04)** — `write.reorder` landed: today/project/area native + evening bounce, experimental gate + sdef canary, H-REORDER-SCOPE guard, e2e-validated in the VM.
-2. **Phase 9a** — R-suite (reminders: `when=today@18:00` set/clear/encoding, repeating-template hazard, reminderTime codec) + E-suite (area/tag rename, tag re-parent, notes append/prepend, move-to-inbox, duplicate, log-completed-now, project-when firm-up, sidebar-ordering discovery). Task #24.
-3. **Phase 9b** — implement the ops the R+E evidence validates (reminder vocabulary, area.update, tag.update, notes modes, inbox move, duplicate, …). Task #25.
+2. **Phase 9a (DONE 2026-07-04)** — R-suite (16 probes) + E-suite (12 probes) locked; reminderTime codec closed; parser trap pinned (oddity 2d).
+3. **Phase 9b (DONE 2026-07-04)** — reminder vocabulary, area.update, tag.update, notes modes, inbox move, todo.duplicate; e2e 43/43.
 4. **Phase 10** — read-layer batch, host-only: tag-filtered reads (incl. inherited), Today ordering fidelity (todayIndexReferenceDate), upcoming repeat occurrences, checklist per-item state. Task #26.
 5. **Phase 11 (blocked on Mike's L5 sitting)** — S-campaign → Shortcuts vector → heading ops in existing projects; plus `project.add` json-payload headings (small win, independent of Shortcuts). Task #27.
 

--- a/lab/guest/e2e-write-smoke.sh
+++ b/lab/guest/e2e-write-smoke.sh
@@ -87,6 +87,20 @@ run_step 0 "seed project child P2" todo add "E2E-RP2" --project "$RPROJ"
 RP2=$(json_get "d['data']['uuid']")
 run_step 0 "native project reorder (uuid specifier)" reorder --scope project --project "$RPROJ" "$RP2" "$RP1"
 
+echo "== phase 9b: reminders, notes modes, duplicate, entity updates =="
+run_step 0 "todo add with reminder (emitter: 10:05 -> 10:05am)" todo add "E2E-REM" --when today --reminder 10:05
+REM=$(json_get "d['data']['uuid']")
+run_step 0 "re-schedule preserves the reminder (auto-preserve)" todo update "$REM" --when evening
+run_step 0 "clear the reminder (bare when=)" todo update "$REM" --when evening --clear-reminder
+run_step 4 "reminder without when today|evening is blocked" todo update "$REM" --when 2026-07-08 --reminder 09:00
+run_step 0 "append-notes (newline separator verified)" todo update "$REM" --append-notes "appended"
+run_step 0 "prepend-notes" todo update "$REM" --prepend-notes "prepended"
+run_step 0 "duplicate (url-only, copy discovered)" todo duplicate "$REM"
+run_step 0 "move back to Inbox (de-schedules)" todo move "$REM" --inbox
+run_step 0 "area update: rename + tags" area update LAB-AREA-B --title "E2E-AREA-RENAMED" --tags lab-tag-1
+run_step 0 "tag add for update tests" tag add e2e-parent
+run_step 0 "tag update: re-parent + shortcut" tag update lab-tag-2 --parent e2e-parent --shortcut 8
+
 echo "== deletes =="
 run_step 0 "todo delete -> trash (applescript)" todo delete "$UUID"
 run_step 0 "area add (applescript)" area add "E2E-AREA"

--- a/lab/suites/e-suite.json
+++ b/lab/suites/e-suite.json
@@ -388,6 +388,82 @@
           }
         ]
       }
+    },
+    {
+      "id": "E11",
+      "title": "append-notes to an EMPTY note — is the newline separator inserted anyway? (exact delta assertions need this pinned)",
+      "vector": "url",
+      "operation": "notes.append-empty",
+      "appState": "running-background",
+      "setup": [
+        {
+          "openUrl": "things:///add?title=E-NOTES2"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='E-NOTES2' AND notes=''"
+        }
+      ],
+      "commands": [
+        {
+          "openUrl": "things:///update?id={uuid:E-NOTES2}&auth-token={ctx:token}&append-notes=SOLO"
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTask WHERE title='E-NOTES2' AND notes LIKE '%SOLO'"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "E-NOTES2"
+            },
+            "field": "notes",
+            "value": "SOLO"
+          }
+        ]
+      }
+    },
+    {
+      "id": "E12",
+      "title": "prepend-notes to an EMPTY note — same separator edge from the other side",
+      "vector": "url",
+      "operation": "notes.prepend-empty",
+      "appState": "running-background",
+      "setup": [
+        {
+          "openUrl": "things:///add?title=E-NOTES3"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='E-NOTES3' AND notes=''"
+        }
+      ],
+      "commands": [
+        {
+          "openUrl": "things:///update?id={uuid:E-NOTES3}&auth-token={ctx:token}&prepend-notes=SOLO2"
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTask WHERE title='E-NOTES3' AND notes LIKE 'SOLO2%'"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "E-NOTES3"
+            },
+            "field": "notes",
+            "value": "SOLO2"
+          }
+        ]
+      }
     }
   ]
 }

--- a/src/cli/commands/writes.ts
+++ b/src/cli/commands/writes.ts
@@ -264,6 +264,10 @@ export function registerWriteCommands(program: Command): void {
       )
       .option("--notes <text>", "notes body")
       .option("--when <value>", "today | evening | anytime | someday | YYYY-MM-DD")
+      .option(
+        "--reminder <HH:mm>",
+        "time-of-day reminder (24h); requires --when today|evening (R-suite scope)",
+      )
       .option("--deadline <date>", "YYYY-MM-DD")
       .option("--tags <list>", "comma-separated EXISTING tag names")
       .option("--checklist-item <text>", "checklist item (repeatable)", collect, [])
@@ -282,6 +286,7 @@ export function registerWriteCommands(program: Command): void {
           title,
           ...(opts["notes"] !== undefined && { notes: opts["notes"] as string }),
           ...(opts["when"] !== undefined && { when: opts["when"] as never }),
+          ...(opts["reminder"] !== undefined && { reminder: opts["reminder"] as string }),
           ...(opts["deadline"] !== undefined && { deadline: opts["deadline"] as string }),
           ...(tags !== undefined && { tags }),
           ...(checklist.length > 0 && { checklistItems: checklist }),
@@ -302,23 +307,50 @@ export function registerWriteCommands(program: Command): void {
     todo
       .command("update <uuid>")
       .description(
-        "Update title/notes/when/deadline (vector: url-scheme, tier 0). " +
+        "Update title/notes/when/reminder/deadline (vector: url-scheme, tier 0). " +
           "Hazard: H-REPEAT-SCHEDULE — when/deadline on a repeating template is hard-blocked " +
-          "(the URL write crashes Things); title/notes stay allowed.",
+          "(the URL write crashes Things); title/notes stay allowed. " +
+          "Reminders (H-REMINDER-SCOPE): --reminder needs --when today|evening; when " +
+          "re-scheduling WITHOUT --reminder an existing reminder is auto-preserved " +
+          "(a bare when= would silently clear it — R07); --clear-reminder clears explicitly. " +
+          "--append-notes/--prepend-notes join with a newline (exclusive with --notes).",
       )
       .option("--title <text>", "new title")
       .option("--notes <text>", "replace notes")
+      .option("--append-notes <text>", "append to existing notes (newline-joined)")
+      .option("--prepend-notes <text>", "prepend to existing notes (newline-joined)")
       .option("--when <value>", "today | evening | anytime | someday | YYYY-MM-DD")
+      .option("--reminder <HH:mm>", "set a reminder (24h); requires --when today|evening")
+      .option("--clear-reminder", "clear the reminder (requires --when today|evening)")
       .option("--deadline <date>", "YYYY-MM-DD")
       .option("--clear-deadline", "remove the deadline"),
   ).action(async (uuid: string, opts: WriteFlagOpts & Record<string, unknown>) => {
+    const notesModes = ["notes", "appendNotes", "prependNotes"].filter(
+      (k) => opts[k] !== undefined,
+    );
+    if (notesModes.length > 1) {
+      process.stderr.write("error: --notes, --append-notes, --prepend-notes are exclusive\n");
+      process.exitCode = ExitCode.Usage;
+      return;
+    }
+    if (opts["reminder"] !== undefined && opts["clearReminder"] === true) {
+      process.stderr.write("error: pass at most one of --reminder / --clear-reminder\n");
+      process.exitCode = ExitCode.Usage;
+      return;
+    }
     await runWrite(opts, (c) =>
       c.write.updateTodo(
         uuid,
         {
           ...(opts["title"] !== undefined && { title: opts["title"] as string }),
           ...(opts["notes"] !== undefined && { notes: opts["notes"] as string }),
+          ...(opts["appendNotes"] !== undefined && { appendNotes: opts["appendNotes"] as string }),
+          ...(opts["prependNotes"] !== undefined && {
+            prependNotes: opts["prependNotes"] as string,
+          }),
           ...(opts["when"] !== undefined && { when: opts["when"] as never }),
+          ...(opts["reminder"] !== undefined && { reminder: opts["reminder"] as string }),
+          ...(opts["clearReminder"] === true && { reminder: null }),
           ...(opts["deadline"] !== undefined && { deadline: opts["deadline"] as string }),
           ...(opts["clearDeadline"] === true && { deadline: null }),
         },
@@ -355,10 +387,17 @@ export function registerWriteCommands(program: Command): void {
       .option("--project <ref>", "destination project (uuid or unique name)")
       .option("--area <ref>", "destination area (uuid or unique name)")
       .option("--heading <name>", "existing heading in the destination project")
+      .option("--inbox", "move back to the Inbox — de-schedules (vector: applescript, E06)")
       .option("--acknowledge-project-reopen", "allow moving into a completed/canceled project"),
   ).action(async (uuid: string, opts: WriteFlagOpts & Record<string, unknown>) => {
     const project = containerRef(opts["project"] as string | undefined);
     const area = containerRef(opts["area"] as string | undefined);
+    const inbox = opts["inbox"] === true;
+    if (inbox && (project !== undefined || area !== undefined || opts["heading"] !== undefined)) {
+      process.stderr.write("error: --inbox is exclusive with --project/--area/--heading\n");
+      process.exitCode = ExitCode.Usage;
+      return;
+    }
     await runWrite(opts, (c) =>
       c.write.moveTodo(
         uuid,
@@ -366,14 +405,28 @@ export function registerWriteCommands(program: Command): void {
           ...(project !== undefined && { project }),
           ...(area !== undefined && { area }),
           ...(opts["heading"] !== undefined && { heading: opts["heading"] as string }),
+          ...(inbox && { inbox: true }),
         },
         writeOptionsFrom(opts, {
+          ...(inbox && { vector: "applescript" as const }),
           ...(opts["acknowledgeProjectReopen"] !== undefined && {
             acknowledgeProjectReopen: opts["acknowledgeProjectReopen"] as boolean,
           }),
         }),
       ),
     );
+  });
+
+  addWriteFlags(
+    todo
+      .command("duplicate <uuid>")
+      .description(
+        "Duplicate a to-do (vector: url-scheme, tier 0; validated E07 — exact copy of " +
+          "title/notes, new uuid discovered by verification). AppleScript refuses duplication " +
+          "(E08). Hazard: H-REPEAT-SCHEDULE — blocked on repeating templates (unvalidated).",
+      ),
+  ).action(async (uuid: string, opts: WriteFlagOpts) => {
+    await runWrite(opts, (c) => c.write.duplicateTodo(uuid, writeOptionsFrom(opts)));
   });
 
   addWriteFlags(
@@ -540,6 +593,34 @@ export function registerWriteCommands(program: Command): void {
   });
   addWriteFlags(
     area
+      .command("update <target>")
+      .description(
+        "Rename an area and/or replace its tags (vector: applescript, tier 0; E01). " +
+          "Target by uuid or unique name. Hazard: H-UNKNOWN-TAG for --tags.",
+      )
+      .option("--title <text>", "new name")
+      .option("--tags <list>", "comma-separated EXISTING tag names (full replacement)"),
+  ).action(async (target: string, opts: WriteFlagOpts & Record<string, unknown>) => {
+    const tags = splitCsv(opts["tags"] as string | undefined);
+    if (opts["title"] === undefined && tags === undefined) {
+      process.stderr.write("error: pass --title and/or --tags\n");
+      process.exitCode = ExitCode.Usage;
+      return;
+    }
+    await runWrite(opts, (c) =>
+      c.write.updateArea(
+        target,
+        {
+          ...(opts["title"] !== undefined && { title: opts["title"] as string }),
+          ...(tags !== undefined && { tags }),
+        },
+        writeOptionsFrom(opts),
+      ),
+    );
+  });
+
+  addWriteFlags(
+    area
       .command("delete <target>")
       .description(
         "Delete an area PERMANENTLY (vector: applescript, tier 0). Areas skip the Trash " +
@@ -576,6 +657,40 @@ export function registerWriteCommands(program: Command): void {
       ),
     );
   });
+  addWriteFlags(
+    tag
+      .command("update <target>")
+      .description(
+        "Rename a tag (assignments survive — E02), nest it under an existing tag (E03), " +
+          "and/or set its keyboard shortcut (E10). Vector: applescript, tier 0. " +
+          "Un-nesting to root and clearing a shortcut are unprobed — not offered.",
+      )
+      .option("--title <text>", "new name")
+      .option("--parent <name>", "existing tag to nest under")
+      .option("--shortcut <char>", "keyboard shortcut character"),
+  ).action(async (target: string, opts: WriteFlagOpts & Record<string, unknown>) => {
+    if (
+      opts["title"] === undefined &&
+      opts["parent"] === undefined &&
+      opts["shortcut"] === undefined
+    ) {
+      process.stderr.write("error: pass --title, --parent, and/or --shortcut\n");
+      process.exitCode = ExitCode.Usage;
+      return;
+    }
+    await runWrite(opts, (c) =>
+      c.write.updateTag(
+        target,
+        {
+          ...(opts["title"] !== undefined && { title: opts["title"] as string }),
+          ...(opts["parent"] !== undefined && { parent: opts["parent"] as string }),
+          ...(opts["shortcut"] !== undefined && { shortcut: opts["shortcut"] as string }),
+        },
+        writeOptionsFrom(opts),
+      ),
+    );
+  });
+
   addWriteFlags(
     tag
       .command("delete <target>")

--- a/src/client.ts
+++ b/src/client.ts
@@ -30,6 +30,7 @@ import {
 } from "./read/views.ts";
 import type {
   AreaAddParams,
+  AreaUpdateParams,
   OperationKind,
   OperationParamsMap,
   ProjectAddParams,
@@ -37,6 +38,7 @@ import type {
   ProjectUpdateParams,
   ReorderParams,
   TagAddParams,
+  TagUpdateParams,
   TodoAddParams,
   TodoMoveParams,
   TodoUpdateParams,
@@ -122,6 +124,8 @@ export interface ThingsClient {
       options?: WriteOptions,
     ): Promise<MutationResult>;
     deleteTodo(uuid: string, options?: WriteOptions): Promise<MutationResult>;
+    /** Duplicate via URL `duplicate=true` (E07) — the copy's uuid is discovered by verification. */
+    duplicateTodo(uuid: string, options?: WriteOptions): Promise<MutationResult>;
     addProject(params: ProjectAddParams, options?: WriteOptions): Promise<MutationResult>;
     updateProject(
       uuid: string,
@@ -135,8 +139,18 @@ export interface ThingsClient {
     ): Promise<MutationResult>;
     deleteProject(uuid: string, options?: WriteOptions): Promise<MutationResult>;
     addArea(params: AreaAddParams, options?: WriteOptions): Promise<MutationResult>;
+    updateArea(
+      target: string,
+      patch: Omit<AreaUpdateParams, "target">,
+      options?: WriteOptions,
+    ): Promise<MutationResult>;
     deleteArea(target: string, options?: WriteOptions): Promise<MutationResult>;
     addTag(params: TagAddParams, options?: WriteOptions): Promise<MutationResult>;
+    updateTag(
+      target: string,
+      patch: Omit<TagUpdateParams, "target">,
+      options?: WriteOptions,
+    ): Promise<MutationResult>;
     deleteTag(target: string, options?: WriteOptions): Promise<MutationResult>;
     emptyTrash(options?: WriteOptions): Promise<MutationResult>;
     /**
@@ -235,14 +249,17 @@ export function openThings(options: OpenOptions = {}): ThingsClient {
       },
       replaceChecklist: (uuid, items, o) => run("todo.replace-checklist", { uuid, items }, o),
       deleteTodo: (uuid, o) => run("todo.delete", { uuid }, o),
+      duplicateTodo: (uuid, o) => run("todo.duplicate", { uuid }, o),
       addProject: (params, o) => run("project.add", params, o),
       updateProject: (uuid, patch, o) => run("project.update", { uuid, ...patch }, o),
       completeProject: (uuid, policy, o) =>
         run("project.complete", { uuid, children: policy.children }, o),
       deleteProject: (uuid, o) => run("project.delete", { uuid }, o),
       addArea: (params, o) => run("area.add", params, o),
+      updateArea: (target, patch, o) => run("area.update", { target, ...patch }, o),
       deleteArea: (target, o) => run("area.delete", { target }, o),
       addTag: (params, o) => run("tag.add", params, o),
+      updateTag: (target, patch, o) => run("tag.update", { target, ...patch }, o),
       deleteTag: (target, o) => run("tag.delete", { target }, o),
       emptyTrash: (o) => run("trash.empty", {}, o),
       reorder: (params, o) => runReorder(writeDeps, params, o ?? {}),

--- a/src/model/dates.ts
+++ b/src/model/dates.ts
@@ -42,6 +42,54 @@ export function encodeEpochReal(date: Date): number {
   return date.getTime() / 1000;
 }
 
+/** Reminder time-of-day, `HH:mm` 24-hour. Timezone-less like IsoDate. */
+export type ReminderTime = string;
+
+/**
+ * TMTask.reminderTime packing: `hour<<26 | minute<<20` — verified against 13
+ * known-time lab samples (R-suite 2026-07-04; docs/lab/r-suite-results.md).
+ */
+export function decodeReminderTime(value: number | null): ReminderTime | null {
+  if (value === null) return null;
+  const packed = value >> 20;
+  const h = packed >> 6;
+  const m = packed & 0x3f;
+  if (h < 0 || h > 23 || m < 0 || m > 59) {
+    throw new RangeError(`packed reminderTime out of domain: ${value} (h=${h} m=${m})`);
+  }
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}`;
+}
+
+export function encodeReminderTime(time: ReminderTime): number {
+  const { h, m } = parseReminderTime(time);
+  return (h * 64 + m) << 20;
+}
+
+function parseReminderTime(time: ReminderTime): { h: number; m: number } {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(time);
+  if (!match) throw new RangeError(`not an HH:mm time: ${time}`);
+  const h = Number(match[1]);
+  const m = Number(match[2]);
+  if (h > 23 || m > 59) throw new RangeError(`time components out of range: ${time}`);
+  return { h, m };
+}
+
+/**
+ * Deterministic URL spelling for `when=<list>@<time>`. The app's parser
+ * treats BARE hours 1–11 as 12-hour times resolved to the next upcoming
+ * occurrence (10:05 → 22:05 at an afternoon wall clock!), while leading-zero
+ * hours are 24-hour literals and hours ≥ 12 are unambiguous. Every branch
+ * here is probe-backed (R01–R16): 0–9 → zero-padded 24h; 10–11 → explicit
+ * am suffix; 12–23 → literal.
+ */
+export function reminderUrlToken(time: ReminderTime): string {
+  const { h, m } = parseReminderTime(time);
+  const mm = String(m).padStart(2, "0");
+  if (h <= 9) return `0${h}:${mm}`;
+  if (h <= 11) return `${h}:${mm}am`;
+  return `${h}:${mm}`;
+}
+
 /**
  * Today's date in the machine's local timezone, as Things computes it.
  * The Today list boundary is local-midnight; injectable `now` for tests.

--- a/src/model/entities.ts
+++ b/src/model/entities.ts
@@ -2,7 +2,7 @@
  * Public entity types. Enum encodings per docs/atlas/schema-v26.md
  * (verified live against schema v26).
  */
-import type { IsoDate } from "./dates.ts";
+import type { IsoDate, ReminderTime } from "./dates.ts";
 
 export type TaskStatus = "open" | "canceled" | "completed"; // status 0 | 2 | 3
 export type StartState = "inbox" | "active" | "someday"; // start 0 | 1 | 2
@@ -39,6 +39,8 @@ interface TaskCommon {
    */
   todaySection: TodaySection | null;
   deadline: IsoDate | null;
+  /** Time-of-day reminder (`HH:mm`, 24h); requires a scheduled startDate. */
+  reminder: ReminderTime | null;
   area: Ref | null;
   /** Direct tags only — mirrors DB truth (inherited tags are computed; see inheritedTags). */
   tags: Ref[];

--- a/src/model/mappers.ts
+++ b/src/model/mappers.ts
@@ -16,7 +16,7 @@ import {
   type Todo,
   type TodaySection,
 } from "./entities.ts";
-import { decodeEpochReal, decodePackedDate } from "./dates.ts";
+import { decodeEpochReal, decodePackedDate, decodeReminderTime } from "./dates.ts";
 
 /** Raw TMTask row shape (subset per schema manifest). */
 export interface TaskRow {
@@ -32,6 +32,7 @@ export interface TaskRow {
   start: number | null;
   startDate: number | null;
   startBucket: number | null;
+  reminderTime: number | null;
   deadline: number | null;
   index: number | null;
   todayIndex: number | null;
@@ -107,6 +108,7 @@ function commonFields(row: TaskRow, refs: RefResolver, tags: Ref[]) {
     startDate: decodePackedDate(row.startDate),
     todaySection: mapTodaySection(row),
     deadline: decodePackedDate(row.deadline),
+    reminder: decodeReminderTime(row.reminderTime),
     area: refs(row.area),
     tags,
     repeating: mapRepeating(row),

--- a/src/write/commands.ts
+++ b/src/write/commands.ts
@@ -6,7 +6,13 @@
  */
 import type { DatabaseSync } from "node:sqlite";
 
-import type { IsoDate } from "../model/dates.ts";
+import {
+  decodeReminderTime,
+  encodeReminderTime,
+  reminderUrlToken,
+  type IsoDate,
+  type ReminderTime,
+} from "../model/dates.ts";
 import type { HazardId } from "./guards.ts";
 import type { ContainerRef, OperationKind, OperationParamsMap, WhenValue } from "./operations.ts";
 import {
@@ -123,6 +129,20 @@ function sortedTags(tags: string[]): string[] {
   return [...tags].toSorted();
 }
 
+/** Round-trip normalization: "6:5"-style inputs → canonical "06:05". */
+function normalizeReminder(time: ReminderTime): ReminderTime {
+  return decodeReminderTime(encodeReminderTime(time)) ?? time;
+}
+
+/**
+ * The URL `when` value with an optional reminder token appended through the
+ * deterministic emitter (never a bare 1–11 hour — oddity 2d).
+ */
+function whenWithReminder(when: WhenValue, reminder: ReminderTime | null | undefined): string {
+  if (reminder === undefined || reminder === null) return when;
+  return `${when}@${reminderUrlToken(reminder)}`;
+}
+
 function containerGiven(ref: ContainerRef | undefined): boolean {
   return ref !== undefined && (ref.uuid !== undefined || ref.title !== undefined);
 }
@@ -136,6 +156,7 @@ const todoAdd: CommandSpec<"todo.add"> = {
     "H-UNKNOWN-DESTINATION",
     "H-AMBIGUOUS-HEADING",
     "H-REOPEN-RESOLVED-PROJECT",
+    "H-REMINDER-SCOPE",
   ],
   preRead(db, params) {
     const pre = emptyPreState();
@@ -156,6 +177,9 @@ const todoAdd: CommandSpec<"todo.add"> = {
     const assert: FieldAssertion[] = [];
     if (params.notes !== undefined) assert.push({ field: "notes", equals: params.notes });
     if (params.when !== undefined) assert.push(...whenAssertions(params.when, ctx.todayIso));
+    if (params.reminder !== undefined) {
+      assert.push({ field: "reminder", equals: normalizeReminder(params.reminder) });
+    }
     if (params.deadline !== undefined) assert.push({ field: "deadline", equals: params.deadline });
     if (params.tags !== undefined) assert.push({ field: "tags", equals: sortedTags(params.tags) });
     if (params.checklistItems !== undefined) {
@@ -184,7 +208,8 @@ const todoAdd: CommandSpec<"todo.add"> = {
       {
         title: params.title,
         notes: params.notes,
-        when: params.when,
+        when:
+          params.when === undefined ? undefined : whenWithReminder(params.when, params.reminder),
         deadline: params.deadline,
         tags: params.tags?.join(","),
         "checklist-items": params.checklistItems?.join("\n"),
@@ -196,23 +221,71 @@ const todoAdd: CommandSpec<"todo.add"> = {
   },
 };
 
+/**
+ * The effective reminder a when-bearing update should leave behind. A bare
+ * `when=` CLEARS an existing reminder (R07), so when the caller re-schedules
+ * without addressing the reminder we auto-preserve the current one; an
+ * explicit null is the intentional clear.
+ */
+function effectiveReminder(
+  pre: PreState,
+  params: { when?: WhenValue; reminder?: ReminderTime | null },
+): ReminderTime | null {
+  if (params.reminder !== undefined) return params.reminder;
+  if (params.when !== "today" && params.when !== "evening") return null;
+  const target = pre.target;
+  if (target === null || target.type === "heading") return null;
+  return target.reminder;
+}
+
+function expectedNotes(pre: PreState, params: { appendNotes?: string; prependNotes?: string }) {
+  const current = pre.target !== null && pre.target.type !== "heading" ? pre.target.notes : "";
+  // Separator semantics probed: newline-joined, no stray newline against an
+  // empty note (E04/E05/E11/E12).
+  if (params.appendNotes !== undefined) {
+    return current === "" ? params.appendNotes : `${current}\n${params.appendNotes}`;
+  }
+  if (params.prependNotes !== undefined) {
+    return current === "" ? params.prependNotes : `${params.prependNotes}\n${current}`;
+  }
+  return undefined;
+}
+
 const todoUpdate: CommandSpec<"todo.update"> = {
   op: "todo.update",
-  hazards: ["H-UNKNOWN-DESTINATION", "H-REPEAT-SCHEDULE"],
+  hazards: ["H-UNKNOWN-DESTINATION", "H-REPEAT-SCHEDULE", "H-REMINDER-SCOPE"],
   preRead(db, params) {
+    if (
+      params.notes !== undefined &&
+      (params.appendNotes !== undefined || params.prependNotes !== undefined)
+    ) {
+      throw new RangeError("notes (replace) is exclusive with appendNotes/prependNotes");
+    }
+    if (params.appendNotes !== undefined && params.prependNotes !== undefined) {
+      throw new RangeError("appendNotes and prependNotes cannot be combined in one update");
+    }
     const pre = emptyPreState();
     pre.target = loadTarget(db, params.uuid);
     return pre;
   },
-  expectedDelta(_pre, params, ctx) {
+  expectedDelta(pre, params, ctx) {
     const assert: FieldAssertion[] = [];
     if (params.title !== undefined) assert.push({ field: "title", equals: params.title });
     if (params.notes !== undefined) assert.push({ field: "notes", equals: params.notes });
-    if (params.when !== undefined) assert.push(...whenAssertions(params.when, ctx.todayIso));
+    const joined = expectedNotes(pre, params);
+    if (joined !== undefined) assert.push({ field: "notes", equals: joined });
+    if (params.when !== undefined) {
+      assert.push(...whenAssertions(params.when, ctx.todayIso));
+      const reminder = effectiveReminder(pre, params);
+      assert.push({
+        field: "reminder",
+        equals: reminder === null ? null : normalizeReminder(reminder),
+      });
+    }
     if (params.deadline !== undefined) assert.push({ field: "deadline", equals: params.deadline });
     return { mode: "update", uuid: params.uuid, assert };
   },
-  compile(params, vector, _pre, ctx) {
+  compile(params, vector, pre, ctx) {
     if (vector !== "url-scheme") unsupportedVector(this.op, vector);
     return thingsUrl(
       "update",
@@ -220,7 +293,12 @@ const todoUpdate: CommandSpec<"todo.update"> = {
         id: params.uuid,
         title: params.title,
         notes: params.notes,
-        when: params.when,
+        "append-notes": params.appendNotes,
+        "prepend-notes": params.prependNotes,
+        when:
+          params.when === undefined
+            ? undefined
+            : whenWithReminder(params.when, effectiveReminder(pre, params)),
         deadline: params.deadline === null ? "" : params.deadline,
       },
       ctx.token,
@@ -267,6 +345,14 @@ const todoMove: CommandSpec<"todo.move"> = {
     "H-REPEAT-SCHEDULE",
   ],
   preRead(db, params) {
+    if (
+      params.inbox === true &&
+      (containerGiven(params.project) ||
+        containerGiven(params.area) ||
+        params.heading !== undefined)
+    ) {
+      throw new RangeError("inbox is exclusive with project/area/heading destinations");
+    }
     const pre = emptyPreState();
     pre.target = loadTarget(db, params.uuid);
     if (containerGiven(params.project)) {
@@ -283,6 +369,11 @@ const todoMove: CommandSpec<"todo.move"> = {
   },
   expectedDelta(pre, params) {
     const assert: FieldAssertion[] = [];
+    if (params.inbox === true) {
+      // De-schedules cleanly (E06): back to the Inbox bucket, no start date.
+      assert.push({ field: "start", equals: "inbox" }, { field: "startDate", equals: null });
+      return { mode: "update", uuid: params.uuid, assert };
+    }
     const heading = pre.destHeading?.resolved;
     const project = pre.destProject?.resolved;
     const area = pre.destArea?.resolved;
@@ -299,6 +390,10 @@ const todoMove: CommandSpec<"todo.move"> = {
     return { mode: "update", uuid: params.uuid, assert };
   },
   compile(params, vector, pre, ctx) {
+    if (params.inbox === true) {
+      if (vector !== "applescript") unsupportedVector(this.op, vector);
+      return osa(`move to do id ${q(params.uuid)} to list "Inbox"`);
+    }
     const project = pre.destProject?.resolved;
     const area = pre.destArea?.resolved;
     if (vector === "url-scheme") {
@@ -627,6 +722,122 @@ const tagDelete: CommandSpec<"tag.delete"> = {
   },
 };
 
+const todoDuplicate: CommandSpec<"todo.duplicate"> = {
+  op: "todo.duplicate",
+  hazards: ["H-UNKNOWN-DESTINATION", "H-REPEAT-SCHEDULE"],
+  preRead(db, params) {
+    const pre = emptyPreState();
+    pre.target = loadTarget(db, params.uuid);
+    return pre;
+  },
+  expectedDelta(pre, _params, ctx) {
+    // The copy carries the same title/notes with a fresh uuid + creationDate
+    // (E07) — discover it with the create probe, assert copy fidelity.
+    const target = pre.target;
+    const title = target !== null && target.type !== "heading" ? target.title : "";
+    const notes = target !== null && target.type !== "heading" ? target.notes : "";
+    return {
+      mode: "create",
+      probe: { title, type: "to-do", sinceEpoch: ctx.nowEpoch - 2 },
+      assert: [{ field: "notes", equals: notes }],
+    };
+  },
+  compile(params, vector, _pre, ctx) {
+    // AppleScript refuses duplication outright ("can not be copied", E08).
+    if (vector !== "url-scheme") unsupportedVector(this.op, vector);
+    return thingsUrl("update", { id: params.uuid, duplicate: "true" }, ctx.token);
+  },
+};
+
+const areaUpdate: CommandSpec<"area.update"> = {
+  op: "area.update",
+  hazards: ["H-UNKNOWN-DESTINATION", "H-UNKNOWN-TAG"],
+  preRead(db, params) {
+    if (params.title === undefined && params.tags === undefined) {
+      throw new RangeError("area.update needs title and/or tags");
+    }
+    const pre = emptyPreState();
+    pre.entityTarget = resolveArea(db, { title: params.target, uuid: params.target });
+    if (params.tags !== undefined) pre.missingTags = missingTagTitles(db, params.tags);
+    return pre;
+  },
+  expectedDelta(pre, params) {
+    const assert: FieldAssertion[] = [];
+    if (params.title !== undefined) assert.push({ field: "title", equals: params.title });
+    if (params.tags !== undefined) assert.push({ field: "tags", equals: sortedTags(params.tags) });
+    return {
+      mode: "entity-updated",
+      entity: "area",
+      uuid: pre.entityTarget?.resolved?.uuid ?? "",
+      assert,
+    };
+  },
+  compile(params, vector, pre) {
+    if (vector !== "applescript") unsupportedVector(this.op, vector);
+    const id = q(pre.entityTarget?.resolved?.uuid ?? "");
+    const lines: string[] = [];
+    if (params.title !== undefined) lines.push(`set name of area id ${id} to ${q(params.title)}`);
+    if (params.tags !== undefined) {
+      lines.push(`set tag names of area id ${id} to ${q(params.tags.join(", "))}`);
+    }
+    if (lines.length === 1) return osa(lines[0] as string);
+    const payload = `tell application "Things3"\n${lines.map((l) => `  ${l}`).join("\n")}\nend tell`;
+    return { vector: "applescript", kind: "osascript", payload, redactedPayload: payload };
+  },
+};
+
+const tagUpdate: CommandSpec<"tag.update"> = {
+  op: "tag.update",
+  hazards: ["H-UNKNOWN-DESTINATION", "H-UNKNOWN-TAG"],
+  preRead(db, params) {
+    if (
+      params.title === undefined &&
+      params.parent === undefined &&
+      params.shortcut === undefined
+    ) {
+      throw new RangeError("tag.update needs title, parent, and/or shortcut");
+    }
+    const pre = emptyPreState();
+    pre.entityTarget = resolveTag(db, params.target);
+    if (params.parent !== undefined) {
+      pre.parentTag = resolveTag(db, params.parent);
+      if (pre.parentTag.resolved === null) pre.missingTags = [params.parent];
+    }
+    return pre;
+  },
+  expectedDelta(pre, params) {
+    const assert: FieldAssertion[] = [];
+    if (params.title !== undefined) assert.push({ field: "title", equals: params.title });
+    if (params.parent !== undefined) {
+      assert.push({ field: "parent", equals: pre.parentTag?.resolved?.uuid ?? "" });
+    }
+    if (params.shortcut !== undefined) assert.push({ field: "shortcut", equals: params.shortcut });
+    return {
+      mode: "entity-updated",
+      entity: "tag",
+      uuid: pre.entityTarget?.resolved?.uuid ?? "",
+      assert,
+    };
+  },
+  compile(params, vector, pre) {
+    if (vector !== "applescript") unsupportedVector(this.op, vector);
+    const id = q(pre.entityTarget?.resolved?.uuid ?? "");
+    const lines: string[] = [];
+    if (params.title !== undefined) lines.push(`set name of tag id ${id} to ${q(params.title)}`);
+    if (params.parent !== undefined) {
+      lines.push(
+        `set parent tag of tag id ${id} to tag id ${q(pre.parentTag?.resolved?.uuid ?? "")}`,
+      );
+    }
+    if (params.shortcut !== undefined) {
+      lines.push(`set keyboard shortcut of tag id ${id} to ${q(params.shortcut)}`);
+    }
+    if (lines.length === 1) return osa(lines[0] as string);
+    const payload = `tell application "Things3"\n${lines.map((l) => `  ${l}`).join("\n")}\nend tell`;
+    return { vector: "applescript", kind: "osascript", payload, redactedPayload: payload };
+  },
+};
+
 const reorder: CommandSpec<"reorder"> = {
   op: "reorder",
   hazards: ["H-UNKNOWN-DESTINATION", "H-REORDER-SCOPE"],
@@ -706,4 +917,7 @@ export const COMMANDS: { [K in OperationKind]: CommandSpec<K> } = {
   "tag.delete": tagDelete,
   "trash.empty": trashEmpty,
   reorder,
+  "todo.duplicate": todoDuplicate,
+  "area.update": areaUpdate,
+  "tag.update": tagUpdate,
 };

--- a/src/write/guards.ts
+++ b/src/write/guards.ts
@@ -16,6 +16,7 @@ export const HAZARD_IDS = [
   "H-AMBIGUOUS-HEADING",
   "H-PERMANENT-DELETE",
   "H-REORDER-SCOPE",
+  "H-REMINDER-SCOPE",
 ] as const;
 
 export type HazardId = (typeof HAZARD_IDS)[number];
@@ -42,6 +43,7 @@ const REPEAT_SENSITIVE: OperationKind[] = [
   "todo.reopen",
   "todo.move",
   "todo.delete",
+  "todo.duplicate", // unvalidated on templates (E07 probed a plain to-do)
 ];
 
 const GUARDS: Record<HazardId, GuardFn> = {
@@ -145,6 +147,22 @@ const GUARDS: Record<HazardId, GuardFn> = {
           ? "multiple headings with that name exist in the destination project"
           : "heading not found in the destination project (the heading param never creates one — T09/U09)",
       remediation: "rename the duplicate headings, or omit --heading",
+    };
+  },
+  "H-REMINDER-SCOPE": ({ op, params }) => {
+    if (op !== "todo.add" && op !== "todo.update") return null;
+    if (!("reminder" in params) || params["reminder"] === undefined) return null;
+    const when = params["when"];
+    if (when === "today" || when === "evening") return null;
+    return {
+      hazard: "H-REMINDER-SCOPE",
+      detail:
+        params["reminder"] === null
+          ? "clearing a reminder IS a bare when= write (R07) — when: today|evening must be " +
+            "re-stated in the same call"
+          : "reminders are only validated with when: today|evening (R-suite); date-scheduled " +
+            "reminders are unprobed",
+      remediation: "pass when today|evening together with the reminder",
     };
   },
   "H-REORDER-SCOPE": ({ op, params, pre }) => {

--- a/src/write/operations.ts
+++ b/src/write/operations.ts
@@ -3,7 +3,7 @@
  * typed parameter shapes. Vector support for each operation lives in the
  * per-vector matrices (data, produced by the lab), not here.
  */
-import type { IsoDate } from "../model/dates.ts";
+import type { IsoDate, ReminderTime } from "../model/dates.ts";
 
 export const OPERATION_KINDS = [
   "todo.add",
@@ -25,6 +25,9 @@ export const OPERATION_KINDS = [
   "tag.delete",
   "trash.empty",
   "reorder",
+  "todo.duplicate",
+  "area.update",
+  "tag.update",
 ] as const;
 
 export type OperationKind = (typeof OPERATION_KINDS)[number];
@@ -42,6 +45,12 @@ export interface TodoAddParams {
   title: string;
   notes?: string;
   when?: WhenValue;
+  /**
+   * Time-of-day reminder, `HH:mm` 24h. Requires when: today|evening (the
+   * only probed combinations, R01–R16); compiled through the deterministic
+   * URL emitter (the app's bare-hour parser is a trap — oddity 2d).
+   */
+  reminder?: ReminderTime;
   deadline?: IsoDate;
   tags?: string[];
   checklistItems?: string[];
@@ -55,7 +64,18 @@ export interface TodoUpdateParams {
   uuid: string;
   title?: string;
   notes?: string;
+  /** Append to the existing notes (newline-joined; E04/E11). Exclusive with notes/prependNotes. */
+  appendNotes?: string;
+  /** Prepend to the existing notes (newline-joined; E05/E12). Exclusive with notes/appendNotes. */
+  prependNotes?: string;
   when?: WhenValue;
+  /**
+   * `HH:mm` sets a reminder (requires when: today|evening in the same call);
+   * null clears it. When `when` is today/evening and this is OMITTED, an
+   * existing reminder is auto-preserved — a bare when= would silently clear
+   * it (R07).
+   */
+  reminder?: ReminderTime | null;
   deadline?: IsoDate | null;
 }
 
@@ -69,6 +89,8 @@ export interface TodoMoveParams {
   area?: ContainerRef;
   /** Existing heading inside the destination project. */
   heading?: string;
+  /** Move back to the Inbox (de-schedules; E06). Exclusive with the others. */
+  inbox?: boolean;
 }
 
 export interface TodoSetTagsParams {
@@ -124,6 +146,24 @@ export interface NameOrUuidParams {
   target: string;
 }
 
+export interface AreaUpdateParams {
+  /** uuid or unique case-insensitive title. */
+  target: string;
+  title?: string;
+  /** Full replacement set of EXISTING tag titles. */
+  tags?: string[];
+}
+
+export interface TagUpdateParams {
+  /** uuid or unique case-insensitive title. */
+  target: string;
+  title?: string;
+  /** Existing tag to nest under (un-nesting to root is unprobed — not offered). */
+  parent?: string;
+  /** Single character (clearing to none is unprobed — not offered). */
+  shortcut?: string;
+}
+
 export type ReorderScope = "today" | "evening" | "project" | "area";
 export type ReorderStrategy = "native" | "bounce";
 
@@ -170,6 +210,9 @@ export interface OperationParamsMap {
   "tag.delete": NameOrUuidParams;
   "trash.empty": EmptyParams;
   reorder: ReorderParams;
+  "todo.duplicate": UuidParams;
+  "area.update": AreaUpdateParams;
+  "tag.update": TagUpdateParams;
 }
 
 /** Explicit acknowledgements for guarded operations (never defaulted). */

--- a/src/write/pipeline.ts
+++ b/src/write/pipeline.ts
@@ -168,6 +168,12 @@ function capturePre(
     for (const uuid of spec.sequence) preRanks[uuid] = reader.rankOf(uuid, spec.key);
     fields["__ordering__"] = preRanks;
   }
+  if (spec.mode === "entity-updated") {
+    const current = reader.entityFields(spec.entity, spec.uuid);
+    const captured: Record<string, unknown> = {};
+    for (const a of spec.assert) captured[a.field] = current?.[a.field] ?? null;
+    fields[spec.uuid] = captured;
+  }
   if (spec.mode === "trash-emptied") {
     return { modDates, fields, trashedCount: pre.trashedCount };
   }

--- a/src/write/vectors/applescript.ts
+++ b/src/write/vectors/applescript.ts
@@ -30,9 +30,10 @@ export const APPLESCRIPT_MATRIX: VectorMatrix = {
     support: "partial",
     disruption: 0,
     validation: "validated",
-    evidence: ["A22", "A22B", "A22C"],
+    evidence: ["A22", "A22B", "A22C", "E06"],
     notes:
-      "list moves + project/area property setters; cannot target Upcoming (schedule instead); no heading placement",
+      "list moves + project/area property setters + move to Inbox (de-schedules, E06); " +
+      "cannot target Upcoming (schedule instead); no heading placement",
   },
   "todo.set-tags": {
     support: "yes",
@@ -46,6 +47,13 @@ export const APPLESCRIPT_MATRIX: VectorMatrix = {
     disruption: 0,
     validation: "validated",
     evidence: ["A30"],
+  },
+  "todo.duplicate": {
+    support: "no",
+    disruption: 0,
+    validation: "validated",
+    evidence: ["E08"],
+    notes: "the app refuses: 'Selected to dos can not be copied. (-1717)'",
   },
   "todo.delete": {
     support: "yes",
@@ -75,6 +83,13 @@ export const APPLESCRIPT_MATRIX: VectorMatrix = {
     notes: "SHALLOW: only the project row is trashed; children keep links (derived membership)",
   },
   "area.add": { support: "yes", disruption: 0, validation: "validated", evidence: ["A03"] },
+  "area.update": {
+    support: "yes",
+    disruption: 0,
+    validation: "validated",
+    evidence: ["E01"],
+    notes: "rename via `set name`; tag replacement via `set tag names`",
+  },
   "area.delete": {
     support: "yes",
     disruption: 0,
@@ -83,6 +98,13 @@ export const APPLESCRIPT_MATRIX: VectorMatrix = {
     notes: "PERMANENT — the area row is hard-deleted; contained to-dos land in Trash",
   },
   "tag.add": { support: "yes", disruption: 0, validation: "validated", evidence: ["A04", "A05"] },
+  "tag.update": {
+    support: "yes",
+    disruption: 0,
+    validation: "validated",
+    evidence: ["E02", "E03", "E10"],
+    notes: "rename (assignments survive), re-parent existing, keyboard shortcut",
+  },
   "tag.delete": {
     support: "yes",
     disruption: 0,

--- a/src/write/vectors/url-scheme.ts
+++ b/src/write/vectors/url-scheme.ts
@@ -13,15 +13,20 @@ export const URL_SCHEME_MATRIX: VectorMatrix = {
     support: "yes",
     disruption: 0,
     validation: "validated",
-    evidence: ["U03", "U04", "U07", "U09"],
-    notes: "unknown tags silently ignored by the app — H-UNKNOWN-TAG guards pre-write",
+    evidence: ["U03", "U04", "U07", "U09", "R01", "R04"],
+    notes:
+      "unknown tags silently ignored by the app — H-UNKNOWN-TAG guards pre-write; " +
+      "reminders via when=<list>@<time> (deterministic emitter — oddity 2d)",
   },
   "todo.update": {
     support: "yes",
     disruption: 0,
     validation: "validated",
-    evidence: ["U04", "U13", "U12B"],
-    notes: "when= on a repeating template CRASHES Things (U12) — H-REPEAT-SCHEDULE hard-blocks",
+    evidence: ["U04", "U13", "U12B", "R06", "R07", "E04", "E05", "E11", "E12"],
+    notes:
+      "when= on a repeating template CRASHES Things (U12/R09) — H-REPEAT-SCHEDULE hard-blocks; " +
+      "reminders set/auto-preserved/cleared via when=@time (R06/R07); " +
+      "append-/prepend-notes newline-joined (E04/E05/E11/E12)",
   },
   "todo.complete": {
     support: "yes",
@@ -52,6 +57,13 @@ export const URL_SCHEME_MATRIX: VectorMatrix = {
     notes: "wholesale replacement — destroys per-item state (H-CHECKLIST-REPLACE)",
   },
   "todo.delete": { support: "no", disruption: 3, validation: "validated", evidence: ["U14"] },
+  "todo.duplicate": {
+    support: "yes",
+    disruption: 0,
+    validation: "validated",
+    evidence: ["E07"],
+    notes: "update?duplicate=true — exact copy (title/notes), fresh uuid + creationDate",
+  },
   "project.add": {
     support: "yes",
     disruption: 0,

--- a/src/write/verify/delta.ts
+++ b/src/write/verify/delta.ts
@@ -48,7 +48,9 @@ export type DeltaSpec =
    * Ordering: the given uuids must read back in strictly ascending rank on
    * the named key (todayIndex for Today/Evening scopes, index elsewhere).
    */
-  | { mode: "ordering"; key: "index" | "todayIndex"; sequence: string[] };
+  | { mode: "ordering"; key: "index" | "todayIndex"; sequence: string[] }
+  /** Area/tag property updates (TMArea/TMTag rows aren't tasks). */
+  | { mode: "entity-updated"; entity: "area" | "tag"; uuid: string; assert: FieldAssertion[] };
 
 /** Movement tripwires captured by the pre-read, keyed by uuid. */
 export type PreModDates = Record<string, number | null>;
@@ -75,6 +77,11 @@ export interface VerifyReader {
   trashedCount(): number;
   findCreated(probe: CreateProbe): AnyTask[];
   modDateOf(uuid: string): number | null;
+  /**
+   * Assertable fields of a TMArea/TMTag row: title, tags (areas, sorted
+   * titles), parent (tags, uuid or null), shortcut (tags). Null = row gone.
+   */
+  entityFields(entity: "area" | "tag", uuid: string): Record<string, unknown> | null;
 }
 
 export function createDbReader(db: DatabaseSync): VerifyReader {
@@ -130,6 +137,27 @@ export function createDbReader(db: DatabaseSync): VerifyReader {
         | { userModificationDate: number | null }
         | undefined;
       return row?.userModificationDate ?? null;
+    },
+    entityFields(entity, uuid) {
+      if (entity === "area") {
+        const row = db.prepare("SELECT title FROM TMArea WHERE uuid = ?").get(uuid) as
+          | { title: string | null }
+          | undefined;
+        if (row === undefined) return null;
+        const tags = db
+          .prepare(
+            "SELECT t.title FROM TMAreaTag at JOIN TMTag t ON at.tags = t.uuid WHERE at.areas = ?",
+          )
+          .all(uuid) as { title: string }[];
+        return { title: row.title ?? "", tags: tags.map((t) => t.title).toSorted() };
+      }
+      const row = db
+        .prepare("SELECT title, parent, shortcut FROM TMTag WHERE uuid = ?")
+        .get(uuid) as
+        | { title: string | null; parent: string | null; shortcut: string | null }
+        | undefined;
+      if (row === undefined) return null;
+      return { title: row.title ?? "", parent: row.parent, shortcut: row.shortcut };
     },
   };
 }
@@ -300,6 +328,28 @@ export function evaluateDelta(
       return {
         satisfied: sorted,
         movement: moved,
+        assertedMovement: moved,
+        observed,
+      };
+    }
+    case "entity-updated": {
+      const fields = reader.entityFields(spec.entity, spec.uuid);
+      const observed: Record<string, unknown> = {};
+      let pass = fields !== null;
+      for (const a of spec.assert) {
+        const actual = fields?.[a.field];
+        observed[a.field] = actual === undefined ? null : actual;
+        if (!valuesEqual(actual, a.equals)) pass = false;
+      }
+      // TMArea/TMTag carry no modification date: movement = any asserted
+      // field departed from its captured pre-value.
+      const preFields = pre.fields[spec.uuid] ?? {};
+      const moved = Object.entries(observed).some(
+        ([field, value]) => field in preFields && !valuesEqual(preFields[field], value),
+      );
+      return {
+        satisfied: pass,
+        movement: moved || fields === null,
         assertedMovement: moved,
         observed,
       };

--- a/test/cli/help-contract.test.ts
+++ b/test/cli/help-contract.test.ts
@@ -95,6 +95,32 @@ describe("write-command help states the contract", () => {
     expect(help).toContain("--op");
   });
 
+  it("todo update: reminder contract (scope, auto-preserve, clear)", () => {
+    const help = helpFor("todo", "update");
+    expect(help).toContain("--reminder <HH:mm>");
+    expect(help).toContain("--clear-reminder");
+    expect(help).toContain("H-REMINDER-SCOPE");
+    expect(help).toContain("auto-preserved");
+    expect(help).toContain("--append-notes");
+    expect(help).toContain("--prepend-notes");
+  });
+
+  it("todo duplicate: url-only path + template block", () => {
+    const help = helpFor("todo", "duplicate");
+    expect(help).toContain("url-scheme");
+    expect(help).toContain("H-REPEAT-SCHEDULE");
+  });
+
+  it("area/tag update: setters exist with evidence-scoped caveats", () => {
+    const areaHelp = helpFor("area", "update");
+    expect(areaHelp).toContain("--title");
+    expect(areaHelp).toContain("H-UNKNOWN-TAG");
+    const tagHelp = helpFor("tag", "update");
+    expect(tagHelp).toContain("--parent");
+    expect(tagHelp).toContain("--shortcut");
+    expect(tagHelp).toContain("unprobed");
+  });
+
   it("reorder: experimental gate, bounce cap, scope hazards", () => {
     const help = helpFor("reorder");
     expect(help).toContain("EXPERIMENTAL");

--- a/test/engine/write-r9b.test.ts
+++ b/test/engine/write-r9b.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Phase 9b engine tests: reminders (codec, emitter, auto-preserve/clear),
+ * notes append/prepend, move-to-inbox, duplicate, area/tag updates. Fake
+ * vectors simulate the app semantics the R/E suites validated.
+ */
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { AuditRecord } from "../../src/audit/schema.ts";
+import type { ThingsApiConfig } from "../../src/config.ts";
+import type { FingerprintStatus } from "../../src/db/fingerprint.ts";
+import { decodeReminderTime, encodeReminderTime, reminderUrlToken } from "../../src/model/dates.ts";
+import { runMutation, type WriteDeps } from "../../src/write/pipeline.ts";
+import type { VectorMatrix, WriteVector } from "../../src/write/vectors/types.ts";
+import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
+import { seedArea, seedTag, seedTodo, tagArea } from "../fixtures/seed.ts";
+
+const NOW = new Date("2026-07-05T12:00:00Z");
+const NOW_EPOCH = Math.floor(NOW.getTime() / 1000);
+const TODAY_ISO = "2026-07-05";
+
+let fixture: FixtureDb;
+let auditRecords: AuditRecord[];
+let lockSeq = 0;
+
+beforeEach(() => {
+  fixture = buildFixtureDb();
+  auditRecords = [];
+});
+afterEach(() => {
+  fixture.close();
+});
+
+const CONFIG: ThingsApiConfig = {
+  profile: "workstation",
+  maxDisruption: 1,
+  actor: "test-actor",
+  auditEnabled: true,
+  acceptedFingerprint: null,
+  allowExperimental: false,
+  host: "test-host",
+};
+
+const URL_MATRIX: VectorMatrix = Object.fromEntries(
+  ["todo.add", "todo.update", "todo.duplicate"].map((op) => [
+    op,
+    { support: "yes", disruption: 0, validation: "validated" },
+  ]),
+) as VectorMatrix;
+
+const AS_MATRIX: VectorMatrix = Object.fromEntries(
+  ["todo.move", "area.update", "tag.update"].map((op) => [
+    op,
+    { support: "yes", disruption: 0, validation: "validated" },
+  ]),
+) as VectorMatrix;
+
+function fakeVector(
+  id: WriteVector["id"],
+  matrix: VectorMatrix,
+  effect: ((payload: string) => void) | null,
+) {
+  const calls: string[] = [];
+  const vector: WriteVector = {
+    id,
+    matrix,
+    async execute(invocation) {
+      calls.push(invocation.payload);
+      effect?.(invocation.payload);
+      return { exitCode: 0, stdout: "", stderr: "" };
+    },
+  };
+  return { vector, calls };
+}
+
+function okFingerprint(): FingerprintStatus {
+  return {
+    kind: "ok",
+    observation: { databaseVersion: 26, tables: [], fingerprint: "sha256:test" },
+  };
+}
+
+function deps(vectors: WriteVector[]): WriteDeps {
+  return {
+    db: fixture.db,
+    vectors,
+    config: CONFIG,
+    audit: { append: (r) => auditRecords.push(r) },
+    fingerprint: okFingerprint,
+    lockPath: join(tmpdir(), `things-api-9b-lock-${process.pid}-${lockSeq++}`),
+    isAppRunning: () => true,
+    ensureRunning: async () => true,
+    now: () => NOW,
+  };
+}
+
+function touch(uuid: string, sets: string): void {
+  fixture.db
+    .prepare(`UPDATE TMTask SET ${sets}, userModificationDate = ? WHERE uuid = ?`)
+    .run(NOW_EPOCH + 1, uuid);
+}
+
+describe("reminder codec + emitter", () => {
+  it("round-trips all lab samples", () => {
+    for (const [time, raw] of [
+      ["18:00", 1207959552],
+      ["06:30", 434110464],
+      ["00:15", 15728640],
+      ["21:15", 1425014784],
+      ["22:05", 1481637888],
+      ["10:05", 676331520],
+    ] as const) {
+      expect(encodeReminderTime(time)).toBe(raw);
+      expect(decodeReminderTime(raw)).toBe(time);
+    }
+  });
+
+  it("emits the deterministic URL spelling per hour class (oddity 2d)", () => {
+    expect(reminderUrlToken("06:45")).toBe("06:45");
+    expect(reminderUrlToken("6:45")).toBe("06:45"); // normalized, never bare
+    expect(reminderUrlToken("00:05")).toBe("00:05");
+    expect(reminderUrlToken("10:05")).toBe("10:05am");
+    expect(reminderUrlToken("11:59")).toBe("11:59am");
+    expect(reminderUrlToken("12:30")).toBe("12:30");
+    expect(reminderUrlToken("14:10")).toBe("14:10");
+    expect(reminderUrlToken("23:59")).toBe("23:59");
+  });
+});
+
+describe("reminders through the pipeline", () => {
+  it("todo.add compiles when@token and verifies the stored reminder", async () => {
+    const { vector, calls } = fakeVector("url-scheme", URL_MATRIX, () => {
+      seedTodo(fixture.db, {
+        uuid: "NEW-R",
+        title: "Remind",
+        startDate: TODAY_ISO,
+        reminder: "10:05",
+        creationDate: NOW_EPOCH,
+      });
+    });
+    const result = await runMutation(deps([vector]), "todo.add", {
+      title: "Remind",
+      when: "today",
+      reminder: "10:05",
+    });
+    expect(result.kind).toBe("ok");
+    expect(calls[0]).toContain(encodeURIComponent("today@10:05am"));
+  });
+
+  it("H-REMINDER-SCOPE blocks a reminder without when today|evening", async () => {
+    const { vector, calls } = fakeVector("url-scheme", URL_MATRIX, null);
+    const result = await runMutation(deps([vector]), "todo.add", {
+      title: "X",
+      when: "2026-07-08",
+      reminder: "10:05",
+    });
+    expect(result.kind).toBe("blocked");
+    if (result.kind === "blocked") expect(result.hazard).toBe("H-REMINDER-SCOPE");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("todo.update auto-preserves an existing reminder on re-schedule", async () => {
+    const uuid = seedTodo(fixture.db, {
+      title: "Keep",
+      startDate: TODAY_ISO,
+      reminder: "18:00",
+    });
+    const { vector, calls } = fakeVector("url-scheme", URL_MATRIX, () => {
+      touch(uuid, "startBucket = 1"); // app moves to evening; reminder stays
+    });
+    const result = await runMutation(deps([vector]), "todo.update", { uuid, when: "evening" });
+    expect(result.kind).toBe("ok");
+    expect(calls[0]).toContain(encodeURIComponent("evening@18:00"));
+    if (result.kind === "ok") expect(result.observed?.["reminder"]).toBe("18:00");
+  });
+
+  it("todo.update reminder:null compiles a bare when and verifies the clear", async () => {
+    const uuid = seedTodo(fixture.db, {
+      title: "Clear",
+      startDate: TODAY_ISO,
+      reminder: "18:00",
+    });
+    const { vector, calls } = fakeVector("url-scheme", URL_MATRIX, () => {
+      touch(uuid, "reminderTime = NULL");
+    });
+    const result = await runMutation(deps([vector]), "todo.update", {
+      uuid,
+      when: "today",
+      reminder: null,
+    });
+    expect(result.kind).toBe("ok");
+    expect(calls[0]).toMatch(/when=today(&|$)/);
+    expect(calls[0]).not.toContain("%40"); // no @token
+    if (result.kind === "ok") expect(result.observed?.["reminder"]).toBeNull();
+  });
+
+  it("silent reminder loss is caught: app clears it but delta expected preservation", async () => {
+    const uuid = seedTodo(fixture.db, {
+      title: "Lost",
+      startDate: TODAY_ISO,
+      reminder: "18:00",
+    });
+    const { vector } = fakeVector("url-scheme", URL_MATRIX, () => {
+      touch(uuid, "reminderTime = NULL"); // hostile app: drops the reminder
+    });
+    const result = await runMutation(
+      deps([vector]),
+      "todo.update",
+      { uuid, when: "today" },
+      { verifyTimeoutMs: 300 },
+    );
+    expect(result.kind).toBe("verify-failed");
+  });
+});
+
+describe("notes modes", () => {
+  it("appendNotes joins with newline against existing notes (E04)", async () => {
+    const uuid = seedTodo(fixture.db, { title: "N", notes: "BASE" });
+    const { vector, calls } = fakeVector("url-scheme", URL_MATRIX, () => {
+      touch(uuid, "notes = 'BASE' || char(10) || 'TAIL'");
+    });
+    const result = await runMutation(deps([vector]), "todo.update", {
+      uuid,
+      appendNotes: "TAIL",
+    });
+    expect(result.kind).toBe("ok");
+    expect(calls[0]).toContain("append-notes=TAIL");
+  });
+
+  it("appendNotes against an EMPTY note expects no separator (E11)", async () => {
+    const uuid = seedTodo(fixture.db, { title: "N2", notes: "" });
+    const { vector } = fakeVector("url-scheme", URL_MATRIX, () => {
+      touch(uuid, "notes = 'SOLO'");
+    });
+    const result = await runMutation(deps([vector]), "todo.update", {
+      uuid,
+      appendNotes: "SOLO",
+    });
+    expect(result.kind).toBe("ok");
+  });
+
+  it("notes + appendNotes is a hard param conflict", async () => {
+    const uuid = seedTodo(fixture.db, { title: "N3" });
+    const { vector } = fakeVector("url-scheme", URL_MATRIX, null);
+    await expect(
+      runMutation(deps([vector]), "todo.update", { uuid, notes: "A", appendNotes: "B" }),
+    ).rejects.toThrow(/exclusive/);
+  });
+});
+
+describe("move to inbox / duplicate / entity updates", () => {
+  it("todo.move inbox compiles AppleScript and verifies the de-schedule (E06)", async () => {
+    const uuid = seedTodo(fixture.db, { title: "Mv", startDate: TODAY_ISO });
+    const { vector, calls } = fakeVector("applescript", AS_MATRIX, () => {
+      touch(uuid, "start = 0, startDate = NULL");
+    });
+    const result = await runMutation(
+      deps([vector]),
+      "todo.move",
+      { uuid, inbox: true },
+      { vector: "applescript" },
+    );
+    expect(result.kind).toBe("ok");
+    expect(calls[0]).toContain(`move to do id "${uuid}" to list "Inbox"`);
+  });
+
+  it("todo.duplicate discovers the copy and asserts fidelity (E07)", async () => {
+    const uuid = seedTodo(fixture.db, {
+      title: "Dup",
+      notes: "BODY",
+      creationDate: NOW_EPOCH - 500,
+    });
+    const { vector, calls } = fakeVector("url-scheme", URL_MATRIX, () => {
+      seedTodo(fixture.db, {
+        uuid: "COPY-1",
+        title: "Dup",
+        notes: "BODY",
+        creationDate: NOW_EPOCH,
+        start: "inbox",
+      });
+    });
+    const result = await runMutation(deps([vector]), "todo.duplicate", { uuid });
+    expect(result.kind).toBe("ok");
+    if (result.kind === "ok") expect(result.uuid).toBe("COPY-1");
+    expect(calls[0]).toContain("duplicate=true");
+  });
+
+  it("todo.duplicate is blocked on repeating templates", async () => {
+    const uuid = seedTodo(fixture.db, { title: "Tmpl", recurrenceRule: true });
+    const { vector, calls } = fakeVector("url-scheme", URL_MATRIX, null);
+    const result = await runMutation(deps([vector]), "todo.duplicate", { uuid });
+    expect(result.kind).toBe("blocked");
+    if (result.kind === "blocked") expect(result.hazard).toBe("H-REPEAT-SCHEDULE");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("area.update renames + retags with entity-updated verification (E01)", async () => {
+    const areaUuid = seedArea(fixture.db, "Home");
+    const tagUuid = seedTag(fixture.db, "deep");
+    const { vector, calls } = fakeVector("applescript", AS_MATRIX, () => {
+      fixture.db.prepare("UPDATE TMArea SET title = 'Casa' WHERE uuid = ?").run(areaUuid);
+      tagArea(fixture.db, areaUuid, tagUuid);
+    });
+    const result = await runMutation(deps([vector]), "area.update", {
+      target: "Home",
+      title: "Casa",
+      tags: ["deep"],
+    });
+    expect(result.kind).toBe("ok");
+    expect(calls[0]).toContain(`set name of area id "${areaUuid}" to "Casa"`);
+    expect(calls[0]).toContain(`set tag names of area id "${areaUuid}" to "deep"`);
+    if (result.kind === "ok") {
+      expect(result.observed).toEqual({ title: "Casa", tags: ["deep"] });
+    }
+  });
+
+  it("tag.update re-parents by uuid specifier and verifies (E03)", async () => {
+    const parent = seedTag(fixture.db, "work");
+    const child = seedTag(fixture.db, "deep");
+    const { vector, calls } = fakeVector("applescript", AS_MATRIX, () => {
+      fixture.db.prepare("UPDATE TMTag SET parent = ? WHERE uuid = ?").run(parent, child);
+    });
+    const result = await runMutation(deps([vector]), "tag.update", {
+      target: "deep",
+      parent: "work",
+    });
+    expect(result.kind).toBe("ok");
+    expect(calls[0]).toContain(`set parent tag of tag id "${child}" to tag id "${parent}"`);
+  });
+
+  it("tag.update to an unknown parent is blocked (H-UNKNOWN-TAG)", async () => {
+    seedTag(fixture.db, "deep");
+    const { vector, calls } = fakeVector("applescript", AS_MATRIX, null);
+    const result = await runMutation(deps([vector]), "tag.update", {
+      target: "deep",
+      parent: "nope",
+    });
+    expect(result.kind).toBe("blocked");
+    if (result.kind === "blocked") expect(result.hazard).toBe("H-UNKNOWN-TAG");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("area.update silent no-op is classified (nothing moves)", async () => {
+    seedArea(fixture.db, "Home");
+    const { vector } = fakeVector("applescript", AS_MATRIX, null);
+    const result = await runMutation(
+      deps([vector]),
+      "area.update",
+      { target: "Home", title: "Casa" },
+      { verifyTimeoutMs: 300 },
+    );
+    expect(result.kind).toBe("verify-failed");
+    if (result.kind === "verify-failed") expect(result.reason).toBe("silent-noop");
+  });
+});

--- a/test/fixtures/seed.ts
+++ b/test/fixtures/seed.ts
@@ -4,7 +4,7 @@
  */
 import type { DatabaseSync } from "node:sqlite";
 
-import { encodePackedDate } from "../../src/model/dates.ts";
+import { encodePackedDate, encodeReminderTime } from "../../src/model/dates.ts";
 
 let seq = 0;
 const uid = (prefix: string) => `${prefix}-${(++seq).toString().padStart(4, "0")}`;
@@ -21,6 +21,8 @@ export interface SeedTaskOpts {
   /** ISO date; encoded to the packed int. */
   startDate?: string | null;
   evening?: boolean;
+  /** HH:mm; encoded to the packed reminderTime int. */
+  reminder?: string | null;
   deadline?: string | null;
   trashed?: boolean;
   index?: number;
@@ -42,12 +44,12 @@ function insertTask(db: DatabaseSync, type: 0 | 1 | 2, opts: SeedTaskOpts): stri
     `INSERT INTO TMTask (
        uuid, type, status, stopDate, trashed, title, notes,
        creationDate, userModificationDate,
-       start, startDate, startBucket, deadline,
+       start, startDate, startBucket, reminderTime, deadline,
        "index", todayIndex, area, project, heading,
        untrashedLeafActionsCount, openUntrashedLeafActionsCount,
        checklistItemsCount, openChecklistItemsCount,
        rt1_repeatingTemplate, rt1_recurrenceRule, repeater
-     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, ?, ?, NULL)`,
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 0, 0, ?, ?, NULL)`,
   ).run(
     uuid,
     type,
@@ -61,6 +63,7 @@ function insertTask(db: DatabaseSync, type: 0 | 1 | 2, opts: SeedTaskOpts): stri
     START[opts.start ?? "active"],
     opts.startDate ? encodePackedDate(opts.startDate) : null,
     opts.evening ? 1 : 0,
+    opts.reminder ? encodeReminderTime(opts.reminder) : null,
     opts.deadline ? encodePackedDate(opts.deadline) : null,
     opts.index ?? 0,
     opts.todayIndex ?? 0,

--- a/test/unit/mappers.test.ts
+++ b/test/unit/mappers.test.ts
@@ -26,6 +26,7 @@ function row(overrides: Partial<TaskRow> = {}): TaskRow {
     start: 1,
     startDate: 132803712, // 2026-06-25, live-verified vector
     startBucket: 1,
+    reminderTime: null,
     deadline: null,
     index: -1731,
     todayIndex: 6000626,


### PR DESCRIPTION
Implements every operation the Phase-9a probe campaigns (PR #16) validated. All evidence-scoped; matrices cite probe ids.

## Reminders
- Model: `reminderTime` codec (`hour<<26 | minute<<20`) decoded onto `Todo`/`Project` as `reminder: "HH:mm"`.
- `--reminder HH:mm` on `todo add`/`todo update` — compiled via the **deterministic emitter** (hours 0–9 zero-padded 24h, 10–11 am-suffixed, 12–23 literal) so the app's bare-hour 12-hour "next-upcoming" parser (oddity 2d) can never bite.
- **Auto-preserve**: re-scheduling without `--reminder` re-sends the existing reminder — a bare `when=` silently clears it (R07). `--clear-reminder` / `reminder: null` is the explicit clear.
- `H-REMINDER-SCOPE` guard pins usage to the probed `when today|evening` scope.
- Verification asserts the exact decoded reminder; a hostile clear is a verify-failure (tested).

## Editing completeness
- `todo update --append-notes/--prepend-notes` (newline-joined; empty-note edge probed via new E11/E12, suite re-locked at 12 probes ×2 identical).
- `todo move --inbox` (AppleScript, de-schedules — E06).
- `todo duplicate` (URL `duplicate=true`, copy discovered by create-probe with fidelity assertion — E07; AppleScript path marked refused per E08; blocked on repeating templates).
- `area update` (rename/tags) and `tag update` (rename/re-parent/shortcut) via uuid-specifier AppleScript setters; new `entity-updated` DeltaSpec mode (TMArea/TMTag have no mod-date — movement classified from asserted-field pre-capture).

## Verification
- 157 unit tests (17 new engine tests + codec/emitter locks + help contracts).
- **E2E in VM: 43/43 green** — includes the percent-encoded `when=today%4010%3A05am` form accepted by the real app, auto-preserve, clear, H-REMINDER-SCOPE block (exit 4), both notes modes, duplicate, inbox move, area+tag updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)