### PR TITLE
Phase 13: batch mutations + changes-since

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ things capabilities --op todo.move --json      # is it possible, which vector, w
 things search "Buy milk" --json                # resolve the uuid (open items; scope with --project/--area/--tag, widen with --logged/--trashed/--all)
 things todo move <uuid> --project "Errands" --dry-run --json   # inspect the plan
 things todo move <uuid> --project "Errands" --json             # execute, verified
+things changes --since 2026-07-05T08:00 --json # what changed since the agent last looked
+things batch inbox-triage.jsonl                # N ops, each guarded+verified, JSONL results
 ```
 
 Failure modes are first-class: a `verify-failed:silent-noop` means the app accepted the command and did nothing (a real Things behavior the guards mostly prevent — see [docs/things-app-oddities.md](docs/things-app-oddities.md)); `blocked:*` responses include machine-readable remediation.

--- a/lab/guest/e2e-write-smoke.sh
+++ b/lab/guest/e2e-write-smoke.sh
@@ -104,6 +104,19 @@ run_step 0 "area update: rename + tags" area update LAB-AREA-B --title "E2E-AREA
 run_step 0 "tag add for update tests" tag add e2e-parent
 run_step 0 "tag update: re-parent + shortcut" tag update lab-tag-2 --parent e2e-parent --shortcut 8
 
+echo "== batch + changes (Phase 13) =="
+SINCE=$(date -v-2M +%Y-%m-%dT%H:%M:%S)
+cat > /tmp/e2e-batch.jsonl <<'EOB'
+{"op":"todo.add","params":{"title":"E2E-B1","when":"today"}}
+{"op":"todo.add","params":{"title":"E2E-B2","notes":"from batch"}}
+EOB
+run_step 0 "batch: two verified adds via JSONL" batch /tmp/e2e-batch.jsonl
+run_step 0 "changes --since shows the batch adds" changes --since "$SINCE"
+if ! json_get "len([i for i in d['data'] if i['title'].startswith('E2E-B')])" | grep -q "^2$"; then
+  echo "FAIL changes did not include both batch adds"
+  FAILURES=$((FAILURES + 1))
+fi
+
 echo "== deletes =="
 run_step 0 "todo delete -> trash (applescript)" todo delete "$UUID"
 run_step 0 "area add (applescript)" area add "E2E-AREA"

--- a/src/cli/commands/reads.ts
+++ b/src/cli/commands/reads.ts
@@ -262,6 +262,36 @@ export function registerReadCommands(program: Command): void {
     });
 
   program
+    .command("changes")
+    .description(
+      "Everything created or modified since a moment (--since), newest first — INCLUDES " +
+        "trashed, logged, and repeating-template rows so agents can sync state; check " +
+        "trashed/status/repeating on each item. Caveats: tag/area edits and checklist-item " +
+        "edits don't bump tasks and are invisible here.",
+    )
+    .requiredOption("--since <when>", "ISO date/datetime (e.g. 2026-07-05T14:30:00)")
+    .option("--limit <n>", "maximum items", "200")
+    .option("--json", "emit versioned JSON envelope on stdout")
+    .option("--db <path>", "explicit database path")
+    .action((opts: GlobalReadOpts & { since: string; limit: string }) => {
+      const since = new Date(opts.since);
+      if (Number.isNaN(since.getTime())) {
+        process.stderr.write(`error: --since is not a parseable date: ${opts.since}\n`);
+        process.exitCode = ExitCode.Usage;
+        return;
+      }
+      withClient(opts, "changes", (c) => c.read.changes({ since, limit: Number(opts.limit) }), ((
+        items: Array<ListItem & { changeKind: string }>,
+      ) =>
+        items.length === 0
+          ? ["(no changes)"]
+          : items.map(
+              (i) =>
+                `${i.changeKind === "created" ? "+" : "~"} ${formatItem(i)}${i.trashed ? " [trashed]" : ""}`,
+            )) as (d: never) => string[]);
+    });
+
+  program
     .command("search <query>")
     .description(
       "Title/notes substring search, most recently modified first. Default scope: OPEN + " +

--- a/src/cli/commands/writes.ts
+++ b/src/cli/commands/writes.ts
@@ -5,6 +5,8 @@
  */
 import type { Command } from "commander";
 
+import { readFileSync } from "node:fs";
+
 import { openThings, type ThingsClient } from "../../client.ts";
 import { saveConfigKey, type DisruptionTier } from "../../config.ts";
 import { ThingsDbNotFoundError } from "../../db/locate.ts";
@@ -16,6 +18,7 @@ import {
   type ReorderStrategy,
 } from "../../write/operations.ts";
 import type { WriteOptions } from "../../write/pipeline.ts";
+import { outcomeFailed, type BatchItemResult, type BatchOp } from "../../write/batch.ts";
 import { BOUNCE_MAX_ITEMS, type ReorderResult } from "../../write/reorder.ts";
 import { defaultVectors } from "../../write/vectors/registry.ts";
 import type { VectorId } from "../../write/vectors/types.ts";
@@ -737,6 +740,98 @@ export function registerWriteCommands(program: Command): void {
       ),
     );
   });
+
+  program
+    .command("batch [file]")
+    .description(
+      "Run MANY mutations from JSONL (file, or stdin when omitted/'-'): one op per line, " +
+        '{"op": "<kind>", "params": {...}, "options": {...}} — see `things capabilities` for ' +
+        "op kinds and params. Every op runs the FULL pipeline (guards, verified " +
+        "read-after-write, audit) sequentially; per-op results stream as JSONL. No " +
+        "transactions. Per-op options carry acknowledgement flags " +
+        "(acknowledgeChecklistReset, acknowledgeProjectReopen, dangerouslyPermanent). " +
+        "--dry-run plans everything without executing; --fail-fast skips the rest after " +
+        "the first failure. Exit: 0 all ok · 3 any verify-failed/invalid · 4 any blocked " +
+        "· 5 any drift-blocked.",
+    )
+    .option("--dry-run", "plan every op; execute nothing")
+    .option("--fail-fast", "skip remaining ops after the first failure")
+    .option("--json", "JSONL results + summary on stdout (also the default)")
+    .option("--db <path>", "explicit database path")
+    .option("--actor <name>", "audit attribution for the whole batch")
+    .action(async (file: string | undefined, opts: WriteFlagOpts & Record<string, unknown>) => {
+      let raw: string;
+      if (file !== undefined && file !== "-") {
+        raw = readFileSync(file, "utf8");
+      } else {
+        const chunks: Buffer[] = [];
+        for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+        raw = Buffer.concat(chunks).toString("utf8");
+      }
+      const lines = raw.split("\n").filter((l) => l.trim() !== "");
+      const ops: BatchOp[] = [];
+      const preInvalid: BatchItemResult[] = [];
+      for (let i = 0; i < lines.length; i++) {
+        try {
+          ops.push(JSON.parse(lines[i] as string) as BatchOp);
+        } catch (err) {
+          // keep index alignment: a placeholder op that runBatch flags invalid
+          ops.push({ op: "?" as never, params: {} });
+          preInvalid.push({
+            index: i,
+            op: "?",
+            outcome: {
+              kind: "invalid",
+              op: "?",
+              detail: `line ${i + 1} is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+            },
+          });
+        }
+      }
+      let client: ThingsClient | null = null;
+      try {
+        client = openThings(opts.db ? { dbPath: opts.db } : {});
+        const emit = (r: BatchItemResult): void => {
+          process.stdout.write(`${JSON.stringify(r)}\n`);
+        };
+        const results = await client.write.batch(
+          ops,
+          {
+            ...(opts.dryRun !== undefined && { dryRun: opts.dryRun }),
+            ...(opts["failFast"] === true && { failFast: true }),
+            ...(opts.actor !== undefined && { actor: opts.actor }),
+          },
+          (r) => {
+            const pre = preInvalid.find((p) => p.index === r.index);
+            emit(pre ?? r);
+          },
+        );
+        const merged = results.map((r) => preInvalid.find((p) => p.index === r.index) ?? r);
+        const failed = merged.filter((r) => outcomeFailed(r.outcome));
+        const summary = {
+          summary: {
+            total: merged.length,
+            ok: merged.length - failed.length,
+            failed: failed.filter((r) => r.outcome.kind !== "skipped").length,
+            skipped: merged.filter((r) => r.outcome.kind === "skipped").length,
+          },
+        };
+        process.stdout.write(`${JSON.stringify(summary)}\n`);
+        const kinds = new Set(failed.map((r) => r.outcome.kind));
+        const reasons = new Set(
+          failed.map((r) => (r.outcome.kind === "blocked" ? r.outcome.reason : "")),
+        );
+        process.exitCode = reasons.has("drift")
+          ? ExitCode.DriftBlocked
+          : kinds.has("blocked")
+            ? ExitCode.Blocked
+            : failed.length > 0
+              ? ExitCode.VerifyFailed
+              : ExitCode.Ok;
+      } finally {
+        client?.close();
+      }
+    });
 
   addWriteFlags(
     program

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,6 +17,7 @@ import { snapshotView, type Snapshot } from "./read/snapshot.ts";
 import { areasView, tagsView } from "./read/tags.ts";
 import {
   anytimeView,
+  changesView,
   inboxView,
   logbookView,
   projectsView,
@@ -25,6 +26,7 @@ import {
   todayView,
   trashView,
   upcomingView,
+  type ChangedItem,
   type ListItem,
   type SearchOptions,
   type TodayView,
@@ -53,6 +55,7 @@ import {
   type WriteDeps,
   type WriteOptions,
 } from "./write/pipeline.ts";
+import { runBatch, type BatchItemResult, type BatchOp, type BatchOptions } from "./write/batch.ts";
 import { runReorder, type ReorderResult } from "./write/reorder.ts";
 import { defaultVectors } from "./write/vectors/registry.ts";
 import type { WriteVector } from "./write/vectors/types.ts";
@@ -93,6 +96,8 @@ export interface ThingsClient {
     areas(): Area[];
     tags(): Tag[];
     search(query: string, options?: SearchOptions): ListItem[];
+    /** Rows created/modified since a moment — incl. trashed/logged/templates. */
+    changes(options: { since: Date; limit?: number }): ChangedItem[];
     byUuid(uuid: string): AnyTask | null;
     snapshot(): Snapshot;
   };
@@ -161,6 +166,15 @@ export interface ThingsClient {
      * uuid lists are placed on top; the rest keep their current order.
      */
     reorder(params: ReorderParams, options?: WriteOptions): Promise<ReorderResult>;
+    /**
+     * Run N ops sequentially through the full pipeline (each guarded,
+     * verified, audited). No transactional semantics — per-op results.
+     */
+    batch(
+      ops: BatchOp[],
+      options?: BatchOptions,
+      onResult?: (result: BatchItemResult) => void,
+    ): Promise<BatchItemResult[]>;
   };
   close(): void;
 }
@@ -231,6 +245,7 @@ export function openThings(options: OpenOptions = {}): ThingsClient {
       areas: () => areasView(conn.db),
       tags: () => tagsView(conn.db),
       search: (query, o) => searchView(conn.db, query, o),
+      changes: (o) => changesView(conn.db, o),
       byUuid: (uuid) => byUuid(conn.db, uuid),
       snapshot: () => snapshotView(conn.db),
     },
@@ -266,6 +281,7 @@ export function openThings(options: OpenOptions = {}): ThingsClient {
       deleteTag: (target, o) => run("tag.delete", { target }, o),
       emptyTrash: (o) => run("trash.empty", {}, o),
       reorder: (params, o) => runReorder(writeDeps, params, o ?? {}),
+      batch: (ops, o, onResult) => runBatch(writeDeps, ops, o ?? {}, onResult),
     },
     close: () => conn.close(),
   };

--- a/src/read/views.ts
+++ b/src/read/views.ts
@@ -292,6 +292,36 @@ export interface SearchOptions extends ViewFilter {
   all?: boolean;
 }
 
+export type ChangeKind = "created" | "modified";
+export type ChangedItem = ListItem & { changeKind: ChangeKind };
+
+/**
+ * Everything that changed since a moment — created or modified TMTask rows,
+ * INCLUDING trashed, logged, and repeating-template rows (an agent syncing
+ * state needs to see deletions and template edits too; check `trashed`,
+ * `status`, and `repeating.isTemplate` on each item). Caveats: TMArea/TMTag
+ * carry no modification dates, and checklist-item edits do not bump the
+ * parent task — those changes are invisible here.
+ */
+export function changesView(
+  db: DatabaseSync,
+  options: { since: Date; limit?: number },
+): ChangedItem[] {
+  const limit = options.limit ?? 200;
+  const sinceEpoch = options.since.getTime() / 1000;
+  const rows = fetchTaskRows(
+    db,
+    `t.type IN (0, 1) AND t.userModificationDate > ?
+     ORDER BY t.userModificationDate DESC LIMIT ?`,
+    [sinceEpoch, limit],
+  );
+  return materialize(db, rows).map((item, i) => ({
+    ...item,
+    changeKind:
+      (rows[i]?.creationDate ?? 0) > sinceEpoch ? ("created" as const) : ("modified" as const),
+  }));
+}
+
 export function searchView(db: DatabaseSync, query: string, options?: SearchOptions): ListItem[] {
   const limit = options?.limit ?? 50;
   const needle = `%${query}%`;

--- a/src/write/batch.ts
+++ b/src/write/batch.ts
@@ -1,0 +1,141 @@
+/**
+ * Batch mutations: N ops through the SAME pipeline as single mutations —
+ * every op individually pre-read, guarded, verified, and audited. The wins
+ * are amortization (one process, one DB handle, one config load) and a
+ * per-op result stream; there is deliberately NO transactional semantics
+ * (the app's surfaces have none to offer). Ops run SEQUENTIALLY: the
+ * mutation lock serializes them anyway, and create-probe verification must
+ * never race.
+ */
+import { OPERATION_KINDS, type OperationKind, type OperationParamsMap } from "./operations.ts";
+import { runMutation, type WriteDeps, type WriteOptions } from "./pipeline.ts";
+import { runReorder, type ReorderResult } from "./reorder.ts";
+
+/** One line of a batch: the op kind, its params, and per-op options. */
+export interface BatchOp {
+  op: OperationKind;
+  params: Record<string, unknown>;
+  /** Per-op acknowledgements/overrides (a safe subset of WriteOptions). */
+  options?: {
+    acknowledgeChecklistReset?: boolean;
+    acknowledgeProjectReopen?: boolean;
+    dangerouslyPermanent?: boolean;
+    vector?: WriteOptions["vector"];
+    verifyTimeoutMs?: number;
+    maxDisruption?: WriteOptions["maxDisruption"];
+  };
+}
+
+export type BatchItemOutcome =
+  | ReorderResult
+  | { kind: "invalid"; op: string; detail: string }
+  | { kind: "skipped"; op: string; detail: string };
+
+export interface BatchItemResult {
+  index: number;
+  op: string;
+  outcome: BatchItemOutcome;
+}
+
+export interface BatchOptions {
+  /** Stop at the first non-ok outcome; remaining ops report kind "skipped". */
+  failFast?: boolean;
+  /** Plan every op without executing (each result is its dry-run plan). */
+  dryRun?: boolean;
+  actor?: string;
+}
+
+const KNOWN_OPS = new Set<string>(OPERATION_KINDS);
+
+/** True when an outcome should be treated as a failure for --fail-fast/exit. */
+export function outcomeFailed(outcome: BatchItemOutcome): boolean {
+  return outcome.kind !== "ok" && outcome.kind !== "dry-run";
+}
+
+export async function runBatch(
+  deps: WriteDeps,
+  ops: BatchOp[],
+  options: BatchOptions = {},
+  onResult?: (result: BatchItemResult) => void,
+): Promise<BatchItemResult[]> {
+  const results: BatchItemResult[] = [];
+  let halted = false;
+
+  for (let index = 0; index < ops.length; index++) {
+    const entry = ops[index] as BatchOp;
+    let outcome: BatchItemOutcome;
+
+    if (halted) {
+      outcome = {
+        kind: "skipped",
+        op: String(entry?.op),
+        detail: "skipped after earlier failure (--fail-fast)",
+      };
+    } else if (typeof entry !== "object" || entry === null || typeof entry.op !== "string") {
+      outcome = {
+        kind: "invalid",
+        op: String((entry as { op?: unknown })?.op),
+        detail: "each op needs {op, params}",
+      };
+    } else if (!KNOWN_OPS.has(entry.op)) {
+      outcome = {
+        kind: "invalid",
+        op: entry.op,
+        detail: `unknown op "${entry.op}" — see \`things capabilities\``,
+      };
+    } else if (typeof entry.params !== "object" || entry.params === null) {
+      outcome = { kind: "invalid", op: entry.op, detail: "params must be an object" };
+    } else {
+      const writeOptions: WriteOptions = {
+        ...(entry.options?.acknowledgeChecklistReset !== undefined && {
+          acknowledgeChecklistReset: entry.options.acknowledgeChecklistReset,
+        }),
+        ...(entry.options?.acknowledgeProjectReopen !== undefined && {
+          acknowledgeProjectReopen: entry.options.acknowledgeProjectReopen,
+        }),
+        ...(entry.options?.dangerouslyPermanent !== undefined && {
+          dangerouslyPermanent: entry.options.dangerouslyPermanent,
+        }),
+        ...(entry.options?.vector !== undefined && { vector: entry.options.vector }),
+        ...(entry.options?.verifyTimeoutMs !== undefined && {
+          verifyTimeoutMs: entry.options.verifyTimeoutMs,
+        }),
+        ...(entry.options?.maxDisruption !== undefined && {
+          maxDisruption: entry.options.maxDisruption,
+        }),
+        ...(options.dryRun === true && { dryRun: true }),
+        ...(options.actor !== undefined && { actor: options.actor }),
+      };
+      try {
+        // Params arrive as parsed JSON; the pipeline's pre-read + guards are
+        // the runtime validators (loud on bad shapes), same as single ops.
+        outcome =
+          entry.op === "reorder"
+            ? await runReorder(
+                deps,
+                entry.params as unknown as OperationParamsMap["reorder"],
+                writeOptions,
+              )
+            : await runMutation(
+                deps,
+                entry.op as Exclude<OperationKind, "reorder">,
+                entry.params as never,
+                writeOptions,
+              );
+      } catch (err) {
+        // Param-shape errors (exclusive combos etc.) surface per-op, not fatally.
+        outcome = {
+          kind: "invalid",
+          op: entry.op,
+          detail: err instanceof Error ? err.message : String(err),
+        };
+      }
+    }
+
+    const result: BatchItemResult = { index, op: String(entry?.op), outcome };
+    results.push(result);
+    onResult?.(result);
+    if (options.failFast === true && !halted && outcomeFailed(outcome)) halted = true;
+  }
+  return results;
+}

--- a/test/cli/e2e.test.ts
+++ b/test/cli/e2e.test.ts
@@ -138,3 +138,29 @@ describe("cli --exact-tag (Phase 12c)", () => {
     ]);
   });
 });
