### PR TITLE
Phase 10a: tag-filtered list reads

### DIFF
--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -39,10 +39,10 @@ Living register of Things-app capabilities that are missing, thin, or janky in t
 
 | Gap | Detail |
 |---|---|
-| Tag-filtered list reads | The UI filters any list by tag INCLUDING inherited; our `read.*` views take no tag parameter. Inheritance model itself is correct (direct `tags` + computed `inheritedTags`, T18/U18/A13) — this is query surface only. |
-| Today ordering fidelity | `todayIndexReferenceDate` re-bucketing unresolved — our Today order can mismatch the UI for stale-referenceDate items. Matters more now that we WRITE order. |
-| Upcoming repeat occurrences | Templates' future instances aren't synthesized into `upcoming` (the UI shows them). |
-| Checklist state granularity | Read per-item state via private `json` (A51) not yet surfaced; writes stay wholesale-replace everywhere (app limitation, all surfaces). |
+| ~~Tag-filtered list reads~~ | **SHIPPED 2026-07-04 (Phase 10a)**: `--tag <ref>` on today/inbox/anytime/upcoming/someday/logbook — direct OR inherited via the heading→project→area chain (single SQL predicate mirroring `inheritedTagsFor`). Tag-HIERARCHY descendant matching (filter by parent matches child-tagged items, as the UI does) is unvalidated — not offered yet. |
+| Today ordering fidelity | `todayIndexReferenceDate` re-bucketing unresolved — our Today order can mismatch the UI for stale-referenceDate items. Matters more now that we WRITE order. Research-heavy (needs live UI comparison probes). |
+| Upcoming repeat occurrences | Templates' future instances aren't synthesized into `upcoming` (the UI shows them). Research-heavy (rt1_recurrenceRule bplist decode, read-only). |
+| ~~Checklist state granularity~~ | **Already covered** — `byUuid` returns the checklist with per-item `status` from TMChecklistItem (the old register entry was stale). Writes stay wholesale-replace everywhere (app limitation, all surfaces). |
 
 ## Deliberately excluded (not gaps)
 
@@ -57,7 +57,7 @@ Fills: **headings in existing projects** (unique), maybe heading-archive + remin
 1. **Phase 8 (DONE 2026-07-04)** — `write.reorder` landed: today/project/area native + evening bounce, experimental gate + sdef canary, H-REORDER-SCOPE guard, e2e-validated in the VM.
 2. **Phase 9a (DONE 2026-07-04)** — R-suite (16 probes) + E-suite (12 probes) locked; reminderTime codec closed; parser trap pinned (oddity 2d).
 3. **Phase 9b (DONE 2026-07-04)** — reminder vocabulary, area.update, tag.update, notes modes, inbox move, todo.duplicate; e2e 43/43.
