### PR TITLE
Phase 12b: dated reminders + template-duplication verdict

### DIFF
--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -12,11 +12,12 @@ Living register of Things-app capabilities that are missing, thin, or janky in t
 
 ### 2. Repeating items — creation and rule-editing are UI-only, permanently (until CC ships an API)
 - No surface creates a repeating item or edits a repeat rule: URL crashes on schedule-writes (the bug report), AppleScript refuses (error 302), Shortcuts actions expose no repeat parameters, and the rule plist must never be written directly.
+- The clone-and-rename workaround is DISPROVEN (E13, 2026-07-05): `duplicate=true` on a template duplicates nothing and opens windows (tier 3) — oddity 5d.
 - What works: safe template edits (title/notes/checklist — U12B/T12), full editing of spawned instances (guards only block templates), reading rule presence + config via the private `json` property (A51).
 - **Path:** none. Document; guard (done); revisit per Things release.
 
-### 3. Reminders (time-of-day) — SHIPPED 2026-07-04 (Phase 9b)
-- `--reminder HH:mm` on todo add/update (when today|evening only — H-REMINDER-SCOPE), auto-preserve on re-schedule, `--clear-reminder`; codec-verified read-after-write; e2e-validated. Remaining edge: reminders on date-scheduled items (`when=2026-07-08@time`) unprobed — guard rejects.
+### 3. Reminders (time-of-day) — SHIPPED (Phase 9b + 12b)
+- `--reminder HH:mm` on todo add/update with when today|evening|YYYY-MM-DD (R17/R18); auto-preserve on re-schedule; `--clear-reminder` on today|evening. **Dated reminders are STICKY** (R20/R21): no URL clear path exists — the guard rejects `--clear-reminder` on dated whens with the bounce-via-today remediation (oddity 2e). Bare-hour parser trap is today/evening-only (R19).
 
 ## Editing-completeness gaps — SHIPPED 2026-07-04 (Phase 9b: area update, tag update, notes append/prepend, move-to-inbox, todo duplicate; `log completed now` still unexposed — DB delta unclear, low value)
 

