### PR TITLE
Phase 12a: search ergonomics + tag-hierarchy descendants

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A typical mutation flow:
 
 ```sh
 things capabilities --op todo.move --json      # is it possible, which vector, what tier?
-things search "Buy milk" --json                # resolve the uuid
+things search "Buy milk" --json                # resolve the uuid (open items; scope with --project/--area/--tag, widen with --logged/--trashed/--all)
 things todo move <uuid> --project "Errands" --dry-run --json   # inspect the plan
 things todo move <uuid> --project "Errands" --json             # execute, verified
 ```

--- a/src/cli/commands/reads.ts
+++ b/src/cli/commands/reads.ts
@@ -237,10 +237,43 @@ export function registerReadCommands(program: Command): void {
 
   program
     .command("search <query>")
-    .description("Title/notes substring search across all items (most recently modified first)")
+    .description(
+      "Title/notes substring search, most recently modified first. Default scope: OPEN + " +
+        "untrashed items only — widen with --logged / --trashed / --all. Scope with " +
+        "--project / --area / --tag (tag matches include hierarchy descendants) / --type.",
+    )
+    .option("--project <ref>", "restrict to one project's children (uuid or unique name)")
+    .option("--area <ref>", "restrict to one area's direct members (uuid or unique name)")
+    .option("--tag <ref>", "restrict by tag: direct, inherited, or descendant-tagged")
+    .option("--type <kind>", "todo | project")
+    .option("--logged", "include completed/canceled items")
+    .option("--trashed", "include trashed items")
+    .option("--all", "legacy behavior: everything (open + logged + trashed)")
+    .option("--limit <n>", "maximum results", "50")
     .option("--json", "emit versioned JSON envelope on stdout")
     .option("--db <path>", "explicit database path")
-    .action((query: string, opts: GlobalReadOpts) => {
-      withClient(opts, "search", (c) => c.read.search(query), renderList as (d: never) => string[]);
+    .action((query: string, opts: GlobalReadOpts & Record<string, unknown>) => {
+      const type = opts["type"] as string | undefined;
+      if (type !== undefined && type !== "todo" && type !== "project") {
+        process.stderr.write("error: --type must be todo or project\n");
+        process.exitCode = 2;
+        return;
+      }
+      withClient(
+        opts,
+        "search",
+        (c) =>
+          c.read.search(query, {
+            limit: Number(opts["limit"] ?? 50),
+            ...(opts["project"] !== undefined && { project: opts["project"] as string }),
+            ...(opts["area"] !== undefined && { area: opts["area"] as string }),
+            ...(opts["tag"] !== undefined && { tag: opts["tag"] as string }),
+            ...(type !== undefined && { type: type === "todo" ? "to-do" : "project" }),
+            ...(opts["logged"] === true && { logged: true }),
+            ...(opts["trashed"] === true && { trashed: true }),
+            ...(opts["all"] === true && { all: true }),
+          }),
+        renderList as (d: never) => string[],
+      );
     });
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -26,6 +26,7 @@ import {
   trashView,
   upcomingView,
   type ListItem,
+  type SearchOptions,
   type TodayView,
   type UpcomingFilter,
   type ViewFilter,
@@ -91,7 +92,7 @@ export interface ThingsClient {
     projectView(uuid: string): ProjectView;
     areas(): Area[];
     tags(): Tag[];
-    search(query: string, options?: { limit?: number }): ListItem[];
+    search(query: string, options?: SearchOptions): ListItem[];
     byUuid(uuid: string): AnyTask | null;
     snapshot(): Snapshot;
   };

--- a/src/read/queries.ts
+++ b/src/read/queries.ts
@@ -14,21 +14,47 @@ export const NOT_TEMPLATE = "(t.rt1_recurrenceRule IS NULL AND t.repeater IS NUL
 /**
  * UI-faithful tag membership for list filtering: direct tag, or inherited
  * through the ancestor chain heading → project → area (T18/U18/A13 — the
- * same chain inheritedTagsFor() walks). Binds the tag uuid SIX times.
+ * same chain inheritedTagsFor() walks). Takes a SET of tag uuids (the target
+ * plus its hierarchy descendants) — each of the six clauses gets the full
+ * set, so callers bind `uuids.length * 6` values via tagScopeBinds().
  */
-export const TAG_SCOPE = `(
-  EXISTS (SELECT 1 FROM TMTaskTag tt WHERE tt.tasks = t.uuid AND tt.tags = ?)
-  OR EXISTS (SELECT 1 FROM TMTaskTag tt WHERE tt.tasks = t.project AND tt.tags = ?)
-  OR EXISTS (SELECT 1 FROM TMAreaTag at WHERE at.areas = t.area AND at.tags = ?)
+export function tagScopeSql(uuidCount: number): string {
+  const set = `(${Array.from({ length: uuidCount }, () => "?").join(", ")})`;
+  return `(
+  EXISTS (SELECT 1 FROM TMTaskTag tt WHERE tt.tasks = t.uuid AND tt.tags IN ${set})
+  OR EXISTS (SELECT 1 FROM TMTaskTag tt WHERE tt.tasks = t.project AND tt.tags IN ${set})
+  OR EXISTS (SELECT 1 FROM TMAreaTag at WHERE at.areas = t.area AND at.tags IN ${set})
   OR EXISTS (SELECT 1 FROM TMTask p JOIN TMAreaTag at ON at.areas = p.area
-             WHERE p.uuid = t.project AND at.tags = ?)
+             WHERE p.uuid = t.project AND at.tags IN ${set})
   OR EXISTS (SELECT 1 FROM TMTask h JOIN TMTaskTag tt ON tt.tasks = h.project
-             WHERE h.uuid = t.heading AND tt.tags = ?)
+             WHERE h.uuid = t.heading AND tt.tags IN ${set})
   OR EXISTS (SELECT 1 FROM TMTask h JOIN TMTask p ON p.uuid = h.project
-             JOIN TMAreaTag at ON at.areas = p.area WHERE h.uuid = t.heading AND at.tags = ?)
+             JOIN TMAreaTag at ON at.areas = p.area WHERE h.uuid = t.heading AND at.tags IN ${set})
 )`;
+}
 
-export const TAG_SCOPE_BINDS = 6;
+export function tagScopeBinds(uuids: string[]): string[] {
+  return Array.from({ length: 6 }, () => uuids).flat();
+}
+
+/**
+ * A tag plus every hierarchy descendant. Filtering by a parent tag matches
+ * child-tagged items — DOCUMENTED app behavior (the UI's tag filter works
+ * this way), not lab-oracled: the UI's filter clicks aren't automatable.
+ * UNION (not UNION ALL): dedupes, so a parent cycle in TMTag data can't
+ * recurse forever.
+ */
+export function tagWithDescendants(db: DatabaseSync, uuid: string): string[] {
+  const rows = db
+    .prepare(
+      `WITH RECURSIVE d(uuid) AS (
+         SELECT ? UNION
+         SELECT tg.uuid FROM TMTag tg JOIN d ON tg.parent = d.uuid
+       ) SELECT uuid FROM d`,
+    )
+    .all(uuid) as { uuid: string }[];
+  return rows.map((r) => r.uuid);
+}
 
 /** Resolve a tag reference (uuid or unique case-insensitive title) — loud on miss. */
 export function resolveTagUuid(db: DatabaseSync, ref: string): string {
@@ -44,6 +70,40 @@ export function resolveTagUuid(db: DatabaseSync, ref: string): string {
     rows.length === 0
       ? `tag not found: ${ref} (list tags with \`things tags\`)`
       : `tag reference is ambiguous: ${ref} (${rows.length} matches — use the uuid)`,
+  );
+}
+
+/** Resolve a project reference (uuid or unique case-insensitive title) — loud on miss. */
+export function resolveProjectUuid(db: DatabaseSync, ref: string): string {
+  const byId = db
+    .prepare("SELECT uuid FROM TMTask WHERE uuid = ? AND type = 1 AND trashed = 0")
+    .get(ref) as { uuid: string } | undefined;
+  if (byId !== undefined) return byId.uuid;
+  const rows = db
+    .prepare("SELECT uuid FROM TMTask WHERE title = ? COLLATE NOCASE AND type = 1 AND trashed = 0")
+    .all(ref) as { uuid: string }[];
+  if (rows.length === 1 && rows[0] !== undefined) return rows[0].uuid;
+  throw new RangeError(
+    rows.length === 0
+      ? `project not found: ${ref} (list projects with \`things projects\`)`
+      : `project reference is ambiguous: ${ref} (${rows.length} matches — use the uuid)`,
+  );
+}
+
+/** Resolve an area reference (uuid or unique case-insensitive title) — loud on miss. */
+export function resolveAreaUuid(db: DatabaseSync, ref: string): string {
+  const byId = db.prepare("SELECT uuid FROM TMArea WHERE uuid = ?").get(ref) as
+    | { uuid: string }
+    | undefined;
+  if (byId !== undefined) return byId.uuid;
+  const rows = db.prepare("SELECT uuid FROM TMArea WHERE title = ? COLLATE NOCASE").all(ref) as {
+    uuid: string;
+  }[];
+  if (rows.length === 1 && rows[0] !== undefined) return rows[0].uuid;
+  throw new RangeError(
+    rows.length === 0
+      ? `area not found: ${ref} (list areas with \`things areas\`)`
+      : `area reference is ambiguous: ${ref} (${rows.length} matches — use the uuid)`,
   );
 }
 