-4. **Phase 10** — read-layer batch, host-only: tag-filtered reads (incl. inherited), Today ordering fidelity (todayIndexReferenceDate), upcoming repeat occurrences, checklist per-item state. Task #26.
+4. **Phase 10a (DONE 2026-07-04)** — tag-filtered reads shipped; checklist per-item state confirmed already covered. **Phase 10b (open)** — Today ordering fidelity (todayIndexReferenceDate re-bucketing probes) + upcoming repeat occurrences (recurrence-rule bplist decode); both research-heavy, no app-write risk.
 5. **Phase 11 (blocked on Mike's L5 sitting)** — S-campaign → Shortcuts vector → heading ops in existing projects; plus `project.add` json-payload headings (small win, independent of Shortcuts). Task #27.
 
 Permanently out of reach (documented + guarded, revisit per Things release): repeat creation/rule-editing; checklist granular writes.

--- a/src/cli/commands/reads.ts
+++ b/src/cli/commands/reads.ts
@@ -92,14 +92,14 @@ export function registerReadCommands(program: Command): void {
   const listCommands: Array<{
     name: string;
     description: string;
-    fetch: (client: ThingsClient) => unknown;
+    fetch: (client: ThingsClient, tag?: string) => unknown;
     render?: (data: never) => string[];
   }> = [
     {
       name: "today",
       description:
         "The Today list, split into Today and This Evening (evening expires daily), with the sidebar badge split (red = deadline due/overdue)",
-      fetch: (c) => c.read.today(),
+      fetch: (c, tag) => c.read.today(tag === undefined ? undefined : { tag }),
       render: (data: {
         today: ListItem[];
         evening: ListItem[];
@@ -116,7 +116,7 @@ export function registerReadCommands(program: Command): void {
       name: "anytime",
       description:
         "All active items, mirroring the UI: Today members are starred (★), unscheduled items are not",
-      fetch: (c) => c.read.anytime(),
+      fetch: (c, tag) => c.read.anytime(tag === undefined ? undefined : { tag }),
       render: (items: ListItem[]) =>
         items.length === 0
           ? ["(empty)"]
@@ -126,12 +126,12 @@ export function registerReadCommands(program: Command): void {
       name: "upcoming",
       description:
         "Future-scheduled items grouped chronologically (repeating occurrences not yet included)",
-      fetch: (c) => c.read.upcoming(),
+      fetch: (c, tag) => c.read.upcoming(tag === undefined ? undefined : { tag }),
     },
     {
       name: "someday",
       description: "Someday items (incubated, undated)",
-      fetch: (c) => c.read.someday(),
+      fetch: (c, tag) => c.read.someday(tag === undefined ? undefined : { tag }),
     },
   ];
 
@@ -139,10 +139,19 @@ export function registerReadCommands(program: Command): void {
     program
       .command(cmd.name)
       .description(cmd.description)
+      .option(
+        "--tag <ref>",
+        "filter by tag (uuid or unique name), direct OR inherited (UI semantics)",
+      )
       .option("--json", "emit versioned JSON envelope on stdout")
       .option("--db <path>", "explicit database path")
-      .action((opts: GlobalReadOpts) => {
-        withClient(opts, cmd.name, cmd.fetch, (cmd.render ?? renderList) as (d: never) => string[]);
+      .action((opts: GlobalReadOpts & { tag?: string }) => {
+        withClient(
+          opts,
+          cmd.name,
+          (c) => cmd.fetch(c, opts.tag),
+          (cmd.render ?? renderList) as (d: never) => string[],
+        );
       });
   }
 
@@ -150,13 +159,14 @@ export function registerReadCommands(program: Command): void {
     {
       name: "logbook",
       description: "Completed and canceled items, most recent first",
-      fetch: (c: ThingsClient, limit: number) => c.read.logbook({ limit }),
+      fetch: (c: ThingsClient, limit: number, tag?: string) =>
+        c.read.logbook({ limit, ...(tag !== undefined && { tag }) }),
       defaultLimit: 100,
     },
     {
       name: "trash",
       description: "Trashed items (trashed=1 flag, any status), most recently modified first",
-      fetch: (c: ThingsClient, limit: number) => c.read.trash({ limit }),
+      fetch: (c: ThingsClient, limit: number, _tag?: string) => c.read.trash({ limit }),
       defaultLimit: 200,
     },
   ]) {
@@ -164,13 +174,17 @@ export function registerReadCommands(program: Command): void {
       .command(cmd.name)
       .description(cmd.description)
       .option("--limit <n>", "maximum items to return", String(cmd.defaultLimit))
+      .option(
+        "--tag <ref>",
+        "filter by tag (uuid or unique name), direct OR inherited — logbook only",
+      )
       .option("--json", "emit versioned JSON envelope on stdout")
       .option("--db <path>", "explicit database path")
-      .action((opts: GlobalReadOpts & { limit: string }) => {
+      .action((opts: GlobalReadOpts & { limit: string; tag?: string }) => {
         withClient(
           opts,
           cmd.name,
-          (c) => cmd.fetch(c, Number(opts.limit)),
+          (c) => cmd.fetch(c, Number(opts.limit), opts.tag),
           renderList as (d: never) => string[],
         );
       });

--- a/src/client.ts
+++ b/src/client.ts
@@ -27,6 +27,7 @@ import {
   upcomingView,
   type ListItem,
   type TodayView,
+  type ViewFilter,
 } from "./read/views.ts";
 import type {
   AreaAddParams,
@@ -78,12 +79,12 @@ export interface ThingsClient {
   config: ThingsApiConfig;
   fingerprint(): FingerprintStatus;
   read: {
-    today(): TodayView;
-    inbox(): ListItem[];
-    anytime(): ListItem[];
-    upcoming(): ListItem[];
-    someday(): ListItem[];
-    logbook(options?: { limit?: number }): ListItem[];
+    today(filter?: ViewFilter): TodayView;
+    inbox(filter?: ViewFilter): ListItem[];
+    anytime(filter?: ViewFilter): ListItem[];
+    upcoming(filter?: ViewFilter): ListItem[];
+    someday(filter?: ViewFilter): ListItem[];
+    logbook(options?: { limit?: number; tag?: string }): ListItem[];
     trash(options?: { limit?: number }): ListItem[];
     projects(options?: { areaUuid?: string }): Project[];
     projectView(uuid: string): ProjectView;
@@ -216,11 +217,11 @@ export function openThings(options: OpenOptions = {}): ThingsClient {
     config,
     fingerprint,
     read: {
-      today: () => todayView(conn.db, now()),
-      inbox: () => inboxView(conn.db),
-      anytime: () => anytimeView(conn.db, now()),
-      upcoming: () => upcomingView(conn.db, now()),
-      someday: () => somedayView(conn.db),
+      today: (f) => todayView(conn.db, now(), f),
+      inbox: (f) => inboxView(conn.db, f),
+      anytime: (f) => anytimeView(conn.db, now(), f),
+      upcoming: (f) => upcomingView(conn.db, now(), f),
+      someday: (f) => somedayView(conn.db, f),
       logbook: (o) => logbookView(conn.db, o),
       trash: (o) => trashView(conn.db, o),
       projects: (o) => projectsView(conn.db, o),

--- a/src/read/queries.ts
+++ b/src/read/queries.ts
@@ -11,6 +11,42 @@ import type { ChecklistRow, TaskRow } from "../model/mappers.ts";
 /** Rows that repeat via a template are normal; template rows are invisible in list views. */
 export const NOT_TEMPLATE = "(t.rt1_recurrenceRule IS NULL AND t.repeater IS NULL)";
 
+/**
+ * UI-faithful tag membership for list filtering: direct tag, or inherited
+ * through the ancestor chain heading → project → area (T18/U18/A13 — the
+ * same chain inheritedTagsFor() walks). Binds the tag uuid SIX times.
+ */
+export const TAG_SCOPE = `(
+  EXISTS (SELECT 1 FROM TMTaskTag tt WHERE tt.tasks = t.uuid AND tt.tags = ?)
+  OR EXISTS (SELECT 1 FROM TMTaskTag tt WHERE tt.tasks = t.project AND tt.tags = ?)
+  OR EXISTS (SELECT 1 FROM TMAreaTag at WHERE at.areas = t.area AND at.tags = ?)
+  OR EXISTS (SELECT 1 FROM TMTask p JOIN TMAreaTag at ON at.areas = p.area
+             WHERE p.uuid = t.project AND at.tags = ?)
+  OR EXISTS (SELECT 1 FROM TMTask h JOIN TMTaskTag tt ON tt.tasks = h.project
+             WHERE h.uuid = t.heading AND tt.tags = ?)
+  OR EXISTS (SELECT 1 FROM TMTask h JOIN TMTask p ON p.uuid = h.project
+             JOIN TMAreaTag at ON at.areas = p.area WHERE h.uuid = t.heading AND at.tags = ?)
+)`;
+
+export const TAG_SCOPE_BINDS = 6;
+
+/** Resolve a tag reference (uuid or unique case-insensitive title) — loud on miss. */
+export function resolveTagUuid(db: DatabaseSync, ref: string): string {
+  const byId = db.prepare("SELECT uuid FROM TMTag WHERE uuid = ?").get(ref) as
+    | { uuid: string }
+    | undefined;
+  if (byId !== undefined) return byId.uuid;
+  const rows = db.prepare("SELECT uuid FROM TMTag WHERE title = ? COLLATE NOCASE").all(ref) as {
+    uuid: string;
+  }[];
+  if (rows.length === 1 && rows[0] !== undefined) return rows[0].uuid;
+  throw new RangeError(
+    rows.length === 0
+      ? `tag not found: ${ref} (list tags with \`things tags\`)`
+      : `tag reference is ambiguous: ${ref} (${rows.length} matches — use the uuid)`,
+  );
+}
+
 export function fetchTaskRows(db: DatabaseSync, where: string, params: unknown[] = []): TaskRow[] {
   const sql = `SELECT ${selectList("TMTask")
     .split(", ")

--- a/src/read/views.ts
+++ b/src/read/views.ts
@@ -34,9 +34,32 @@ import type { DatabaseSync } from "node:sqlite";
 import { encodePackedDate, localToday } from "../model/dates.ts";
 import type { Project, Todo } from "../model/entities.ts";
 import { mapProject, mapTodo, type TaskRow } from "../model/mappers.ts";
-import { fetchTagsForTasks, fetchTaskRows, makeRefResolver, NOT_TEMPLATE } from "./queries.ts";
+import {
+  fetchTagsForTasks,
+  fetchTaskRows,
+  makeRefResolver,
+  NOT_TEMPLATE,
+  resolveTagUuid,
+  TAG_SCOPE,
+  TAG_SCOPE_BINDS,
+} from "./queries.ts";
 
 export type ListItem = Todo | Project;
+
+/** Optional list-view filters. */
+export interface ViewFilter {
+  /** Tag (uuid or unique title): direct OR inherited membership (UI semantics). */
+  tag?: string;
+}
+
+function tagFilter(
+  db: DatabaseSync,
+  filter: ViewFilter | undefined,
+): { sql: string; binds: string[] } {
+  if (filter?.tag === undefined) return { sql: "", binds: [] };
+  const uuid = resolveTagUuid(db, filter.tag);
+  return { sql: ` AND ${TAG_SCOPE}`, binds: Array.from({ length: TAG_SCOPE_BINDS }, () => uuid) };
+}
 
 const LIVE = `t.type IN (0, 1) AND t.trashed = 0 AND ${NOT_TEMPLATE}`;
 const OPEN = `${LIVE} AND t.status = 0`;
@@ -61,14 +84,15 @@ export interface TodayView {
   badge: { dueOrOverdue: number; other: number };
 }
 
-export function todayView(db: DatabaseSync, now?: Date): TodayView {
+export function todayView(db: DatabaseSync, now?: Date, filter?: ViewFilter): TodayView {
   const todayIso = localToday(now);
   const packedToday = encodePackedDate(todayIso);
+  const tf = tagFilter(db, filter);
   const rows = fetchTaskRows(
     db,
-    `${OPEN} AND t.startDate IS NOT NULL AND t.startDate <= ? AND t.start IN (1, 2)
+    `${OPEN} AND t.startDate IS NOT NULL AND t.startDate <= ? AND t.start IN (1, 2)${tf.sql}
      ORDER BY t.startBucket ASC, t.todayIndex ASC`,
-    [packedToday],
+    [packedToday, ...tf.binds],
   );
   const items = materialize(db, rows);
   // Evening membership expires daily: raw startBucket=1 counts only while
@@ -82,13 +106,19 @@ export function todayView(db: DatabaseSync, now?: Date): TodayView {
   };
 }
 
-export function inboxView(db: DatabaseSync): ListItem[] {
-  const rows = fetchTaskRows(db, `${OPEN} AND t.start = 0 ORDER BY t."index" ASC`);
+export function inboxView(db: DatabaseSync, filter?: ViewFilter): ListItem[] {
+  const tf = tagFilter(db, filter);
+  const rows = fetchTaskRows(
+    db,
+    `${OPEN} AND t.start = 0${tf.sql} ORDER BY t."index" ASC`,
+    tf.binds,
+  );
   return materialize(db, rows);
 }
 
-export function anytimeView(db: DatabaseSync, now?: Date): ListItem[] {
+export function anytimeView(db: DatabaseSync, now?: Date, filter?: ViewFilter): ListItem[] {
   const packedToday = encodePackedDate(localToday(now));
+  const tf = tagFilter(db, filter);
   // Mirrors UI membership: every active item, including Today members
   // (starred in the UI) and pending-promotion rows (start=2, past-dated).
   const rows = fetchTaskRows(
@@ -96,8 +126,8 @@ export function anytimeView(db: DatabaseSync, now?: Date): ListItem[] {
     `${OPEN} AND (
        (t.start = 1 AND (t.startDate IS NULL OR t.startDate <= ?))
        OR (t.start = 2 AND t.startDate IS NOT NULL AND t.startDate <= ?)
-     ) ORDER BY t."index" ASC`,
-    [packedToday, packedToday],
+     )${tf.sql} ORDER BY t."index" ASC`,
+    [packedToday, packedToday, ...tf.binds],
   );
   return materialize(db, rows);
 }
@@ -107,31 +137,38 @@ export function isTodayMember(item: ListItem, now?: Date): boolean {
   return item.startDate !== null && item.startDate <= localToday(now);
 }
 
-export function upcomingView(db: DatabaseSync, now?: Date): ListItem[] {
+export function upcomingView(db: DatabaseSync, now?: Date, filter?: ViewFilter): ListItem[] {
   const packedToday = encodePackedDate(localToday(now));
+  const tf = tagFilter(db, filter);
   const rows = fetchTaskRows(
     db,
-    `${OPEN} AND t.start = 2 AND t.startDate IS NOT NULL AND t.startDate > ?
+    `${OPEN} AND t.start = 2 AND t.startDate IS NOT NULL AND t.startDate > ?${tf.sql}
      ORDER BY t.startDate ASC, t."index" ASC`,
-    [packedToday],
+    [packedToday, ...tf.binds],
   );
   return materialize(db, rows);
 }
 
-export function somedayView(db: DatabaseSync): ListItem[] {
+export function somedayView(db: DatabaseSync, filter?: ViewFilter): ListItem[] {
+  const tf = tagFilter(db, filter);
   const rows = fetchTaskRows(
     db,
-    `${OPEN} AND t.start = 2 AND t.startDate IS NULL ORDER BY t."index" ASC`,
+    `${OPEN} AND t.start = 2 AND t.startDate IS NULL${tf.sql} ORDER BY t."index" ASC`,
+    tf.binds,
   );
   return materialize(db, rows);
 }
 
-export function logbookView(db: DatabaseSync, options?: { limit?: number }): ListItem[] {
+export function logbookView(
+  db: DatabaseSync,
+  options?: { limit?: number; tag?: string },
+): ListItem[] {
   const limit = options?.limit ?? 100;
+  const tf = tagFilter(db, options);
   const rows = fetchTaskRows(
     db,
-    `${LIVE} AND t.status IN (2, 3) ORDER BY t.stopDate DESC LIMIT ?`,
-    [limit],
+    `${LIVE} AND t.status IN (2, 3)${tf.sql} ORDER BY t.stopDate DESC LIMIT ?`,
+    [...tf.binds, limit],
   );
   return materialize(db, rows);
 }

--- a/test/unit/views.test.ts
+++ b/test/unit/views.test.ts
@@ -183,3 +183,54 @@ describe("inherited tags", () => {
     expect(inherited.map((t) => t.title).sort()).toEqual(["area-tag", "proj-tag"]);
   });
 });
+
+describe("tag-filtered list views (Phase 10)", () => {
+  function seedTagChain() {
+    fx = buildFixtureDb();
+    const tag = seedTag(fx.db, "focus");
+    const area = seedArea(fx.db, "Work");
+    tagArea(fx.db, area, tag);
+    const proj = seedProject(fx.db, { title: "P", area, startDate: "2026-07-02" });
+    const heading = seedHeading(fx.db, { title: "H", project: proj });
+    // Membership through every hop of the inheritance chain:
+    const direct = seedTodo(fx.db, { title: "direct", startDate: "2026-07-02" });
+    tagTask(fx.db, direct, tag);
+    seedTodo(fx.db, { title: "via-project", project: proj, startDate: "2026-07-02" });
+    seedTodo(fx.db, { title: "via-area", area, startDate: "2026-07-02" });
+    seedTodo(fx.db, { title: "via-heading", heading, startDate: "2026-07-02" });
+    seedTodo(fx.db, { title: "unrelated", startDate: "2026-07-02" });
+    return { tag };
+  }
+
+  it("today: matches direct + inherited through project/area/heading, excludes the rest", () => {
+    seedTagChain();
+    const view = todayView(fx.db, NOW, { tag: "focus" });
+    const titles = [...view.today, ...view.evening].map((i) => i.title).toSorted();
+    // "P" itself is area-tagged too (projects are list items in Today).
+    expect(titles).toEqual(["P", "direct", "via-area", "via-heading", "via-project"]);
+  });
+
+  it("resolves by uuid too, and unfiltered views are unchanged", () => {
+    const { tag } = seedTagChain();
+    const byUuid = todayView(fx.db, NOW, { tag });
+    expect(byUuid.today.map((i) => i.title)).toContain("direct");
+    expect(todayView(fx.db, NOW).today.map((i) => i.title)).toContain("unrelated");
+  });
+
+  it("throws loudly on unknown or ambiguous tag references", () => {
+    seedTagChain();
+    expect(() => todayView(fx.db, NOW, { tag: "nope" })).toThrow(/tag not found/);
+    seedTag(fx.db, "focus"); // duplicate title
+    expect(() => todayView(fx.db, NOW, { tag: "focus" })).toThrow(/ambiguous/);
+  });
+
+  it("filters anytime/someday/logbook the same way", () => {
+    seedTagChain();
+    seedTodo(fx.db, { title: "done-tagged", status: "completed", stopDate: 1_780_000_100 });
+    expect(anytimeView(fx.db, NOW, { tag: "focus" }).map((i) => i.title)).not.toContain(
+      "unrelated",
+    );
+    expect(somedayView(fx.db, { tag: "focus" })).toEqual([]);
+    expect(logbookView(fx.db, { tag: "focus" }).map((i) => i.title)).not.toContain("done-tagged");
+  });
+});


### PR DESCRIPTION
Closes the read-layer tag-filter gap from docs/gaps.md.

- `--tag <ref>` (uuid or unique name) on `today` / `inbox` / `anytime` / `upcoming` / `someday` / `logbook`.
- Matches **direct tags OR inherited membership** through the heading → project → area chain — the same chain `inheritedTagsFor()` walks (T18/U18/A13), expressed as a single SQL `EXISTS` predicate so list queries stay one-pass.
- Loud resolution: unknown or ambiguous tag references throw with remediation (`things tags`), never a silently-empty result.
- Documented non-goal (unvalidated): tag-HIERARCHY descendant matching (UI filtering by a parent tag matches child-tagged items) — candidate for a future probe.
- Bonus: corrected a stale gap-register entry — checklist per-item state was already fully readable via `byUuid` (TMChecklistItem.status).

Remaining Phase 10b items (Today ordering fidelity, upcoming repeat occurrences) are research-heavy and tracked separately.

161 tests passing (4 new covering every inheritance hop, uuid refs, loud failures, cross-view filtering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)