--- a/docs/lab/e-suite-results.md
+++ b/docs/lab/e-suite-results.md
@@ -15,6 +15,10 @@ Suite: [lab/suites/e-suite.json](../../lab/suites/e-suite.json) (10 probes, E01�
 | E09 | `update-project?when=<future date>` schedules a project: `start=2`, `startDate` set (firms up the thin U08 evidence) | supported |
 | E10 | `set keyboard shortcut of tag` works; TMTag.shortcut stores the raw character (`"9"`) | supported |
 
+## Template duplication (E13, Phase 12b)
+
+`duplicate=true` on a repeating TEMPLATE does **nothing to the data** (zero new rows; template untouched) and instead opens **new windows** (tier 3 disruption). The clone-and-rename path to de facto repeat creation is dead; repeat creation remains UI-only. Locked as `unsupported`/tier 3, quarantined last in the suite.
+
 ## Feed into Phase 9b
 
 New/extended operations, all tier 0 on already-validated vectors: `area.update` (rename — AppleScript), `tag.update` (rename/re-parent/shortcut — AppleScript), notes `append`/`prepend` modes on todo.update + project.update (URL), `todo.move` gains the Inbox destination (AppleScript), `todo.duplicate` (URL only), `project.update --when` now fully evidence-backed.

--- a/docs/lab/r-suite-results.md
+++ b/docs/lab/r-suite-results.md
@@ -28,6 +28,12 @@ Consequence: **10:xx / 11:xx AM are inexpressible without the `am` suffix** (no 
 - The private `json` AppleScript property exposes the reminder on read (R08).
 - **HAZARD (R09)**: `when=today@18:00` on a repeating template crashes Things exactly like the bare `when=` (U12 family, EXC_BREAKPOINT). H-REPEAT-SCHEDULE already blocks this path in the write layer; oddity 1 updated.
 
+## Dated reminders (R17–R21, Phase 12b)
+
+- Setting works on add AND update with `when=YYYY-MM-DD@time` (R17/R18, exact ints locked).
+- The bare-hour 12-hour "next upcoming" heuristic is **today/evening-only**: `2026-07-09@10:05` stores 10:05 EXACTLY (R19) — scopes oddity 2d to clock-relative keywords.
+- **Dated reminders are STICKY**: a bare `when=` does NOT clear them — neither same-date (R20) nor re-dated (R21; the reminder rides along to the new date). Asymmetric with today/evening, where a bare when= clears (R07). No URL clear path exists for dated reminders → H-REMINDER-SCOPE blocks `reminder:null` on dated whens with the re-schedule-via-today remediation. Filed as oddity 2e.
+
 ## Feed into Phase 9b
 
 Extend the `when` vocabulary with `{ when: "today", reminder: "18:00" }` (or `when: "today@18:00"` sugar), compile via the deterministic emitter, verify `reminderTime` with the codec; `reminder: null` compiles to the bare-when clear.

--- a/docs/things-app-oddities.md
+++ b/docs/things-app-oddities.md
@@ -65,7 +65,13 @@ On `add`, a `heading=` value that doesn't match an existing heading in the targe
 
 **Workaround** (what things-api's compiler does — every branch probe-verified): emit hours 0–9 zero-padded 24h (`06:45`), hours 10–11 with an explicit suffix (`10:05am`), hours 12–23 as literals (`14:10`). Never emit a bare 1–11 hour.
 
-**Evidence:** R-suite (`lab/suites/r-suite.json`, R01–R16), clean-room VM, Things 3.22.11 trial build, 2026-07-04; every probe locks the exact stored `reminderTime` int (packing: `hour<<26 | minute<<20`). Results: `docs/lab/r-suite-results.md`.
+**Scope note (2026-07-05):** the heuristic applies to the clock-relative keywords only — on a DATED schedule, `when=2026-07-09@10:05` stores **10:05 exactly** (R19). The trap is `when=today@…` / `when=evening@…`.
+
+**Evidence:** R-suite (`lab/suites/r-suite.json`, R01–R21), clean-room VM, Things 3.22.11 trial build, 2026-07-04/05; every probe locks the exact stored `reminderTime` int (packing: `hour<<26 | minute<<20`). Results: `docs/lab/r-suite-results.md`.
+
+### 2e. Reminder CLEAR semantics are asymmetric between keyword and dated schedules
+
+On `when=today` / `when=evening`, re-sending a bare `when=` (no `@time`) **clears** an existing reminder (R07). On a dated schedule it does NOT: `when=2026-07-09` on an item already dated 07-09 with a reminder leaves the reminder intact (R20), and re-dating to `when=2026-07-10` carries the reminder along to the new date (R21). Consequence: **there is no URL-scheme way to remove a reminder from a date-scheduled item** — a caller must bounce it through `when=today` (which clears) and re-date, or use the UI. Whichever behavior is intended, the keyword/date asymmetry is surprising; callers relying on the today/evening clear behavior silently fail on dates. Evidence: R07/R20/R21, 2026-07-05.
 
 ## 3. UI vs. URL behavioral divergence: project completion
 
@@ -100,7 +106,11 @@ Adding (or moving) an open to-do into a completed, canceled, or even already-log
 ### 5c. Checklist updates are replace-all and reset per-item state
 `checklist-items=` replaces the entire checklist; previously completed/canceled checklist items are recreated as open — even when re-sending an identical item list. There is no additive or patch form. *(T07/U07/U20)*
 
-### 5d. Repeating templates are invisible to AppleScript list reads but fetchable by id
+### 5d. `duplicate=true` on a repeating template: no-op on the data, but opens new windows
+
+The URL update command with `duplicate=true` works on plain to-dos (exact copy — E07). Aimed at a repeating TEMPLATE, it duplicates nothing (zero DB delta, template untouched) but the app opens **new windows** — a disruptive dead-end where either an error or a rule-carrying copy would be reasonable. Evidence: E13, 2026-07-05.
+
+### 5e. Repeating templates are invisible to AppleScript list reads but fetchable by id
 `to dos of list "Someday"` omits repeating templates entirely, yet `to do id "<template-uuid>"` returns them fine. Third-party tooling that enumerates lists (e.g. things.py) can't see repeat rules at all through official read surfaces. *(A12, T16)*
 
 ### 5e. `things:///version` launches and foregrounds the app, shows nothing

--- a/lab/guest/e2e-write-smoke.sh
+++ b/lab/guest/e2e-write-smoke.sh
@@ -92,7 +92,10 @@ run_step 0 "todo add with reminder (emitter: 10:05 -> 10:05am)" todo add "E2E-RE
 REM=$(json_get "d['data']['uuid']")
 run_step 0 "re-schedule preserves the reminder (auto-preserve)" todo update "$REM" --when evening
 run_step 0 "clear the reminder (bare when=)" todo update "$REM" --when evening --clear-reminder
-run_step 4 "reminder without when today|evening is blocked" todo update "$REM" --when 2026-07-08 --reminder 09:00
+run_step 0 "DATED reminder set (Phase 12b)" todo update "$REM" --when 2026-07-09 --reminder 15:00
+run_step 0 "dated re-schedule auto-preserves the reminder" todo update "$REM" --when 2026-07-10
+run_step 4 "clearing a DATED reminder is blocked (sticky, R20/R21)" todo update "$REM" --when 2026-07-10 --clear-reminder
+run_step 0 "re-schedule to today and clear (the documented path)" todo update "$REM" --when today --clear-reminder
 run_step 0 "append-notes (newline separator verified)" todo update "$REM" --append-notes "appended"
 run_step 0 "prepend-notes" todo update "$REM" --prepend-notes "prepended"
 run_step 0 "duplicate (url-only, copy discovered)" todo duplicate "$REM"

--- a/lab/suites/e-suite.json
+++ b/lab/suites/e-suite.json
@@ -464,6 +464,45 @@
           }
         ]
       }