+
+describe("cli changes (Phase 13)", () => {
+  it("lists created/modified since --since with markers", () => {
+    fx = buildFixtureDb();
+    const SINCE = 1_790_000_000;
+    seedTodo(fx.db, { title: "untouched", creationDate: SINCE - 10, modificationDate: SINCE - 10 });
+    seedTodo(fx.db, { title: "fresh", creationDate: SINCE + 5, modificationDate: SINCE + 5 });
+    const sinceIso = new Date(SINCE * 1000).toISOString();
+    const { stdout, exitCode } = runCli([
+      "changes",
+      "--since",
+      sinceIso,
+      "--json",
+      "--db",
+      fx.path,
+    ]);
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(stdout).data;
+    expect(data).toHaveLength(1);
+    expect(data[0].title).toBe("fresh");
+    expect(data[0].changeKind).toBe("created");
+
+    const bad = runCli(["changes", "--since", "not-a-date", "--db", fx.path]);
+    expect(bad.exitCode).toBe(2);
+  });
+});

--- a/test/cli/help-contract.test.ts
+++ b/test/cli/help-contract.test.ts
@@ -121,6 +121,22 @@ describe("write-command help states the contract", () => {
     expect(tagHelp).toContain("unprobed");
   });
 
+  it("batch: pipeline guarantees, no transactions, exit codes", () => {
+    const help = helpFor("batch");
+    expect(help).toContain("FULL pipeline");
+    expect(help).toContain("No transactions");
+    expect(help).toContain("--fail-fast");
+    expect(help).toContain("--dry-run");
+    expect(help).toContain("0 all ok");
+  });
+
+  it("changes: sync semantics and caveats", () => {
+    const help = helpFor("changes");
+    expect(help).toContain("--since <when>");
+    expect(help).toContain("trashed");
+    expect(help).toContain("invisible");
+  });
+
   it("list views + search expose --exact-tag alongside --tag", () => {
     for (const name of ["today", "inbox", "search", "logbook"]) {
       const help = helpFor(name);

--- a/test/cli/write-cli.test.ts
+++ b/test/cli/write-cli.test.ts
@@ -126,3 +126,54 @@ describe("capabilities", () => {
     expect(entry?.vectors.find((v) => v.vector === "applescript")?.support).toBe("yes");
   });
 });
+
+describe("batch (Phase 13)", () => {
+  it("streams per-op JSONL, handles bad lines, exits with worst severity", async () => {
+    const uuid = seedTodo(fixture.db, { title: "batch-target" });
+    const batchFile = join(stateDir, "ops.jsonl");
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(
+      batchFile,
+      [
+        JSON.stringify({ op: "todo.update", params: { uuid, title: "renamed" } }),
+        "not json at all {",
+        JSON.stringify({ op: "trash.empty", params: {} }),
+      ].join("\n"),
+    );
+    await run(["batch", batchFile, "--dry-run"]);
+    const lines = stdout
+      .join("")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    expect(lines).toHaveLength(4); // 3 results + summary
+    expect(lines[0].outcome.kind).toBe("dry-run");
+    expect(lines[1].outcome.kind).toBe("invalid");
+    expect(lines[1].outcome.detail).toMatch(/not valid JSON/);
+    // trash.empty dry-run still hits the H-PERMANENT-DELETE guard first
+    expect(lines[2].outcome.kind).toBe("blocked");
+    expect(lines[3].summary).toEqual({ total: 3, ok: 1, failed: 2, skipped: 0 });
+    expect(process.exitCode).toBe(4); // blocked outranks invalid
+  });
+
+  it("--fail-fast skips after the first failure", async () => {
+    const uuid = seedTodo(fixture.db, { title: "ff" });
+    const batchFile = join(stateDir, "ff.jsonl");
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(
+      batchFile,
+      [
+        JSON.stringify({ op: "trash.empty", params: {} }),
+        JSON.stringify({ op: "todo.update", params: { uuid, title: "x" } }),
+      ].join("\n"),
+    );
+    await run(["batch", batchFile, "--dry-run", "--fail-fast"]);
+    const lines = stdout
+      .join("")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    expect(lines[0].outcome.kind).toBe("blocked");
+    expect(lines[1].outcome.kind).toBe("skipped");
+  });
+});

--- a/test/engine/write-batch.test.ts
+++ b/test/engine/write-batch.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Batch pipeline tests: each op runs the full mutation pipeline; invalid
+ * lines and thrown param-shape errors surface per-op; --fail-fast skips.
+ */
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { AuditRecord } from "../../src/audit/schema.ts";
+import type { ThingsApiConfig } from "../../src/config.ts";
+import type { FingerprintStatus } from "../../src/db/fingerprint.ts";
+import { outcomeFailed, runBatch, type BatchOp } from "../../src/write/batch.ts";
+import type { WriteDeps } from "../../src/write/pipeline.ts";
+import type { VectorMatrix, WriteVector } from "../../src/write/vectors/types.ts";
+import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
+import { seedTodo } from "../fixtures/seed.ts";
+
+const NOW = new Date("2026-07-05T12:00:00Z");
+const NOW_EPOCH = Math.floor(NOW.getTime() / 1000);
+
+let fixture: FixtureDb;
+let auditRecords: AuditRecord[];
+let lockSeq = 0;
+
+beforeEach(() => {
+  fixture = buildFixtureDb();
+  auditRecords = [];
+});
+afterEach(() => fixture.close());
+
+const MATRIX: VectorMatrix = Object.fromEntries(
+  ["todo.update", "todo.complete", "trash.empty"].map((op) => [
+    op,
+    { support: "yes", disruption: 0, validation: "validated" },
+  ]),
+) as VectorMatrix;
+
+function vectorApplying(effects: Record<string, () => void>): WriteVector {
+  return {
+    id: "url-scheme",
+    matrix: MATRIX,
+    async execute(invocation) {
+      for (const [needle, fn] of Object.entries(effects)) {
+        if (invocation.payload.includes(needle)) fn();
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    },
+  };
+}
+
+const CONFIG: ThingsApiConfig = {
+  profile: "workstation",
+  maxDisruption: 1,
+  actor: "batch-actor",
+  auditEnabled: true,
+  acceptedFingerprint: null,
+  allowExperimental: false,
+  host: "test-host",
+};
+
+function deps(vector: WriteVector): WriteDeps {
+  return {
+    db: fixture.db,
+    vectors: [vector],
+    config: CONFIG,
+    audit: { append: (r) => auditRecords.push(r) },
+    fingerprint: (): FingerprintStatus => ({
+      kind: "ok",
+      observation: { databaseVersion: 26, tables: [], fingerprint: "sha256:test" },
+    }),
+    lockPath: join(tmpdir(), `things-api-batch-lock-${process.pid}-${lockSeq++}`),
+    isAppRunning: () => true,
+    ensureRunning: async () => true,
+    now: () => NOW,
+  };
+}
+
+function touch(uuid: string, sets: string): void {
+  fixture.db
+    .prepare(`UPDATE TMTask SET ${sets}, userModificationDate = ? WHERE uuid = ?`)
+    .run(NOW_EPOCH + 1, uuid);
+}
+
+describe("runBatch", () => {
+  it("streams per-op outcomes: ok, blocked, invalid, thrown param conflicts", async () => {
+    const a = seedTodo(fixture.db, { title: "A" });
+    const b = seedTodo(fixture.db, { title: "B", notes: "x" });
+    const vector = vectorApplying({
+      [`id=${a}`]: () => touch(a, "status = 3, stopDate = 1783300000"),
+    });
+    const streamed: number[] = [];
+    const ops: BatchOp[] = [
+      { op: "todo.complete", params: { uuid: a } },
+      { op: "trash.empty", params: {} }, // blocked: no dangerouslyPermanent
+      { op: "nope.bogus" as never, params: {} }, // invalid: unknown op
+      { op: "todo.update", params: { uuid: b, notes: "y", appendNotes: "z" } }, // throws: exclusive
+    ];
+    const results = await runBatch(deps(vector), ops, {}, (r) => streamed.push(r.index));
+    expect(streamed).toEqual([0, 1, 2, 3]);
+    expect(results.map((r) => r.outcome.kind)).toEqual(["ok", "blocked", "invalid", "invalid"]);
+    expect(results[3]?.outcome.kind === "invalid" && results[3].outcome.detail).toMatch(
+      /exclusive/,
+    );
+    // ok + blocked both audited (invalid ops never reach the pipeline)
+    expect(auditRecords.map((r) => r.result)).toEqual(["ok", "blocked:H-PERMANENT-DELETE"]);
+  });
+
+  it("failFast skips everything after the first failure", async () => {
+    const a = seedTodo(fixture.db, { title: "A" });
+    const vector = vectorApplying({});
+    const ops: BatchOp[] = [
+      { op: "trash.empty", params: {} }, // blocked
+      { op: "todo.complete", params: { uuid: a } },
+    ];
+    const results = await runBatch(deps(vector), ops, { failFast: true });
+    expect(results.map((r) => r.outcome.kind)).toEqual(["blocked", "skipped"]);
+    expect(outcomeFailed(results[1]!.outcome)).toBe(true);
+  });
+
+  it("dryRun plans every op without executing or auditing", async () => {
+    const a = seedTodo(fixture.db, { title: "A" });
+    let executed = 0;
+    const vector: WriteVector = {
+      id: "url-scheme",
+      matrix: MATRIX,
+      async execute() {
+        executed++;
+        return { exitCode: 0, stdout: "", stderr: "" };
+      },
+    };
+    const results = await runBatch(
+      deps(vector),
+      [
+        { op: "todo.complete", params: { uuid: a } },
+        { op: "todo.update", params: { uuid: a, title: "renamed" } },
+      ],
+      { dryRun: true },
+    );
+    expect(results.map((r) => r.outcome.kind)).toEqual(["dry-run", "dry-run"]);
+    expect(executed).toBe(0);
+    expect(auditRecords).toHaveLength(0);
+  });
+
+  it("per-op acknowledgements unblock guarded ops", async () => {
+    seedTodo(fixture.db, { title: "trashed-one", trashed: true });
+    const vector = vectorApplying({
+      "empty trash": () => {
+        fixture.db.prepare("DELETE FROM TMTask WHERE trashed = 1").run();
+      },
+    });
+    const asVector: WriteVector = {
+      ...vector,
+      id: "applescript",
+    };
+    const results = await runBatch(deps(asVector), [
+      { op: "trash.empty", params: {}, options: { dangerouslyPermanent: true } },
+    ]);
+    expect(results[0]?.outcome.kind).toBe("ok");
+  });
+});

--- a/test/unit/views.test.ts
+++ b/test/unit/views.test.ts
@@ -5,6 +5,7 @@ import { inheritedTagsFor } from "../../src/read/tags.ts";
 import { fetchTaskByUuid } from "../../src/read/queries.ts";
 import {
   anytimeView,
+  changesView,
   inboxView,
   isTodayMember,
   logbookView,
@@ -459,5 +460,50 @@ describe("exact-tag filtering (Phase 12c)", () => {
     expect(
       searchView(fx.db, "via", { tag: "errands", exactTag: true }).map((i) => i.title),
     ).toEqual(["via-area"]);
+  });
+});
+
+describe("changesView (Phase 13)", () => {
+  it("returns created vs modified since a moment, including trashed/logged/templates", () => {
+    fx = buildFixtureDb();
+    const SINCE = 1_790_000_000; // epoch seconds
+    seedTodo(fx.db, {
+      title: "old-untouched",
+      creationDate: SINCE - 100,
+      modificationDate: SINCE - 50,
+    });
+    seedTodo(fx.db, {
+      title: "edited-after",
+      creationDate: SINCE - 100,
+      modificationDate: SINCE + 10,
+    });
+    seedTodo(fx.db, {
+      title: "born-after",
+      creationDate: SINCE + 20,
+      modificationDate: SINCE + 20,
+    });
+    seedTodo(fx.db, {
+      title: "trashed-after",
+      trashed: true,
+      creationDate: SINCE - 100,
+      modificationDate: SINCE + 30,
+    });
+    seedTodo(fx.db, {
+      title: "template-edited",
+      recurrenceRule: true,
+      creationDate: SINCE - 100,
+      modificationDate: SINCE + 40,
+    });
+
+    const changes = changesView(fx.db, { since: new Date(SINCE * 1000) });
+    expect(changes.map((c) => [c.title, c.changeKind])).toEqual([
+      ["template-edited", "modified"],
+      ["trashed-after", "modified"],
+      ["born-after", "created"],
+      ["edited-after", "modified"],
+    ]);
+    expect(changes.find((c) => c.title === "trashed-after")?.trashed).toBe(true);
+    expect(changes.find((c) => c.title === "template-edited")?.repeating.isTemplate).toBe(true);
+    expect(changesView(fx.db, { since: new Date(SINCE * 1000), limit: 2 })).toHaveLength(2);
   });
 });


### PR DESCRIPTION
The two agent-workflow features from the approved roadmap (MCP parked).

## `things batch [file|-]`

JSONL in, JSONL out. Every op runs the **same full pipeline as a single mutation** — pre-read, hazard guards, verified read-after-write, audit record — sequentially (the mutation lock serializes anyway, and create-probe verification must never race). Deliberately no transactional semantics: the app's surfaces offer none, so the contract is honest per-op results plus a summary line. Per-op `options` carry acknowledgement flags; global `--dry-run` plans everything; `--fail-fast` skips the remainder (reported as `skipped`); exit code is the worst severity across the batch. Malformed JSON lines and thrown param conflicts (e.g. `notes`+`appendNotes`) surface as per-op `invalid` results without aborting siblings.

## `things changes --since <when>`

Incremental state sync for agents: every TMTask row created or modified since the moment, newest first, **including trashed, logged, and repeating-template rows** (a syncing agent needs to see deletions and template edits — check `trashed`/`status`/`repeating` per item), with `changeKind: created|modified`. Documented caveats: tag/area edits and checklist-item edits don't bump the parent task's modification date and are invisible here.

## Verification

195 unit tests (batch engine: streaming, blocked/invalid/thrown/skipped/dry-run/acks; changes view + CLI). e2e smoke +2 steps exercising a real batch (two verified adds) and `changes` picking both up — will run in the VM with the next lab-gated PR; this one is host-only code on already-validated ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)