### PR TITLE
Phase 12c: --exact-tag, inbox --tag regression fix, prod-read wrapper

### DIFF
--- a/scripts/prod-read.sh
+++ b/scripts/prod-read.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Read-only access to the LIVE Things database — the ONE stable command
+# shape agents use for prod reads, so a single permission grant covers all
+# of them (ad-hoc sqlite3/node one-liners each re-prompt the sandbox).
+#
+# Structurally read-only: sqlite3 opens with SQLITE_OPEN_READONLY; any
+# write statement fails. Never add a write mode here — prod writes are
+# forbidden (see docs/design/architecture.md).
+#
+# Usage:
+#   scripts/prod-read.sh "<SQL>"          one-shot query (default separator |)
+#   scripts/prod-read.sh --json "<SQL>"   JSON row output
+set -euo pipefail
+
+MODE=""
+if [ "${1:-}" = "--json" ]; then
+  MODE="--json"
+  shift
+fi
+SQL="${1:?usage: prod-read.sh [--json] \"<SQL>\"}"
+
+DB=$(/bin/ls -d "$HOME/Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-"*"/Things Database.thingsdatabase/main.sqlite" 2>/dev/null | head -1)
+[ -n "$DB" ] || { echo "Things database not found" >&2; exit 7; }
+
+# shellcheck disable=SC2086
+exec /usr/bin/sqlite3 $MODE -readonly "$DB" "$SQL"