--- a/src/read/views.ts
+++ b/src/read/views.ts
@@ -48,16 +48,24 @@ import {
   fetchTaskRows,
   makeRefResolver,
   NOT_TEMPLATE,
+  resolveAreaUuid,
+  resolveProjectUuid,
   resolveTagUuid,
-  TAG_SCOPE,
-  TAG_SCOPE_BINDS,
+  tagScopeBinds,
+  tagScopeSql,
+  tagWithDescendants,
 } from "./queries.ts";
 
 export type ListItem = Todo | Project;
 
 /** Optional list-view filters. */
 export interface ViewFilter {
-  /** Tag (uuid or unique title): direct OR inherited membership (UI semantics). */
+  /**
+   * Tag (uuid or unique title): direct OR inherited membership (UI
+   * semantics), INCLUDING items tagged with a hierarchy descendant of the
+   * given tag (documented app behavior — the UI's tag filter matches
+   * child-tagged items; not lab-oracled).
+   */
   tag?: string;
 }
 
@@ -66,8 +74,8 @@ function tagFilter(
   filter: ViewFilter | undefined,
 ): { sql: string; binds: string[] } {
   if (filter?.tag === undefined) return { sql: "", binds: [] };
-  const uuid = resolveTagUuid(db, filter.tag);
-  return { sql: ` AND ${TAG_SCOPE}`, binds: Array.from({ length: TAG_SCOPE_BINDS }, () => uuid) };
+  const uuids = tagWithDescendants(db, resolveTagUuid(db, filter.tag));
+  return { sql: ` AND ${tagScopeSql(uuids.length)}`, binds: tagScopeBinds(uuids) };
 }
 
 const LIVE = `t.type IN (0, 1) AND t.trashed = 0 AND ${NOT_TEMPLATE}`;