+    },
+    {
+      "id": "E13",
+      "title": "duplicate=true on a REPEATING TEMPLATE does NOT duplicate — zero DB delta on the family, and the app opens NEW WINDOWS (tier 3). Clone-and-rename repeat creation is dead; regression lock.",
+      "vector": "url",
+      "operation": "todo.duplicate-template",
+      "appState": "running-background",
+      "group": "hazard",
+      "commands": [
+        {
+          "openUrl": "things:///update?id={seed:LAB-REPEAT-DAILY}&auth-token={ctx:token}&duplicate=true"
+        },
+        {
+          "sleep": 5
+        }
+      ],
+      "settleSeconds": 3,
+      "expect": {
+        "verdict": "unsupported",
+        "tier": 3,
+        "crash": false,
+        "assertions": [
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "uuid": "@seed:LAB-REPEAT-DAILY"
+            },
+            "fields": ["rt1_recurrenceRule", "start", "startDate", "status", "title"]
+          },
+          {
+            "kind": "notInserted",
+            "table": "TMTask",
+            "where": {
+              "title": "LAB-REPEAT-DAILY"
+            }
+          }
+        ]
+      }
     }
   ]
 }

--- a/lab/suites/r-suite.json
+++ b/lab/suites/r-suite.json
@@ -595,6 +595,222 @@
       }
     },
     {
+      "id": "R17",
+      "title": "DATED reminder on add: when=2026-07-09@15:00 — future-scheduled with a reminder (codec sample 15:00)",
+      "vector": "url",
+      "operation": "reminder.add-dated",
+      "appState": "running-background",
+      "commands": [
+        {
+          "openUrl": "things:///add?title=R-D1500&when=2026-07-09@15:00"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='R-D1500' AND startDate=132805760 AND reminderTime=1006632960"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "inserted",
+            "table": "TMTask",
+            "where": {
+              "title": "R-D1500"
+            }
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-D1500"
+            },
+            "field": "start",
+            "value": 2
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-D1500"
+            },
+            "field": "reminderTime",
+            "value": 1006632960
+          }
+        ]
+      }
+    },
+    {
+      "id": "R18",
+      "title": "DATED reminder on update: set 06:45 on an existing future-scheduled item (leading-zero branch on dates)",
+      "vector": "url",
+      "operation": "reminder.update-dated",
+      "appState": "running-background",
+      "setup": [
+        {
+          "openUrl": "things:///add?title=R-DUPD&when=2026-07-09"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='R-DUPD' AND startDate=132805760 AND reminderTime IS NULL"
+        }
+      ],
+      "commands": [
+        {
+          "openUrl": "things:///update?id={uuid:R-DUPD}&auth-token={ctx:token}&when=2026-07-09@06:45"
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTask WHERE title='R-DUPD' AND reminderTime=449839104"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-DUPD"
+            },
+            "field": "startDate",
+            "value": 132805760
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-DUPD"
+            },
+            "field": "reminderTime",
+            "value": 449839104
+          },
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTask",
+            "where": {
+              "title": "R-DUPD"
+            },
+            "fields": ["title", "status"]
+          }
+        ]
+      }
+    },
+    {
+      "id": "R19",
+      "title": "DATED bare-hour: 2026-07-09@10:05 stores 10:05 EXACTLY — the 12-hour next-upcoming heuristic is today/evening-only (clock-relative); scopes oddity 2d",
+      "vector": "url",
+      "operation": "reminder.add-dated-bare-hour",
+      "appState": "running-background",
+      "commands": [
+        {
+          "openUrl": "things:///add?title=R-D1005&when=2026-07-09@10:05"
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='R-D1005' AND reminderTime=676331520"
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "inserted",
+            "table": "TMTask",
+            "where": {
+              "title": "R-D1005"
+            }
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-D1005"
+            },
+            "field": "reminderTime",
+            "value": 676331520
+          }
+        ]
+      }
+    },
+    {
+      "id": "R20",
+      "title": "DATED bare when= does NOT clear the reminder (asymmetry with today/evening, where it DOES — R07); regression lock of the persistence",
+      "vector": "url",
+      "operation": "reminder.clear-dated-noop",
+      "appState": "running-background",
+      "commands": [
+        {
+          "openUrl": "things:///update?id={uuid:R-DUPD}&auth-token={ctx:token}&when=2026-07-09"
+        },
+        {
+          "sleep": 4
+        }
+      ],
+      "expect": {
+        "verdict": "unsupported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-DUPD"
+            },
+            "field": "reminderTime",
+            "value": 449839104
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-DUPD"
+            },
+            "field": "startDate",
+            "value": 132805760
+          }
+        ]
+      }
+    },
+    {
+      "id": "R21",
+      "title": "re-scheduling to a DIFFERENT bare date does NOT clear either — dated reminders are STICKY (ride along to the new date); no URL clear path exists for them",
+      "vector": "url",
+      "operation": "reminder.clear-dated-reschedule-noop",
+      "appState": "running-background",
+      "commands": [
+        {
+          "openUrl": "things:///update?id={uuid:R-DUPD}&auth-token={ctx:token}&when=2026-07-10"
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTask WHERE title='R-DUPD' AND startDate=132805888"
+        }
+      ],
+      "expect": {
+        "verdict": "unsupported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-DUPD"
+            },
+            "field": "startDate",
+            "value": 132805888
+          },
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": {
+              "title": "R-DUPD"
+            },
+            "field": "reminderTime",
+            "value": 449839104
+          }
+        ]
+      }
+    },
+    {
       "id": "R09",
       "title": "HAZARD: when=today@18:00 on a REPEATING TEMPLATE — expect the schedule-write crash (same family as U12); template untouched",
       "vector": "url",

--- a/src/cli/commands/writes.ts
+++ b/src/cli/commands/writes.ts
@@ -266,7 +266,7 @@ export function registerWriteCommands(program: Command): void {
       .option("--when <value>", "today | evening | anytime | someday | YYYY-MM-DD")
       .option(
         "--reminder <HH:mm>",
-        "time-of-day reminder (24h); requires --when today|evening (R-suite scope)",
+        "time-of-day reminder (24h); requires --when today|evening|YYYY-MM-DD",
       )
       .option("--deadline <date>", "YYYY-MM-DD")
       .option("--tags <list>", "comma-separated EXISTING tag names")
@@ -310,9 +310,10 @@ export function registerWriteCommands(program: Command): void {
         "Update title/notes/when/reminder/deadline (vector: url-scheme, tier 0). " +
           "Hazard: H-REPEAT-SCHEDULE — when/deadline on a repeating template is hard-blocked " +
           "(the URL write crashes Things); title/notes stay allowed. " +
-          "Reminders (H-REMINDER-SCOPE): --reminder needs --when today|evening; when " +
-          "re-scheduling WITHOUT --reminder an existing reminder is auto-preserved " +
-          "(a bare when= would silently clear it — R07); --clear-reminder clears explicitly. " +
+          "Reminders (H-REMINDER-SCOPE): --reminder needs --when today|evening|YYYY-MM-DD; " +
+          "when re-scheduling WITHOUT --reminder an existing reminder is auto-preserved. " +
+          "--clear-reminder clears on today|evening only — DATED reminders are sticky " +
+          "(no URL clear path, R20/R21). " +
           "--append-notes/--prepend-notes join with a newline (exclusive with --notes).",
       )
       .option("--title <text>", "new title")
@@ -320,8 +321,8 @@ export function registerWriteCommands(program: Command): void {
       .option("--append-notes <text>", "append to existing notes (newline-joined)")
       .option("--prepend-notes <text>", "prepend to existing notes (newline-joined)")
       .option("--when <value>", "today | evening | anytime | someday | YYYY-MM-DD")
-      .option("--reminder <HH:mm>", "set a reminder (24h); requires --when today|evening")
-      .option("--clear-reminder", "clear the reminder (requires --when today|evening)")
+      .option("--reminder <HH:mm>", "set a reminder (24h); requires --when today|evening|date")
+      .option("--clear-reminder", "clear the reminder (today|evening only — dated are sticky)")
       .option("--deadline <date>", "YYYY-MM-DD")
       .option("--clear-deadline", "remove the deadline"),
   ).action(async (uuid: string, opts: WriteFlagOpts & Record<string, unknown>) => {

--- a/src/write/commands.ts
+++ b/src/write/commands.ts
@@ -223,16 +223,21 @@ const todoAdd: CommandSpec<"todo.add"> = {
 
 /**
  * The effective reminder a when-bearing update should leave behind. A bare
- * `when=` CLEARS an existing reminder (R07), so when the caller re-schedules
- * without addressing the reminder we auto-preserve the current one; an
- * explicit null is the intentional clear.
+ * `when=` CLEARS an existing reminder (R07/R20), so when the caller
+ * re-schedules to today/evening/a date without addressing the reminder we
+ * auto-preserve the current one; an explicit null is the intentional clear.
  */
 function effectiveReminder(
   pre: PreState,
   params: { when?: WhenValue; reminder?: ReminderTime | null },
 ): ReminderTime | null {
   if (params.reminder !== undefined) return params.reminder;
-  if (params.when !== "today" && params.when !== "evening") return null;
+  const when = params.when;
+  const schedulable =
+    when === "today" ||
+    when === "evening" ||
+    (typeof when === "string" && /^\d{4}-\d{2}-\d{2}$/.test(when));
+  if (!schedulable) return null;
   const target = pre.target;
   if (target === null || target.type === "heading") return null;
   return target.reminder;

--- a/src/write/guards.ts
+++ b/src/write/guards.ts
@@ -153,16 +153,32 @@ const GUARDS: Record<HazardId, GuardFn> = {
     if (op !== "todo.add" && op !== "todo.update") return null;
     if (!("reminder" in params) || params["reminder"] === undefined) return null;
     const when = params["when"];
-    if (when === "today" || when === "evening") return null;
+    const isDate = typeof when === "string" && /^\d{4}-\d{2}-\d{2}$/.test(when);
+    if (params["reminder"] === null) {
+      // The clear IS a bare when= write — but only today/evening honor it;
+      // dated reminders are STICKY (persist through same-date AND re-dated
+      // bare when=, R20/R21). No URL clear path exists for them.
+      if (when === "today" || when === "evening") return null;
+      return {
+        hazard: "H-REMINDER-SCOPE",
+        detail: isDate
+          ? "dated reminders cannot be cleared via the URL scheme — they persist through " +
+            "bare when= re-schedules (R20/R21)"
+          : "clearing a reminder IS a bare when= write (R07) — when: today|evening must be " +
+            "re-stated in the same call",
+        remediation: isDate
+          ? "re-schedule with `--when today --clear-reminder` first (then re-date), or clear " +
+            "it in the app"
+          : "pass when today|evening together with --clear-reminder",
+      };
+    }
+    if (when === "today" || when === "evening" || isDate) return null;
     return {
       hazard: "H-REMINDER-SCOPE",
       detail:
-        params["reminder"] === null
-          ? "clearing a reminder IS a bare when= write (R07) — when: today|evening must be " +
-            "re-stated in the same call"
-          : "reminders are only validated with when: today|evening (R-suite); date-scheduled " +
-            "reminders are unprobed",
-      remediation: "pass when today|evening together with the reminder",
+        "reminders require a scheduled when: today|evening|YYYY-MM-DD (R-suite; " +
+        "anytime/someday carry no date for the reminder to attach to)",
+      remediation: "pass when today|evening|YYYY-MM-DD together with the reminder",
     };
   },
   "H-REORDER-SCOPE": ({ op, params, pre }) => {

--- a/test/engine/write-r9b.test.ts
+++ b/test/engine/write-r9b.test.ts
@@ -148,11 +148,11 @@ describe("reminders through the pipeline", () => {
     expect(calls[0]).toContain(encodeURIComponent("today@10:05am"));
   });
 
-  it("H-REMINDER-SCOPE blocks a reminder without when today|evening", async () => {
+  it("H-REMINDER-SCOPE blocks a reminder without a schedulable when", async () => {
     const { vector, calls } = fakeVector("url-scheme", URL_MATRIX, null);
     const result = await runMutation(deps([vector]), "todo.add", {
       title: "X",
-      when: "2026-07-08",
+      when: "someday",
       reminder: "10:05",
     });
     expect(result.kind).toBe("blocked");
@@ -352,5 +352,76 @@ describe("move to inbox / duplicate / entity updates", () => {
     );
     expect(result.kind).toBe("verify-failed");
     if (result.kind === "verify-failed") expect(result.reason).toBe("silent-noop");
+  });
+});
+
+describe("dated reminders (Phase 12b, R17–R21)", () => {
+  it("todo.add with a dated reminder compiles when=DATE@token and verifies", async () => {
+    const { vector, calls } = fakeVector("url-scheme", URL_MATRIX, () => {
+      seedTodo(fixture.db, {
+        uuid: "NEW-D",
+        title: "Dentist",
+        start: "someday",
+        startDate: "2026-07-09",
+        reminder: "15:00",
+        creationDate: NOW_EPOCH,
+      });
+    });
+    const result = await runMutation(deps([vector]), "todo.add", {
+      title: "Dentist",
+      when: "2026-07-09",
+      reminder: "15:00",
+    });
+    expect(result.kind).toBe("ok");
+    expect(calls[0]).toContain(encodeURIComponent("2026-07-09@15:00"));
+  });
+
+  it("auto-preserves an existing reminder on a dated re-schedule", async () => {
+    const uuid = seedTodo(fixture.db, {
+      title: "Keep-dated",
+      startDate: TODAY_ISO,
+      reminder: "06:45",
+    });
+    const { vector, calls } = fakeVector("url-scheme", URL_MATRIX, () => {
+      touch(uuid, "startDate = 132805760, start = 2"); // app re-dates; reminder rides along
+    });
+    const result = await runMutation(deps([vector]), "todo.update", {
+      uuid,
+      when: "2026-07-09",
+    });
+    expect(result.kind).toBe("ok");
+    expect(calls[0]).toContain(encodeURIComponent("2026-07-09@06:45"));
+  });
+
+  it("blocks clearing a DATED reminder (sticky — no URL clear path, R20/R21)", async () => {
+    const uuid = seedTodo(fixture.db, {
+      title: "Sticky",
+      start: "someday",
+      startDate: "2026-07-09",
+      reminder: "06:45",
+    });
+    const { vector, calls } = fakeVector("url-scheme", URL_MATRIX, null);
+    const result = await runMutation(deps([vector]), "todo.update", {
+      uuid,
+      when: "2026-07-10",
+      reminder: null,
+    });
+    expect(result.kind).toBe("blocked");
+    if (result.kind === "blocked") {
+      expect(result.hazard).toBe("H-REMINDER-SCOPE");
+      expect(result.detail).toContain("persist");
+    }
+    expect(calls).toHaveLength(0);
+  });
+
+  it("still blocks reminders on anytime/someday", async () => {
+    const { vector } = fakeVector("url-scheme", URL_MATRIX, null);
+    const result = await runMutation(deps([vector]), "todo.add", {
+      title: "X",
+      when: "anytime",
+      reminder: "09:00",
+    });
+    expect(result.kind).toBe("blocked");
+    if (result.kind === "blocked") expect(result.hazard).toBe("H-REMINDER-SCOPE");
   });
 });


### PR DESCRIPTION
Second half of the GTD-polish batch. Probes first, per doctrine — and discovery earned its keep three times.

## Dated reminders (R17–R21)

- `--reminder HH:mm` now works with `--when YYYY-MM-DD` on add and update; auto-preserve extends to dated re-schedules. Guard loosened evidence-scoped.
- **Finding 1**: the bare-hour 12-hour "next upcoming" trap (oddity 2d) is **today/evening-only** — dated schedules store `10:05` as 10:05 exactly (R19). Oddity scoped accordingly.
- **Finding 2 (new oddity 2e)**: dated reminders are **sticky** — a bare `when=` clears reminders on today/evening (R07) but NOT on dates, whether same-date (R20) or re-dated (R21, the reminder rides along). There is no URL path to clear a dated reminder, so `--clear-reminder` on a dated `when` is guard-blocked with the bounce-via-today remediation.

## Template duplication (E13)

The clone-and-rename hope for de facto repeat creation is **disproven**: `duplicate=true` on a repeating template changes nothing in the data and instead opens **new windows** (tier 3 disruption). Locked as `unsupported`, quarantined last in the suite; filed as oddity 5d; the gaps register's "repeat creation" entry now records the dead end.

## Verification

- R-suite (21 probes) and E-suite (13 probes) re-locked, acceptance ×2 with identical verdicts each.
- e2e smoke **46/46** in a VM clone — dated set, dated auto-preserve, sticky-clear block (exit 4), and the documented clear-via-today path, all against the real app.
- Full `lab:regress` ALL GREEN (six suites + e2e). 182 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)