--- a/src/cli/commands/reads.ts
+++ b/src/cli/commands/reads.ts
@@ -93,14 +93,17 @@ export function registerReadCommands(program: Command): void {
   const listCommands: Array<{
     name: string;
     description: string;
-    fetch: (client: ThingsClient, tag?: string) => unknown;
+    fetch: (client: ThingsClient, tag?: string, exactTag?: boolean) => unknown;
     render?: (data: never) => string[];
   }> = [
     {
       name: "today",
       description:
         "The Today list, split into Today and This Evening (evening expires daily), with the sidebar badge split (red = deadline due/overdue)",
-      fetch: (c, tag) => c.read.today(tag === undefined ? undefined : { tag }),
+      fetch: (c, tag, exactTag) =>
+        c.read.today(
+          tag === undefined ? undefined : { tag, ...(exactTag === true && { exactTag }) },
+        ),
       render: (data: {
         today: ListItem[];
         evening: ListItem[];
@@ -112,12 +115,22 @@ export function registerReadCommands(program: Command): void {
         ...renderList(data.evening),
       ],
     },
-    { name: "inbox", description: "Unprocessed captures (Inbox)", fetch: (c) => c.read.inbox() },
+    {
+      name: "inbox",
+      description: "Unprocessed captures (Inbox)",
+      fetch: (c, tag, exactTag) =>
+        c.read.inbox(
+          tag === undefined ? undefined : { tag, ...(exactTag === true && { exactTag }) },
+        ),
+    },
     {
       name: "anytime",
       description:
         "All active items, mirroring the UI: Today members are starred (★), unscheduled items are not",
-      fetch: (c, tag) => c.read.anytime(tag === undefined ? undefined : { tag }),
+      fetch: (c, tag, exactTag) =>
+        c.read.anytime(
+          tag === undefined ? undefined : { tag, ...(exactTag === true && { exactTag }) },
+        ),
       render: (items: ListItem[]) =>
         items.length === 0
           ? ["(empty)"]
@@ -128,12 +141,18 @@ export function registerReadCommands(program: Command): void {
       description:
         "Future-scheduled items in date order, INCLUDING each repeating item's next " +
         "occurrence (↻ marker; deadline derived from the repeat rule)",
-      fetch: (c, tag) => c.read.upcoming(tag === undefined ? undefined : { tag }),
+      fetch: (c, tag, exactTag) =>
+        c.read.upcoming(
+          tag === undefined ? undefined : { tag, ...(exactTag === true && { exactTag }) },
+        ),
     },
     {
       name: "someday",
       description: "Someday items (incubated, undated)",
-      fetch: (c, tag) => c.read.someday(tag === undefined ? undefined : { tag }),
+      fetch: (c, tag, exactTag) =>
+        c.read.someday(
+          tag === undefined ? undefined : { tag, ...(exactTag === true && { exactTag }) },
+        ),
     },
   ];
 
@@ -143,15 +162,16 @@ export function registerReadCommands(program: Command): void {
       .description(cmd.description)
       .option(
         "--tag <ref>",
-        "filter by tag (uuid or unique name), direct OR inherited (UI semantics)",
+        "filter by tag (uuid or unique name): direct, inherited, or descendant-tagged",
       )
+      .option("--exact-tag", "match the named tag only — exclude hierarchy descendants")
       .option("--json", "emit versioned JSON envelope on stdout")
       .option("--db <path>", "explicit database path")
-      .action((opts: GlobalReadOpts & { tag?: string }) => {
+      .action((opts: GlobalReadOpts & { tag?: string; exactTag?: boolean }) => {
         withClient(
           opts,
           cmd.name,
-          (c) => cmd.fetch(c, opts.tag),
+          (c) => cmd.fetch(c, opts.tag, opts.exactTag),
           (cmd.render ?? renderList) as (d: never) => string[],
         );
       });
@@ -161,14 +181,19 @@ export function registerReadCommands(program: Command): void {
     {
       name: "logbook",
       description: "Completed and canceled items, most recent first",
-      fetch: (c: ThingsClient, limit: number, tag?: string) =>
-        c.read.logbook({ limit, ...(tag !== undefined && { tag }) }),
+      fetch: (c: ThingsClient, limit: number, tag?: string, exactTag?: boolean) =>
+        c.read.logbook({
+          limit,
+          ...(tag !== undefined && { tag }),
+          ...(exactTag === true && { exactTag }),
+        }),
       defaultLimit: 100,
     },
     {
       name: "trash",
       description: "Trashed items (trashed=1 flag, any status), most recently modified first",
-      fetch: (c: ThingsClient, limit: number, _tag?: string) => c.read.trash({ limit }),
+      fetch: (c: ThingsClient, limit: number, _tag?: string, _exactTag?: boolean) =>
+        c.read.trash({ limit }),
       defaultLimit: 200,
     },
   ]) {
@@ -180,13 +205,14 @@ export function registerReadCommands(program: Command): void {
         "--tag <ref>",
         "filter by tag (uuid or unique name), direct OR inherited — logbook only",
       )
+      .option("--exact-tag", "match the named tag only — exclude hierarchy descendants")
       .option("--json", "emit versioned JSON envelope on stdout")
       .option("--db <path>", "explicit database path")
-      .action((opts: GlobalReadOpts & { limit: string; tag?: string }) => {
+      .action((opts: GlobalReadOpts & { limit: string; tag?: string; exactTag?: boolean }) => {
         withClient(
           opts,
           cmd.name,
-          (c) => cmd.fetch(c, Number(opts.limit), opts.tag),
+          (c) => cmd.fetch(c, Number(opts.limit), opts.tag, opts.exactTag),
           renderList as (d: never) => string[],
         );
       });
@@ -245,6 +271,7 @@ export function registerReadCommands(program: Command): void {
     .option("--project <ref>", "restrict to one project's children (uuid or unique name)")
     .option("--area <ref>", "restrict to one area's direct members (uuid or unique name)")
     .option("--tag <ref>", "restrict by tag: direct, inherited, or descendant-tagged")
+    .option("--exact-tag", "match the named tag only — exclude hierarchy descendants")
     .option("--type <kind>", "todo | project")
     .option("--logged", "include completed/canceled items")
     .option("--trashed", "include trashed items")
@@ -268,6 +295,7 @@ export function registerReadCommands(program: Command): void {
             ...(opts["project"] !== undefined && { project: opts["project"] as string }),
             ...(opts["area"] !== undefined && { area: opts["area"] as string }),
             ...(opts["tag"] !== undefined && { tag: opts["tag"] as string }),
+            ...(opts["exactTag"] === true && { exactTag: true }),
             ...(type !== undefined && { type: type === "todo" ? "to-do" : "project" }),
             ...(opts["logged"] === true && { logged: true }),
             ...(opts["trashed"] === true && { trashed: true }),

--- a/src/client.ts
+++ b/src/client.ts
@@ -86,7 +86,7 @@ export interface ThingsClient {
     anytime(filter?: ViewFilter): ListItem[];
     upcoming(filter?: UpcomingFilter): ListItem[];
     someday(filter?: ViewFilter): ListItem[];
-    logbook(options?: { limit?: number; tag?: string }): ListItem[];
+    logbook(options?: { limit?: number; tag?: string; exactTag?: boolean }): ListItem[];
     trash(options?: { limit?: number }): ListItem[];
     projects(options?: { areaUuid?: string }): Project[];
     projectView(uuid: string): ProjectView;

--- a/src/read/views.ts
+++ b/src/read/views.ts
@@ -67,6 +67,11 @@ export interface ViewFilter {
    * child-tagged items; not lab-oracled).
    */
   tag?: string;
+  /**
+   * Match the given tag ONLY — no hierarchy descendants. Useful when a
+   * parent tag has its own direct assignments distinct from its children's.
+   */
+  exactTag?: boolean;
 }
 
 function tagFilter(
@@ -74,7 +79,8 @@ function tagFilter(
   filter: ViewFilter | undefined,
 ): { sql: string; binds: string[] } {
   if (filter?.tag === undefined) return { sql: "", binds: [] };
-  const uuids = tagWithDescendants(db, resolveTagUuid(db, filter.tag));
+  const target = resolveTagUuid(db, filter.tag);
+  const uuids = filter.exactTag === true ? [target] : tagWithDescendants(db, target);
   return { sql: ` AND ${tagScopeSql(uuids.length)}`, binds: tagScopeBinds(uuids) };
 }
 

--- a/test/cli/e2e.test.ts
+++ b/test/cli/e2e.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { buildProgram } from "../../src/cli/main.ts";
 import { localToday } from "../../src/model/dates.ts";
 import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
-import { seedTodo } from "../fixtures/seed.ts";
+import { seedTag, seedTodo, tagTask } from "../fixtures/seed.ts";
 
 let fx: FixtureDb | null = null;
 afterEach(() => {
@@ -117,5 +117,24 @@ describe("cli search (Phase 12 ergonomics)", () => {
     const bad = runCli(["search", "alpha", "--tag", "nope", "--json", "--db", fx.path]);
     expect(bad.exitCode).not.toBe(0);
     expect(JSON.parse(bad.stdout).error.message).toMatch(/tag not found/);
+  });
+});
+
+describe("cli --exact-tag (Phase 12c)", () => {
+  it("inbox --tag works (12a regression) and --exact-tag narrows", () => {
+    fx = buildFixtureDb();
+    const parent = seedTag(fx.db, "ctx");
+    const child = seedTag(fx.db, "ctx-child", parent);
+    const a = seedTodo(fx.db, { title: "inbox-parent", start: "inbox" });
+    tagTask(fx.db, a, parent);
+    const b = seedTodo(fx.db, { title: "inbox-child", start: "inbox" });
+    tagTask(fx.db, b, child);
+
+    const both = runCli(["inbox", "--tag", "ctx", "--json", "--db", fx.path]);
+    expect(JSON.parse(both.stdout).data).toHaveLength(2);
+    const exact = runCli(["inbox", "--tag", "ctx", "--exact-tag", "--json", "--db", fx.path]);
+    expect(JSON.parse(exact.stdout).data.map((i: { title: string }) => i.title)).toEqual([
+      "inbox-parent",
+    ]);
   });
 });

--- a/test/cli/help-contract.test.ts
+++ b/test/cli/help-contract.test.ts
@@ -121,6 +121,14 @@ describe("write-command help states the contract", () => {
     expect(tagHelp).toContain("unprobed");
   });
 
+  it("list views + search expose --exact-tag alongside --tag", () => {
+    for (const name of ["today", "inbox", "search", "logbook"]) {
+      const help = helpFor(name);
+      expect(help).toContain("--exact-tag");
+      expect(help).toContain("exclude hierarchy descendants");
+    }
+  });
+
   it("search: open-by-default scope, widening flags, scoping flags", () => {
     const help = helpFor("search");
     expect(help).toContain("OPEN + untrashed");

--- a/test/unit/views.test.ts
+++ b/test/unit/views.test.ts
@@ -426,3 +426,38 @@ describe("tag descendant closure safety", () => {
     expect(view.today.map((i) => i.title)).toEqual(["cycled"]);
   });
 });
+
+describe("exact-tag filtering (Phase 12c)", () => {
+  it("exactTag matches the named tag only, excluding descendants", () => {
+    fx = buildFixtureDb();
+    const parent = seedTag(fx.db, "errands");
+    const child = seedTag(fx.db, "groceries", parent);
+    const direct = seedTodo(fx.db, { title: "direct", startDate: "2026-07-02" });
+    tagTask(fx.db, direct, parent);
+    const viaChild = seedTodo(fx.db, { title: "via-child", startDate: "2026-07-02" });
+    tagTask(fx.db, viaChild, child);
+
+    expect(
+      todayView(fx.db, NOW, { tag: "errands", exactTag: true }).today.map((i) => i.title),
+    ).toEqual(["direct"]);
+    // Default (descendants) still matches both.
+    expect(
+      todayView(fx.db, NOW, { tag: "errands" })
+        .today.map((i) => i.title)
+        .toSorted(),
+    ).toEqual(["direct", "via-child"]);
+    // exactTag still honors area/project INHERITANCE (orthogonal dimension).
+    const area = seedArea(fx.db, "Work");
+    tagArea(fx.db, area, parent);
+    seedTodo(fx.db, { title: "via-area", area, startDate: "2026-07-02" });
+    expect(
+      todayView(fx.db, NOW, { tag: "errands", exactTag: true })
+        .today.map((i) => i.title)
+        .toSorted(),
+    ).toEqual(["direct", "via-area"]);
+    // And search takes it through SearchOptions.
+    expect(
+      searchView(fx.db, "via", { tag: "errands", exactTag: true }).map((i) => i.title),
+    ).toEqual(["via-area"]);
+  });
+});


### PR DESCRIPTION
Follow-ups from Mike's review of 12a/12b.

- **`--exact-tag`** on every `--tag`-bearing read command and search: match the named tag only, excluding hierarchy descendants — for the case where a parent tag's direct assignments are distinct from its children's. Exact matching still honors area/project *inheritance* (an orthogonal dimension). Library: `ViewFilter.exactTag` / `SearchOptions.exactTag`.
- **Regression fix (12a)**: `things inbox --tag` accepted the flag but silently ignored it — the inbox entry's one-liner shape dodged the 12a patch. Now forwarded and covered by a CLI e2e regression test.
- **`scripts/prod-read.sh`**: one stable, structurally read-only command shape (`sqlite3 -readonly`) for live-DB reads, so a single sandbox/permission grant covers all future prod reads instead of every ad-hoc one-liner raising a fresh prompt (the root cause of this session's "prod DB stopped responding" ghost).

184 tests; help-contract locks for the new flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)