@@ -263,18 +271,62 @@ export function projectsView(db: DatabaseSync, options?: { areaUuid?: string }):
   return materialize(db, rows) as Project[];
 }
 
-export function searchView(
-  db: DatabaseSync,
-  query: string,
-  options?: { limit?: number },
-): ListItem[] {
+export interface SearchOptions extends ViewFilter {
+  limit?: number;
+  /** Restrict to one project's children (headed children included). */
+  project?: string;
+  /** Restrict to one area's direct members. */
+  area?: string;
+  type?: "to-do" | "project";
+  /** Include completed/canceled items (default: open only). */
+  logged?: boolean;
+  /** Include trashed items (default: untrashed only). */
+  trashed?: boolean;
+  /** Everything — the legacy behavior (open + logged + trashed). */
+  all?: boolean;
+}
+
+export function searchView(db: DatabaseSync, query: string, options?: SearchOptions): ListItem[] {
   const limit = options?.limit ?? 50;
   const needle = `%${query}%`;
+  const where: string[] = [`${NOT_TEMPLATE} AND (t.title LIKE ? OR t.notes LIKE ?)`];
+  const binds: unknown[] = [needle, needle];
+
+  where.push(
+    options?.type === "to-do"
+      ? "t.type = 0"
+      : options?.type === "project"
+        ? "t.type = 1"
+        : "t.type IN (0, 1)",
+  );
+
+  // Scope: open + untrashed by default; --logged/--trashed widen; --all is
+  // the legacy include-everything behavior.
+  if (options?.all !== true) {
+    const statuses = options?.logged === true ? "(0, 2, 3)" : "(0)";
+    where.push(`t.status IN ${statuses}`);
+    if (options?.trashed !== true) where.push("t.trashed = 0");
+  }
+
+  if (options?.project !== undefined) {
+    const uuid = resolveProjectUuid(db, options.project);
+    // Children incl. headed ones (heading rows carry the project link).
+    where.push(
+      "(t.project = ? OR t.heading IN (SELECT uuid FROM TMTask WHERE type = 2 AND project = ?))",
+    );
+    binds.push(uuid, uuid);
+  }
+  if (options?.area !== undefined) {
+    const uuid = resolveAreaUuid(db, options.area);
+    where.push("t.area = ?");
+    binds.push(uuid);
+  }
+  const tf = tagFilter(db, options);
   const rows = fetchTaskRows(
     db,
-    `t.type IN (0, 1) AND ${NOT_TEMPLATE} AND (t.title LIKE ? OR t.notes LIKE ?)
+    `${where.join(" AND ")}${tf.sql}
      ORDER BY t.userModificationDate DESC LIMIT ?`,
-    [needle, needle, limit],
+    [...binds, ...tf.binds, limit],
   );
   return materialize(db, rows);
 }

--- a/test/cli/e2e.test.ts
+++ b/test/cli/e2e.test.ts
@@ -82,3 +82,40 @@ describe("cli end-to-end (fixture db)", () => {
     expect(envelope.error.code).toBe("environment");
   });
 });
+
+describe("cli search (Phase 12 ergonomics)", () => {
+  it("defaults to open+untrashed; --all restores the legacy scope", () => {
+    fx = buildFixtureDb();
+    seedTodo(fx.db, { title: "report draft" });
+    seedTodo(fx.db, { title: "report final", status: "completed" });
+    seedTodo(fx.db, { title: "report scrap", trashed: true });
+
+    const open = runCli(["search", "report", "--json", "--db", fx.path]);
+    expect(open.exitCode).toBe(0);
+    expect(JSON.parse(open.stdout).data.map((i: { title: string }) => i.title)).toEqual([
+      "report draft",
+    ]);
+
+    const all = runCli(["search", "report", "--all", "--json", "--db", fx.path]);
+    expect(JSON.parse(all.stdout).data).toHaveLength(3);
+
+    const logged = runCli(["search", "report", "--logged", "--json", "--db", fx.path]);
+    expect(JSON.parse(logged.stdout).data).toHaveLength(2);
+  });
+
+  it("--limit and --type narrow; unknown --tag fails loudly", () => {
+    fx = buildFixtureDb();
+    seedTodo(fx.db, { title: "alpha one" });
+    seedTodo(fx.db, { title: "alpha two" });
+
+    const limited = runCli(["search", "alpha", "--limit", "1", "--json", "--db", fx.path]);
+    expect(JSON.parse(limited.stdout).data).toHaveLength(1);
+
+    const typed = runCli(["search", "alpha", "--type", "project", "--json", "--db", fx.path]);
+    expect(JSON.parse(typed.stdout).data).toHaveLength(0);
+
+    const bad = runCli(["search", "alpha", "--tag", "nope", "--json", "--db", fx.path]);
+    expect(bad.exitCode).not.toBe(0);
+    expect(JSON.parse(bad.stdout).error.message).toMatch(/tag not found/);
+  });
+});

--- a/test/cli/help-contract.test.ts
+++ b/test/cli/help-contract.test.ts
@@ -121,6 +121,19 @@ describe("write-command help states the contract", () => {
     expect(tagHelp).toContain("unprobed");
   });
 
+  it("search: open-by-default scope, widening flags, scoping flags", () => {
+    const help = helpFor("search");
+    expect(help).toContain("OPEN + untrashed");
+    expect(help).toContain("--logged");
+    expect(help).toContain("--trashed");
+    expect(help).toContain("--all");
+    expect(help).toContain("--project <ref>");
+    expect(help).toContain("--area <ref>");
+    expect(help).toContain("--tag <ref>");
+    expect(help).toContain("descendant");
+    expect(help).toContain("--limit <n>");
+  });
+
   it("reorder: experimental gate, bounce cap, scope hazards", () => {
     const help = helpFor("reorder");
     expect(help).toContain("EXPERIMENTAL");

--- a/test/unit/views.test.ts
+++ b/test/unit/views.test.ts
@@ -8,6 +8,7 @@ import {
   inboxView,
   isTodayMember,
   logbookView,
+  searchView,
   somedayView,
   todayView,
   upcomingView,
@@ -305,5 +306,123 @@ describe("tag-filtered list views (Phase 10)", () => {
     );
     expect(somedayView(fx.db, { tag: "focus" })).toEqual([]);
     expect(logbookView(fx.db, { tag: "focus" }).map((i) => i.title)).not.toContain("done-tagged");
+  });
+});
+
+describe("tag-hierarchy descendants (Phase 12)", () => {
+  it("--tag parent matches child- and grandchild-tagged items (documented UI behavior)", () => {
+    fx = buildFixtureDb();
+    const parent = seedTag(fx.db, "errands");
+    const child = seedTag(fx.db, "groceries", parent);
+    const grandchild = seedTag(fx.db, "farmers-market", child);
+    const sibling = seedTag(fx.db, "calls"); // unrelated root
+
+    const direct = seedTodo(fx.db, { title: "direct", startDate: "2026-07-02" });
+    tagTask(fx.db, direct, parent);
+    const viaChild = seedTodo(fx.db, { title: "via-child", startDate: "2026-07-02" });
+    tagTask(fx.db, viaChild, child);
+    const viaGrandchild = seedTodo(fx.db, { title: "via-grandchild", startDate: "2026-07-02" });
+    tagTask(fx.db, viaGrandchild, grandchild);
+    const unrelated = seedTodo(fx.db, { title: "unrelated", startDate: "2026-07-02" });
+    tagTask(fx.db, unrelated, sibling);
+
+    const titles = todayView(fx.db, NOW, { tag: "errands" })
+      .today.map((i) => i.title)
+      .toSorted();
+    expect(titles).toEqual(["direct", "via-child", "via-grandchild"]);
+    // Filtering by the CHILD does not match parent-tagged items (downward only).
+    expect(
+      todayView(fx.db, NOW, { tag: "groceries" })
+        .today.map((i) => i.title)
+        .toSorted(),
+    ).toEqual(["via-child", "via-grandchild"]);
+  });
+});
+
+describe("searchView (Phase 12 ergonomics)", () => {
+  function seedSearchWorld() {
+    fx = buildFixtureDb();
+    const area = seedArea(fx.db, "Work");
+    const proj = seedProject(fx.db, { title: "Widget launch", area });
+    const heading = seedHeading(fx.db, { title: "H", project: proj });
+    const tag = seedTag(fx.db, "focus");
+    const open1 = seedTodo(fx.db, { title: "widget spec", project: proj });
+    seedTodo(fx.db, { title: "widget kickoff", heading }); // headed child of proj
+    seedTodo(fx.db, { title: "widget for home", area });
+    const done = seedTodo(fx.db, { title: "widget retro", status: "completed" });
+    seedTodo(fx.db, { title: "widget scrap", trashed: true });
+    seedTodo(fx.db, { title: "unrelated note", notes: "mentions widget here" });
+    seedTodo(fx.db, { title: "widget template", recurrenceRule: true });
+    tagTask(fx.db, open1, tag);
+    return { proj, area, done };
+  }
+
+  it("defaults to OPEN + untrashed; notes match; templates excluded", () => {
+    seedSearchWorld();
+    const titles = searchView(fx.db, "widget")
+      .map((i) => i.title)
+      .toSorted();
+    expect(titles).toEqual([
+      "Widget launch",
+      "unrelated note",
+      "widget for home",
+      "widget kickoff",
+      "widget spec",
+    ]);
+  });
+
+  it("--logged / --trashed / --all widen the scope", () => {
+    seedSearchWorld();
+    expect(searchView(fx.db, "widget", { logged: true }).map((i) => i.title)).toContain(
+      "widget retro",
+    );
+    expect(searchView(fx.db, "widget", { trashed: true }).map((i) => i.title)).toContain(
+      "widget scrap",
+    );
+    const all = searchView(fx.db, "widget", { all: true }).map((i) => i.title);
+    expect(all).toContain("widget retro");
+    expect(all).toContain("widget scrap");
+  });
+
+  it("scopes by project (headed children included), area, tag, and type", () => {
+    const { proj, area } = seedSearchWorld();
+    expect(
+      searchView(fx.db, "widget", { project: proj })
+        .map((i) => i.title)
+        .toSorted(),
+    ).toEqual(["widget kickoff", "widget spec"]);
+    expect(searchView(fx.db, "widget", { project: "Widget launch" })).toHaveLength(2);
+    expect(
+      searchView(fx.db, "widget", { area })
+        .map((i) => i.title)
+        .toSorted(),
+    ).toEqual(["Widget launch", "widget for home"]);
+    expect(searchView(fx.db, "widget", { tag: "focus" }).map((i) => i.title)).toEqual([
+      "widget spec",
+    ]);
+    expect(searchView(fx.db, "widget", { type: "project" }).map((i) => i.title)).toEqual([
+      "Widget launch",
+    ]);
+  });
+
+  it("honors --limit and fails loudly on unknown refs", () => {
+    seedSearchWorld();
+    expect(searchView(fx.db, "widget", { limit: 2 })).toHaveLength(2);
+    expect(() => searchView(fx.db, "widget", { project: "nope" })).toThrow(/project not found/);
+    expect(() => searchView(fx.db, "widget", { area: "nope" })).toThrow(/area not found/);
+    expect(() => searchView(fx.db, "widget", { tag: "nope" })).toThrow(/tag not found/);
+  });
+});
+
+describe("tag descendant closure safety", () => {
+  it("terminates on a parent CYCLE in tag data (UNION dedupe)", () => {
+    fx = buildFixtureDb();
+    const a = seedTag(fx.db, "cycle-a");
+    const b = seedTag(fx.db, "cycle-b", a);
+    fx.db.prepare("UPDATE TMTag SET parent = ? WHERE uuid = ?").run(b, a); // a↔b cycle
+    const item = seedTodo(fx.db, { title: "cycled", startDate: "2026-07-02" });
+    tagTask(fx.db, item, b);
+    const view = todayView(fx.db, NOW, { tag: "cycle-a" });
+    expect(view.today.map((i) => i.title)).toEqual(["cycled"]);
   });
 });


### PR DESCRIPTION
First half of the GTD-polish batch (approved plan: rippling-jumping-pearl).

## Search, made useful for agents

- **Default scope is now OPEN + untrashed** — the previous behavior mixed trashed/completed/canceled rows into every result with no way to exclude them. `--logged` and `--trashed` widen; `--all` restores the legacy everything scope.
- **Scoping**: `--project <ref>` (children incl. headed ones), `--area <ref>`, `--tag <ref>`, `--type todo|project`, plus `--limit` finally exposed.
- Unknown project/area/tag refs **fail loudly** with remediation — never a silently-empty result.
- First-ever test coverage for search: unit (scope defaults, every flag, loud failures), CLI e2e, help-contract locks.

## Tag filters now match hierarchy descendants

`--tag errands` matches items tagged with any descendant of *errands* across every list view and search — **documented app behavior** (the UI's tag filter works this way), explicitly *not* lab-oracled since UI filter clicks aren't automatable. Implemented as a recursive-CTE closure feeding a set-based rework of the tag-scope predicate.

**Live-data catch**: the first CTE used `UNION ALL`, which recurses forever if tag data ever contains a parent cycle — it hung against the real library on first contact. Fixed with `UNION` (dedupe = guaranteed termination) and regression-tested with a seeded a↔b cycle.

## Notes

178 tests passing. The prod read-only sanity pass is deferred — the live DB stopped accepting new connections mid-session (app busy or a pending sandbox grant); the logic is fully covered by fixtures and can be spot-checked live post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)