### PR TITLE
feat(write): things undo — inverse mutations replayed from the audit trail (Phase 15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ things todo move <uuid> --project "Errands" --dry-run --json   # inspect the pla
 things todo move <uuid> --project "Errands" --json             # execute, verified
 things changes --since 2026-07-05T08:00 --json # what changed since the agent last looked
 things batch inbox-triage.jsonl                # N ops, each guarded+verified, JSONL results
+things undo --dry-run                          # inverse plan for the last mutation (audit replay)
+things undo                                    # execute it — verified like any mutation
 ```
 
 Failure modes are first-class: a `verify-failed:silent-noop` means the app accepted the command and did nothing (a real Things behavior the guards mostly prevent — see [docs/things-app-oddities.md](docs/things-app-oddities.md)); `blocked:*` responses include machine-readable remediation.

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -83,5 +83,6 @@ Fills: **headings in existing projects** (unique), maybe heading-archive + remin
 6. **Phase 12 (DONE 2026-07-05)** — search ergonomics (open+untrashed default, scoping flags, `--exact-tag`), tag-hierarchy descendants on `--tag`, dated reminders, template-duplication verdict (E13: DISPROVEN).
 7. **Phase 13 (DONE 2026-07-06)** — `things batch` (JSONL through the full pipeline) + `things changes --since` (userModificationDate scan).
 8. **Phase 14 (DONE 2026-07-06)** — Tier-2 probe campaign (E14–E19, O13–O14) + ops: project move/duplicate, todo restore, project notes modes, area-scope project reorder; dead ends locked (convert, tag un-nest, sidebar area order). Tasks #32–#33.
+9. **Phase 15 (DONE 2026-07-06)** — `things undo [--last N]`: inverse mutations replayed from the audit trail's pre-values (status flips, field restores, delete→restore via E15, tag/checklist sets, native-reorder rank restore). Every inverse runs the full guarded+verified pipeline; irreversible ops (permanent deletes, project complete/delete, uncaptured pre-state) are reported honestly, never guessed. Task #34.
 
 Permanently out of reach (documented + guarded, revisit per Things release): repeat creation/rule-editing; checklist granular writes; to-do↔project conversion; tag un-nest to root; sidebar area ordering.

--- a/lab/guest/e2e-write-smoke.sh
+++ b/lab/guest/e2e-write-smoke.sh
@@ -138,6 +138,17 @@ if ! json_get "len([i for i in d['data'] if i['title'].startswith('E2E-B')])" | 
   FAILURES=$((FAILURES + 1))
 fi
 
+echo "== undo (Phase 15: audit replay) =="
+run_step 0 "seed to-do for undo" todo add "E2E-UNDOME" --when today
+UNDO1=$(json_get "d['data']['uuid']")
+run_step 0 "complete it" todo complete "$UNDO1"
+run_step 0 "undo reopens it (inverse verified)" undo
+run_step 0 "it IS open again (completing works)" todo complete "$UNDO1"
+run_step 0 "undo dry-run plans without executing" undo --dry-run
+run_step 0 "undo the re-completion" undo
+run_step 0 "delete it to the Trash" todo delete "$UNDO1"
+run_step 0 "undo restores it from the Trash (E15 inverse)" undo
+
 echo "== deletes =="
 run_step 0 "todo delete -> trash (applescript)" todo delete "$UUID"
 run_step 0 "area add (applescript)" area add "E2E-AREA"

--- a/src/cli/commands/writes.ts
+++ b/src/cli/commands/writes.ts
@@ -20,6 +20,7 @@ import {
 import type { WriteOptions } from "../../write/pipeline.ts";
 import { outcomeFailed, type BatchItemResult, type BatchOp } from "../../write/batch.ts";
 import { BOUNCE_MAX_ITEMS, type ReorderResult } from "../../write/reorder.ts";
+import type { UndoItemResult } from "../../write/undo.ts";
 import { defaultVectors } from "../../write/vectors/registry.ts";
 import type { VectorId } from "../../write/vectors/types.ts";
 import { ExitCode } from "../exit-codes.ts";
@@ -886,6 +887,68 @@ export function registerWriteCommands(program: Command): void {
             : failed.length > 0
               ? ExitCode.VerifyFailed
               : ExitCode.Ok;
+      } finally {
+        client?.close();
+      }
+    });
+
+  program
+    .command("undo")
+    .description(
+      "Undo the last N successful mutations by replaying INVERSE ops from the audit trail " +
+        "(newest first). Each inverse runs the full pipeline: guards, verified " +
+        "read-after-write, audit (as actor `undo:<actor>` — never itself an undo target). " +
+        "IRREVERSIBLE ops are reported, not guessed: permanent deletes, project " +
+        "complete/delete, ops whose pre-state was not captured. Partial restores carry " +
+        "notes (e.g. a delete-undo lands in the Inbox de-scheduled). --dry-run shows every " +
+        "inverse plan without executing. Undoing a CREATED area/tag deletes it permanently " +
+        "— requires --dangerously-permanent. Unwinding stops at the first failed inverse. " +
+        "Exit: 0 all ok · 3 any failed/partial · 0 with per-item detail otherwise.",
+    )
+    .option("--last <n>", "how many trailing mutations to undo", "1")
+    .option("--dry-run", "show the inverse plans; execute nothing")
+    .option("--dangerously-permanent", "allow inverses that delete areas/tags permanently")
+    .option("--json", "JSONL per-item results + summary on stdout (also the default)")
+    .option("--db <path>", "explicit database path")
+    .option("--verify-timeout <ms>", "read-after-write verification deadline per inverse op")
+    .option("--actor <name>", "audit attribution (recorded as undo:<name>)")
+    .action(async (opts: WriteFlagOpts & Record<string, unknown>) => {
+      let client: ThingsClient | null = null;
+      try {
+        client = openThings(opts.db ? { dbPath: opts.db } : {});
+        const items = await client.write.undo(
+          {
+            last: Number(opts["last"] ?? 1),
+            ...(opts.dryRun !== undefined && { dryRun: opts.dryRun }),
+            ...(opts["dangerouslyPermanent"] === true && { dangerouslyPermanent: true }),
+            ...(opts.verifyTimeout !== undefined && {
+              verifyTimeoutMs: Number(opts.verifyTimeout),
+            }),
+            ...(opts.actor !== undefined && { actor: opts.actor }),
+          },
+          (item: UndoItemResult) => {
+            process.stdout.write(`${JSON.stringify(item)}\n`);
+          },
+        );
+        const summary = {
+          summary: {
+            targets: items.length,
+            ok: items.filter((i) => i.outcome === "ok").length,
+            irreversible: items.filter((i) => i.outcome === "irreversible").length,
+            failed: items.filter((i) => i.outcome === "failed" || i.outcome === "partial").length,
+            dryRun: items.filter((i) => i.outcome === "dry-run").length,
+          },
+        };
+        process.stdout.write(`${JSON.stringify(summary)}\n`);
+        process.exitCode =
+          summary.summary.failed > 0
+            ? ExitCode.VerifyFailed
+            : items.length === 0
+              ? ExitCode.Usage
+              : ExitCode.Ok;
+        if (items.length === 0) {
+          process.stderr.write("error: no undoable mutations found in the audit trail\n");
+        }
       } finally {
         client?.close();
       }

--- a/src/client.ts
+++ b/src/client.ts
@@ -58,6 +58,7 @@ import {
 } from "./write/pipeline.ts";
 import { runBatch, type BatchItemResult, type BatchOp, type BatchOptions } from "./write/batch.ts";
 import { runReorder, type ReorderResult } from "./write/reorder.ts";
+import { runUndo, type UndoItemResult, type UndoOptions } from "./write/undo.ts";
 import { defaultVectors } from "./write/vectors/registry.ts";
 import type { WriteVector } from "./write/vectors/types.ts";
 import type { PollerDeps } from "./write/verify/poller.ts";
@@ -182,6 +183,12 @@ export interface ThingsClient {
       options?: BatchOptions,
       onResult?: (result: BatchItemResult) => void,
     ): Promise<BatchItemResult[]>;
+    /**
+     * Undo the last N successful mutations by replaying inverse ops from the
+     * audit trail (each inverse runs the full guarded+verified pipeline).
+     * Irreversible ops are reported as such, never guessed at.
+     */
+    undo(options?: UndoOptions, onItem?: (item: UndoItemResult) => void): Promise<UndoItemResult[]>;
   };
   close(): void;
 }
@@ -292,6 +299,7 @@ export function openThings(options: OpenOptions = {}): ThingsClient {
       emptyTrash: (o) => run("trash.empty", {}, o),
       reorder: (params, o) => runReorder(writeDeps, params, o ?? {}),
       batch: (ops, o, onResult) => runBatch(writeDeps, ops, o ?? {}, onResult),
+      undo: (o, onItem) => runUndo(writeDeps, auditDir(env), o ?? {}, onItem),
     },
     close: () => conn.close(),
   };

--- a/src/write/undo.ts
+++ b/src/write/undo.ts
@@ -1,0 +1,616 @@
+/**
+ * `things undo` — inverse mutations replayed from the audit trail.
+ *
+ * Every successful mutation's audit record carries the pre-values of the
+ * fields it asserted (title, notes, status, tags, ranks, …) plus the target
+ * uuid — enough to compile an INVERSE plan for most operations. The inverse
+ * runs through the SAME pipeline as any mutation (guards, verified
+ * read-after-write, audit), so a concurrently-edited target surfaces as a
+ * blocked/verify-failed result, never a blind overwrite.
+ *
+ * Honesty rules:
+ *  - Ops with no validated inverse surface are reported IRREVERSIBLE with
+ *    the reason (permanent deletes, project completion cascades, un-nesting
+ *    a tag to root — E19, project→no-area — unprobed).
+ *  - Partial inversions carry notes (todo.delete undo restores to the Inbox
+ *    de-scheduled; checklist per-item state is unrecoverable).
+ *  - Inverse mutations are audited under an `undo:`-prefixed actor and are
+ *    themselves EXCLUDED from later undo target selection (no undo-the-undo).
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+import type { AuditRecord } from "../audit/schema.ts";
+import { localToday } from "../model/dates.ts";
+import type { OperationKind, ReorderParams } from "./operations.ts";
+import { runMutation, type MutationResult, type WriteDeps, type WriteOptions } from "./pipeline.ts";
+import { runReorder, type ReorderResult } from "./reorder.ts";
+
+export interface UndoStep {
+  op: OperationKind;
+  params: Record<string, unknown>;
+  /** Acknowledgements the inverse op needs (surfaced in the plan). */
+  options?: {
+    acknowledgeChecklistReset?: boolean;
+    dangerouslyPermanent?: boolean;
+  };
+}
+
+export interface UndoPlan {
+  /** The audit record being undone. */
+  target: { ts: string; op: string; uuid: string | null; actor: string };
+  kind: "invertible" | "irreversible";
+  steps: UndoStep[];
+  /** Fidelity caveats — what the inverse cannot restore. */
+  notes: string[];
+  /** Present when kind is "irreversible". */
+  reason?: string;
+}
+
+export interface UndoItemResult {
+  plan: UndoPlan;
+  /** One result per executed step (empty for dry-run/irreversible). */
+  results: (MutationResult | ReorderResult)[];
+  outcome: "ok" | "partial" | "failed" | "irreversible" | "dry-run";
+}
+
+export interface UndoOptions {
+  /** How many trailing mutations to undo (default 1). */
+  last?: number;
+  dryRun?: boolean;
+  /** Required for inverses that delete areas/tags permanently. */
+  dangerouslyPermanent?: boolean;
+  verifyTimeoutMs?: number;
+  actor?: string;
+}
+
+// -------------------------------------------------------------- audit reads
+
+/** Parse every audit record from the monthly JSONL files, oldest first. */
+export function readAuditRecords(dir: string): AuditRecord[] {
+  let files: string[];
+  try {
+    files = readdirSync(dir)
+      .filter((f) => f.endsWith(".jsonl"))
+      .toSorted();
+  } catch {
+    return [];
+  }
+  const records: AuditRecord[] = [];
+  for (const file of files) {
+    let raw: string;
+    try {
+      raw = readFileSync(join(dir, file), "utf8");
+    } catch {
+      continue;
+    }
+    for (const line of raw.split("\n")) {
+      if (line.trim() === "") continue;
+      try {
+        const parsed = JSON.parse(line) as AuditRecord;
+        if (parsed.v === 1 && typeof parsed.op === "string") records.push(parsed);
+      } catch {
+        // tolerate a torn/corrupt line — audit files are append-only
+      }
+    }
+  }
+  return records.toSorted((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
+}
+
+/**
+ * The last N undoable targets, NEWEST FIRST (undo unwinds a stack). Only
+ * successful mutations qualify; inverse mutations (actor `undo:…`) never do.
+ */
+export function selectUndoTargets(records: AuditRecord[], last: number): AuditRecord[] {
+  return records
+    .filter((r) => r.result === "ok" && !r.actor.startsWith("undo:"))
+    .slice(-Math.max(1, last))
+    .toReversed();
+}
+
+// -------------------------------------------------------------- plan builder
+
+const IRREVERSIBLE: Partial<Record<string, string>> = {
+  "area.delete": "areas are deleted permanently — there is nothing to restore (A25)",
+  "tag.delete": "tags are deleted permanently — assignments already cascaded (A26)",
+  "trash.empty": "emptying the Trash hard-deletes every row — nothing to restore (A27)",
+  "project.delete":
+    "no validated surface restores a trashed project (E15 covers to-dos only) — " +
+    "use the app's Trash > Put Back",
+  "project.complete":
+    "no validated surface reopens a completed project (the URL path only completes; " +
+    "the cascade auto-completed children too) — reopen in the app",
+};
+
+function preField(record: AuditRecord, field: string): unknown {
+  return record.pre === null ? undefined : record.pre[field];
+}
+
+/**
+ * Reconstruct the scheduling step that restores a to-do's pre-op placement
+ * from the captured pre-values (start / startDate / todaySection / reminder).
+ */
+function scheduleSteps(
+  uuid: string,
+  record: AuditRecord,
+  todayIso: string,
+): { steps: UndoStep[]; notes: string[] } {
+  const notes: string[] = [];
+  const start = preField(record, "start");
+  const startDate = preField(record, "startDate");
+  const section = preField(record, "todaySection");
+  const reminder = preField(record, "reminder");
+
+  if (start === "inbox") {
+    if (reminder !== undefined && reminder !== null) {
+      notes.push("the pre-state carried a reminder in the Inbox — not reproducible, skipped");
+    }
+    return { steps: [{ op: "todo.move", params: { uuid, inbox: true } }], notes };
+  }
+
+  let when: string | null = null;
+  if (typeof startDate === "string") {
+    // startDate == today maps back to the today/evening keywords (which also
+    // keep the reminder-clear path open); other dates restore literally.
+    if (startDate === todayIso) when = section === "evening" ? "evening" : "today";
+    else {
+      when = startDate;
+      if (section === "evening") {
+        notes.push(
+          "the item was a STALE evening entry (past startDate) — the date is restored but " +
+            "the evening bucket cannot be (bucket placement is today-only)",
+        );
+      }
+    }
+  } else if (start === "someday") {
+    when = "someday";
+  } else if (start === "active" && startDate === null) {
+    when = "anytime";
+  }
+
+  if (when === null) {
+    if (start !== undefined || startDate !== undefined) {
+      notes.push("pre-op scheduling state was not captured fully — when/schedule not restored");
+    }
+    return { steps: [], notes };
+  }
+
+  const params: Record<string, unknown> = { uuid, when };
+  if (reminder !== undefined) {
+    if (reminder === null) {
+      // The undone op SET a reminder where none was: clear it. Only
+      // today/evening have a clear path (R20/R21 — dated are sticky).
+      if (when === "today" || when === "evening") params["reminder"] = null;
+      else {
+        notes.push(
+          "cannot clear the reminder the undone op set: dated reminders are sticky " +
+            "(R20/R21) — clear via `--when today --clear-reminder`, then re-date",
+        );
+      }
+    } else {
+      params["reminder"] = reminder;
+    }
+  }
+  return { steps: [{ op: "todo.update", params }], notes };
+}
+
+/** Build the inverse plan for one audit record. Pure — unit-testable. */
+export function planUndo(record: AuditRecord, now: Date): UndoPlan {
+  const target = { ts: record.ts, op: record.op, uuid: record.uuid, actor: record.actor };
+  const todayIso = localToday(now);
+  const notes: string[] = [];
+  const irreversible = (reason: string): UndoPlan => ({
+    target,
+    kind: "irreversible",
+    steps: [],
+    notes,
+    reason,
+  });
+
+  const fixed = IRREVERSIBLE[record.op];
+  if (fixed !== undefined) return irreversible(fixed);
+
+  const uuid = record.uuid;
+
+  switch (record.op) {
+    // Creations: the inverse is deleting what appeared. To-dos/projects go
+    // to the Trash (restorable); areas/tags delete PERMANENTLY (ack needed).
+    case "todo.add":
+    case "todo.duplicate": {
+      if (uuid === null) return irreversible("the created uuid was never discovered");
+      return {
+        target,
+        kind: "invertible",
+        steps: [{ op: "todo.delete", params: { uuid } }],
+        notes,
+      };
+    }
+    case "project.add":
+    case "project.duplicate": {
+      if (uuid === null) return irreversible("the created uuid was never discovered");
+      notes.push("the project (and any children it carried) moves to the Trash");
+      return {
+        target,
+        kind: "invertible",
+        steps: [{ op: "project.delete", params: { uuid } }],
+        notes,
+      };
+    }
+    case "area.add": {
+      if (uuid === null) return irreversible("the created uuid was never discovered");
+      notes.push("area deletion is PERMANENT — requires --dangerously-permanent");
+      return {
+        target,
+        kind: "invertible",
+        steps: [
+          { op: "area.delete", params: { target: uuid }, options: { dangerouslyPermanent: true } },
+        ],
+        notes,
+      };
+    }
+    case "tag.add": {
+      if (uuid === null) return irreversible("the created uuid was never discovered");
+      notes.push("tag deletion is PERMANENT — requires --dangerously-permanent");
+      return {
+        target,
+        kind: "invertible",
+        steps: [
+          { op: "tag.delete", params: { target: uuid }, options: { dangerouslyPermanent: true } },
+        ],
+        notes,
+      };
+    }
+
+    // Status flips: the pre status says exactly where to go back to.
+    case "todo.complete":
+    case "todo.cancel": {
+      if (uuid === null) return irreversible("no target uuid recorded");
+      if (preField(record, "status") !== "open") {
+        return irreversible("the to-do was not open before the op — nothing to restore");
+      }
+      return {
+        target,
+        kind: "invertible",
+        steps: [{ op: "todo.reopen", params: { uuid } }],
+        notes,
+      };
+    }
+    case "todo.reopen": {
+      if (uuid === null) return irreversible("no target uuid recorded");
+      const was = preField(record, "status");
+      if (was !== "completed" && was !== "canceled") {
+        return irreversible("the pre-op status was not captured — cannot restore");
+      }
+      return {
+        target,
+        kind: "invertible",
+        steps: [{ op: was === "completed" ? "todo.complete" : "todo.cancel", params: { uuid } }],
+        notes,
+      };
+    }
+
+    case "todo.delete": {
+      if (uuid === null) return irreversible("no target uuid recorded");
+      notes.push(
+        "restore lands in the Inbox DE-SCHEDULED (E15) — the prior list/schedule was not " +
+          "captured by the delete",
+      );
+      return {
+        target,
+        kind: "invertible",
+        steps: [{ op: "todo.restore", params: { uuid } }],
+        notes,
+      };
+    }
+    case "todo.restore": {
+      if (uuid === null) return irreversible("no target uuid recorded");
+      return {
+        target,
+        kind: "invertible",
+        steps: [{ op: "todo.delete", params: { uuid } }],
+        notes,
+      };
+    }
+
+    case "todo.update": {
+      if (uuid === null) return irreversible("no target uuid recorded");
+      const steps: UndoStep[] = [];
+      const params: Record<string, unknown> = { uuid };
+      const title = preField(record, "title");
+      const notesPre = preField(record, "notes");
+      const deadline = preField(record, "deadline");
+      if (title !== undefined) params["title"] = title;
+      if (notesPre !== undefined) params["notes"] = notesPre; // covers append/prepend too
+      if (deadline !== undefined) params["deadline"] = deadline;
+      const requestedWhen =
+        (record.requested["when"] ?? record.requested["reminder"]) !== undefined;
+      if (requestedWhen) {
+        const schedule = scheduleSteps(uuid, record, todayIso);
+        notes.push(...schedule.notes);
+        const scheduleStep = schedule.steps[0];
+        if (scheduleStep !== undefined && scheduleStep.op === "todo.update") {
+          Object.assign(params, scheduleStep.params);
+        } else if (scheduleStep !== undefined) {
+          steps.push(scheduleStep); // inbox restore is a separate move op
+        }
+      }
+      if (Object.keys(params).length > 1) steps.unshift({ op: "todo.update", params });
+      if (steps.length === 0) {
+        return irreversible("no pre-values were captured for the changed fields");
+      }
+      return { target, kind: "invertible", steps, notes };
+    }
+
+    case "project.update": {
+      if (uuid === null) return irreversible("no target uuid recorded");
+      const params: Record<string, unknown> = { uuid };
+      const title = preField(record, "title");
+      const notesPre = preField(record, "notes");
+      const deadline = preField(record, "deadline");
+      if (title !== undefined) params["title"] = title;
+      if (notesPre !== undefined) params["notes"] = notesPre;
+      if (deadline !== undefined) params["deadline"] = deadline;
+      if (record.requested["when"] !== undefined) {
+        const startDate = preField(record, "startDate");
+        const start = preField(record, "start");
+        if (typeof startDate === "string") params["when"] = startDate;
+        else if (start === "someday") params["when"] = "someday";
+        else if (start === "active" && startDate === null) params["when"] = "anytime";
+        else notes.push("pre-op project scheduling was not captured fully — when not restored");
+      }
+      if (Object.keys(params).length === 1) {
+        return irreversible("no pre-values were captured for the changed fields");
+      }
+      return {
+        target,
+        kind: "invertible",
+        steps: [{ op: "project.update", params }],
+        notes,
+      };
+    }
+
+    case "todo.move": {
+      if (uuid === null) return irreversible("no target uuid recorded");
+      // A move-to-inbox op asserted start/startDate instead of containers.
+      if (record.requested["inbox"] === true) {
+        const schedule = scheduleSteps(uuid, record, todayIso);
+        notes.push(...schedule.notes);
+        notes.push(
+          "the pre-op project/area link was not captured by the inbox move — not restored",
+        );
+        if (schedule.steps.length === 0) {
+          return irreversible("pre-op scheduling state was not captured — cannot leave the Inbox");
+        }
+        return { target, kind: "invertible", steps: schedule.steps, notes };
+      }
+      // The audit captured the OLD value of whatever destination-kind fields
+      // the move asserted: "project.uuid"/"heading.uuid" (project moves),
+      // "area.uuid" + "project" as a Ref (area moves — A22B clears the link).
+      const projectRef = preField(record, "project");
+      const oldProject =
+        preField(record, "project.uuid") ??
+        (typeof projectRef === "object" && projectRef !== null
+          ? (projectRef as { uuid?: unknown }).uuid
+          : undefined);
+      const oldArea = preField(record, "area.uuid");
+      if (typeof oldProject === "string") {
+        if (preField(record, "heading.uuid") !== undefined) {
+          notes.push(
+            "heading placement cannot be restored (no heading-move surface) — " +
+              "the to-do returns to the project root",
+          );
+        }
+        return {
+          target,
+          kind: "invertible",
+          steps: [{ op: "todo.move", params: { uuid, project: { uuid: oldProject } } }],
+          notes,
+        };
+      }
+      if (typeof oldArea === "string") {
+        return {
+          target,
+          kind: "invertible",
+          steps: [{ op: "todo.move", params: { uuid, area: { uuid: oldArea } } }],
+          notes,
+        };
+      }
+      // The captured fields say only "no <destination-kind> before" — the
+      // real prior container (a different kind, or none) was never recorded.
+      return irreversible(
+        "the pre-op container was not fully captured (only the destination-kind field is " +
+          "audited) — move it back manually",
+      );
+    }
+
+    case "project.move": {
+      if (uuid === null) return irreversible("no target uuid recorded");
+      const areaPre = preField(record, "area.uuid");
+      if (typeof areaPre === "string") {
+        return {
+          target,
+          kind: "invertible",
+          steps: [{ op: "project.move", params: { uuid, area: { uuid: areaPre } } }],
+          notes,
+        };
+      }
+      return irreversible(
+        "the project had no area before the move — clearing a project's area is unprobed " +
+          "(no validated surface); move it back in the app",
+      );
+    }
+
+    case "todo.set-tags": {
+      if (uuid === null) return irreversible("no target uuid recorded");
+      const tags = preField(record, "tags");
+      if (!Array.isArray(tags)) return irreversible("the pre-op tag set was not captured");
+      return {
+        target,
+        kind: "invertible",
+        steps: [{ op: "todo.set-tags", params: { uuid, tags } }],
+        notes,
+      };
+    }
+
+    case "todo.replace-checklist": {
+      if (uuid === null) return irreversible("no target uuid recorded");
+      const items = preField(record, "checklistTitles");
+      if (!Array.isArray(items)) return irreversible("the pre-op checklist was not captured");
+      notes.push("checklist TITLES are restored; per-item completion state is unrecoverable (T07)");
+      return {
+        target,
+        kind: "invertible",
+        steps: [
+          {
+            op: "todo.replace-checklist",
+            params: { uuid, items },
+            options: { acknowledgeChecklistReset: true },
+          },
+        ],
+        notes,
+      };
+    }
+
+    case "area.update": {
+      if (uuid === null) return irreversible("no target uuid recorded");
+      const patch: Record<string, unknown> = { target: uuid };
+      const title = preField(record, "title");
+      const tags = preField(record, "tags");
+      if (title !== undefined) patch["title"] = title;
+      if (Array.isArray(tags)) patch["tags"] = tags;
+      if (Object.keys(patch).length === 1) return irreversible("no pre-values were captured");
+      return { target, kind: "invertible", steps: [{ op: "area.update", params: patch }], notes };
+    }
+
+    case "tag.update": {
+      if (uuid === null) return irreversible("no target uuid recorded");
+      const patch: Record<string, unknown> = { target: uuid };
+      const title = preField(record, "title");
+      const parent = preField(record, "parent");
+      const shortcut = preField(record, "shortcut");
+      if (title !== undefined) patch["title"] = title;
+      if (typeof parent === "string" && parent !== "") patch["parent"] = parent;
+      else if (parent === null) {
+        notes.push(
+          "the tag was un-nested before the op — un-nesting to root is IMPOSSIBLE via " +
+            "automation (E19); fix the parent in the app",
+        );
+      }
+      if (typeof shortcut === "string") patch["shortcut"] = shortcut;
+      else if (shortcut === null && record.requested["shortcut"] !== undefined) {
+        notes.push("clearing a keyboard shortcut is unprobed — the new shortcut stays");
+      }
+      if (Object.keys(patch).length === 1) {
+        return irreversible("none of the changed tag fields can be restored (see notes)");
+      }
+      return { target, kind: "invertible", steps: [{ op: "tag.update", params: patch }], notes };
+    }
+
+    case "reorder": {
+      const pre = record.pre;
+      if (pre === null) {
+        return irreversible(
+          "bounce reorders record no pre-ranks in their summary — undo their individual " +
+            "when= legs instead (separate audit records)",
+        );
+      }
+      const requested = record.requested as unknown as ReorderParams;
+      const ranked = Object.entries(pre).filter(([, rank]) => typeof rank === "number") as [
+        string,
+        number,
+      ][];
+      if (ranked.length === 0) return irreversible("no pre-ranks were captured");
+      const uuids = ranked.toSorted((a, b) => a[1] - b[1]).map(([id]) => id);
+      const params: Record<string, unknown> = { scope: requested.scope, uuids };
+      if (requested.container !== undefined) params["container"] = requested.container;
+      notes.push(
+        "the requested uuids return to their pre-op relative order; other members keep " +
+          "their current positions",
+      );
+      return { target, kind: "invertible", steps: [{ op: "reorder", params }], notes };
+    }
+
+    default:
+      return irreversible(`no inverse is defined for operation "${record.op}"`);
+  }
+}
+
+// ----------------------------------------------------------------- executor
+
+export async function runUndo(
+  deps: WriteDeps,
+  auditDirPath: string,
+  options: UndoOptions = {},
+  onItem?: (item: UndoItemResult) => void,
+): Promise<UndoItemResult[]> {
+  const records = readAuditRecords(auditDirPath);
+  const targets = selectUndoTargets(records, options.last ?? 1);
+  const now = deps.now?.() ?? new Date();
+  const items: UndoItemResult[] = [];
+
+  for (const record of targets) {
+    const plan = planUndo(record, now);
+    let item: UndoItemResult;
+
+    if (plan.kind === "irreversible") {
+      item = { plan, results: [], outcome: "irreversible" };
+    } else if (options.dryRun === true) {
+      item = { plan, results: [], outcome: "dry-run" };
+    } else {
+      const results: (MutationResult | ReorderResult)[] = [];
+      let failed = false;
+      for (const step of plan.steps) {
+        const needsPermanent = step.options?.dangerouslyPermanent === true;
+        if (needsPermanent && options.dangerouslyPermanent !== true) {
+          results.push({
+            kind: "blocked",
+            op: step.op,
+            reason: "hazard",
+            hazard: "H-PERMANENT-DELETE",
+            detail: `undoing this ${record.op} deletes the created entity PERMANENTLY`,
+            remediation: "re-run with --dangerously-permanent",
+          });
+          failed = true;
+          break;
+        }
+        const writeOptions: WriteOptions = {
+          actor: `undo:${options.actor ?? deps.config.actor}`,
+          ...(options.verifyTimeoutMs !== undefined && {
+            verifyTimeoutMs: options.verifyTimeoutMs,
+          }),
+          ...(step.options?.acknowledgeChecklistReset === true && {
+            acknowledgeChecklistReset: true,
+          }),
+          ...(needsPermanent && { dangerouslyPermanent: true }),
+        };
+        const result =
+          step.op === "reorder"
+            ? await runReorder(deps, step.params as unknown as ReorderParams, writeOptions)
+            : await runMutation(
+                deps,
+                step.op as Exclude<OperationKind, "reorder">,
+                step.params as never,
+                writeOptions,
+              );
+        results.push(result);
+        if (result.kind !== "ok") {
+          failed = true;
+          break;
+        }
+      }
+      const okCount = results.filter((r) => r.kind === "ok").length;
+      item = {
+        plan,
+        results,
+        outcome: failed ? (okCount > 0 ? "partial" : "failed") : "ok",
+      };
+    }
+
+    items.push(item);
+    onItem?.(item);
+    // A failed inverse means the state no longer matches the audit trail —
+    // unwinding further would compound the divergence.
+    if (item.outcome === "failed" || item.outcome === "partial") break;
+  }
+  return items;
+}

--- a/test/cli/help-contract.test.ts
+++ b/test/cli/help-contract.test.ts
@@ -192,6 +192,16 @@ describe("write-command help states the contract", () => {
     expect(help).toContain("H-REPEAT-SCHEDULE");
   });
 
+  it("undo: audit-replay contract — inverse pipeline, irreversibles, permanent gate", () => {
+    const help = helpFor("undo");
+    expect(help).toContain("INVERSE");
+    expect(help).toContain("IRREVERSIBLE");
+    expect(help).toContain("--last <n>");
+    expect(help).toContain("--dry-run");
+    expect(help).toContain("--dangerously-permanent");
+    expect(help).toContain("undo:<actor>");
+  });
+
   it("project update: notes modes documented", () => {
     const help = helpFor("project", "update");
     expect(help).toContain("--append-notes");

--- a/test/engine/write-undo.test.ts
+++ b/test/engine/write-undo.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Phase 15 engine tests: runUndo end-to-end — audit-trail selection, inverse
+ * execution through the real pipeline (fake vectors), the permanent-delete
+ * gate, dry-run, and unwind-stop-on-failure.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { AuditRecord } from "../../src/audit/schema.ts";
+import type { ThingsApiConfig } from "../../src/config.ts";
+import type { FingerprintStatus } from "../../src/db/fingerprint.ts";
+import type { WriteDeps } from "../../src/write/pipeline.ts";
+import { runUndo } from "../../src/write/undo.ts";
+import type { VectorMatrix, WriteVector } from "../../src/write/vectors/types.ts";
+import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
+import { seedArea, seedTodo } from "../fixtures/seed.ts";
+
+const NOW = new Date("2026-07-05T12:00:00Z");
+const NOW_EPOCH = Math.floor(NOW.getTime() / 1000);
+
+let fixture: FixtureDb;
+let auditDir: string;
+let auditRecords: AuditRecord[];
+let lockSeq = 0;
+
+beforeEach(() => {
+  fixture = buildFixtureDb();
+  auditDir = mkdtempSync(join(tmpdir(), "things-api-undo-audit-"));
+  auditRecords = [];
+});
+afterEach(() => {
+  fixture.close();
+  rmSync(auditDir, { recursive: true, force: true });
+});
+
+const CONFIG: ThingsApiConfig = {
+  profile: "workstation",
+  maxDisruption: 1,
+  actor: "mike",
+  auditEnabled: true,
+  acceptedFingerprint: null,
+  allowExperimental: false,
+  host: "test-host",
+};
+
+function auditRecord(partial: Partial<AuditRecord>): AuditRecord {
+  return {
+    v: 1,
+    ts: "2026-07-05T10:00:00.000Z",
+    actor: "mike",
+    host: "test-host",
+    op: "todo.update",
+    uuid: null,
+    vector: "url-scheme",
+    disruption: 0,
+    invocation: "x",
+    requested: {},
+    pre: null,
+    observed: null,
+    result: "ok",
+    verify: null,
+    durationMs: 1,
+    env: { pkg: "0.1.0", dbVersion: 26, fingerprint: "ok" },
+    ...partial,
+  };
+}
+
+function writeAudit(records: AuditRecord[]): void {
+  writeFileSync(join(auditDir, "2026-07.jsonl"), records.map((r) => JSON.stringify(r)).join("\n"));
+}
+
+const MATRIX: VectorMatrix = Object.fromEntries(
+  ["todo.reopen", "todo.complete", "todo.restore", "todo.delete", "area.delete"].map((op) => [
+    op,
+    { support: "yes", disruption: 0, validation: "validated" },
+  ]),
+) as VectorMatrix;
+
+function fakeVector(effect: ((payload: string) => void) | null) {
+  const calls: string[] = [];
+  const vector: WriteVector = {
+    id: "applescript",
+    matrix: MATRIX,
+    async execute(invocation) {
+      calls.push(invocation.payload);
+      effect?.(invocation.payload);
+      return { exitCode: 0, stdout: "", stderr: "" };
+    },
+  };
+  return { vector, calls };
+}
+
+function deps(vectors: WriteVector[]): WriteDeps {
+  return {
+    db: fixture.db,
+    vectors,
+    config: CONFIG,
+    audit: { append: (r) => auditRecords.push(r) },
+    fingerprint: (): FingerprintStatus => ({
+      kind: "ok",
+      observation: { databaseVersion: 26, tables: [], fingerprint: "sha256:test" },
+    }),
+    lockPath: join(tmpdir(), `things-api-undo-lock-${process.pid}-${lockSeq++}`),
+    isAppRunning: () => true,
+    ensureRunning: async () => true,
+    now: () => NOW,
+  };
+}
+
+function touch(uuid: string, sets: string): void {
+  fixture.db
+    .prepare(`UPDATE TMTask SET ${sets}, userModificationDate = ? WHERE uuid = ?`)
+    .run(NOW_EPOCH + 1, uuid);
+}
+
+describe("runUndo", () => {
+  it("undoes a completion: reopen executed, verified, audited as undo:<actor>", async () => {
+    const uuid = seedTodo(fixture.db, { title: "Done", status: "completed" });
+    writeAudit([auditRecord({ op: "todo.complete", uuid, pre: { status: "open" } })]);
+    const { vector, calls } = fakeVector(() => touch(uuid, "status = 0"));
+
+    const items = await runUndo(deps([vector]), auditDir);
+    expect(items).toHaveLength(1);
+    expect(items[0]?.outcome).toBe("ok");
+    expect(calls[0]).toContain(`set status of to do id "${uuid}" to open`);
+    expect(auditRecords[0]?.actor).toBe("undo:mike");
+    expect(auditRecords[0]?.op).toBe("todo.reopen");
+  });
+
+  it("undoes a delete via todo.restore (the Phase-14 primitive)", async () => {
+    const uuid = seedTodo(fixture.db, { title: "Trashed", trashed: true });
+    writeAudit([auditRecord({ op: "todo.delete", uuid, pre: { trashed: false } })]);
+    const { vector, calls } = fakeVector(() => touch(uuid, "trashed = 0, start = 0"));
+
+    const items = await runUndo(deps([vector]), auditDir);
+    expect(items[0]?.outcome).toBe("ok");
+    expect(items[0]?.plan.notes.join(" ")).toContain("Inbox");
+    expect(calls[0]).toContain(`move to do id "${uuid}" to list "Inbox"`);
+  });
+
+  it("dry-run returns plans without executing anything", async () => {
+    const uuid = seedTodo(fixture.db, { title: "Done", status: "completed" });
+    writeAudit([auditRecord({ op: "todo.complete", uuid, pre: { status: "open" } })]);
+    const { vector, calls } = fakeVector(null);
+
+    const items = await runUndo(deps([vector]), auditDir, { dryRun: true });
+    expect(items[0]?.outcome).toBe("dry-run");
+    expect(items[0]?.plan.steps[0]?.op).toBe("todo.reopen");
+    expect(calls).toHaveLength(0);
+    expect(auditRecords).toHaveLength(0);
+  });
+
+  it("gates permanent inverses behind dangerouslyPermanent", async () => {
+    const areaUuid = seedArea(fixture.db, "Created");
+    writeAudit([auditRecord({ op: "area.add", uuid: areaUuid })]);
+    const { vector, calls } = fakeVector(null);
+
+    const blocked = await runUndo(deps([vector]), auditDir);
+    expect(blocked[0]?.outcome).toBe("failed");
+    const result = blocked[0]?.results[0];
+    expect(result?.kind).toBe("blocked");
+    if (result?.kind === "blocked") expect(result.hazard).toBe("H-PERMANENT-DELETE");
+    expect(calls).toHaveLength(0);
+
+    const { vector: v2, calls: c2 } = fakeVector(() => {
+      fixture.db.prepare("DELETE FROM TMArea WHERE uuid = ?").run(areaUuid);
+    });
+    const allowed = await runUndo(deps([v2]), auditDir, { dangerouslyPermanent: true });
+    expect(allowed[0]?.outcome).toBe("ok");
+    expect(c2[0]).toContain(`delete area id "${areaUuid}"`);
+  });
+
+  it("reports irreversible targets without touching the app", async () => {
+    writeAudit([auditRecord({ op: "trash.empty", uuid: null })]);
+    const { vector, calls } = fakeVector(null);
+    const items = await runUndo(deps([vector]), auditDir);
+    expect(items[0]?.outcome).toBe("irreversible");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("unwinds newest-first and STOPS after a failed inverse", async () => {
+    const a = seedTodo(fixture.db, { title: "A", status: "completed" });
+    const b = seedTodo(fixture.db, { title: "B", status: "completed" });
+    writeAudit([
+      auditRecord({
+        ts: "2026-07-05T09:00:00Z",
+        op: "todo.complete",
+        uuid: a,
+        pre: { status: "open" },
+      }),
+      auditRecord({
+        ts: "2026-07-05T09:30:00Z",
+        op: "todo.complete",
+        uuid: b,
+        pre: { status: "open" },
+      }),
+    ]);
+    // The vector does nothing → the first (newest, B) inverse verify-fails.
+    const { vector } = fakeVector(null);
+    const items = await runUndo(deps([vector]), auditDir, { verifyTimeoutMs: 300, last: 2 });
+    expect(items).toHaveLength(1); // stopped before touching A
+    expect(items[0]?.plan.target.uuid).toBe(b);
+    expect(items[0]?.outcome).toBe("failed");
+  });
+
+  it("never selects undo-generated records as targets", async () => {
+    const uuid = seedTodo(fixture.db, { title: "Done", status: "completed" });
+    writeAudit([
+      auditRecord({
+        ts: "2026-07-05T09:00:00Z",
+        op: "todo.complete",
+        uuid,
+        pre: { status: "open" },
+      }),
+      auditRecord({
+        ts: "2026-07-05T09:30:00Z",
+        op: "todo.reopen",
+        uuid,
+        actor: "undo:mike",
+        pre: { status: "completed" },
+      }),
+    ]);
+    const { vector } = fakeVector(() => touch(uuid, "status = 0"));
+    const items = await runUndo(deps([vector]), auditDir);
+    expect(items[0]?.plan.target.op).toBe("todo.complete");
+  });
+});

--- a/test/unit/undo-plan.test.ts
+++ b/test/unit/undo-plan.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Phase 15 unit tests: undo target selection + inverse-plan construction.
+ * planUndo is pure — records in, plans out — so every op class is covered
+ * here without touching a pipeline.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import type { AuditRecord } from "../../src/audit/schema.ts";
+import { planUndo, readAuditRecords, selectUndoTargets } from "../../src/write/undo.ts";
+
+const NOW = new Date("2026-07-05T12:00:00Z");
+
+function record(partial: Partial<AuditRecord>): AuditRecord {
+  return {
+    v: 1,
+    ts: "2026-07-05T10:00:00.000Z",
+    actor: "mike",
+    host: "host",
+    op: "todo.update",
+    uuid: "U-1",
+    vector: "url-scheme",
+    disruption: 0,
+    invocation: "things:///update?...",
+    requested: {},
+    pre: null,
+    observed: null,
+    result: "ok",
+    verify: null,
+    durationMs: 1,
+    env: { pkg: "0.1.0", dbVersion: 26, fingerprint: "ok" },
+    ...partial,
+  };
+}
+
+describe("selectUndoTargets", () => {
+  it("takes only successful records, newest first, excluding undo-generated ones", () => {
+    const records = [
+      record({ ts: "2026-07-05T09:00:00Z", op: "todo.add", uuid: "A" }),
+      record({
+        ts: "2026-07-05T09:10:00Z",
+        op: "todo.complete",
+        result: "blocked:H-REPEAT-SCHEDULE",
+      }),
+      record({ ts: "2026-07-05T09:20:00Z", op: "todo.complete", uuid: "B" }),
+      record({ ts: "2026-07-05T09:30:00Z", op: "todo.reopen", uuid: "B", actor: "undo:mike" }),
+    ];
+    const targets = selectUndoTargets(records, 2);
+    expect(targets.map((t) => t.uuid)).toEqual(["B", "A"]);
+  });
+});
+
+describe("readAuditRecords", () => {
+  it("parses monthly files, tolerates torn lines, sorts by ts", () => {
+    const dir = mkdtempSync(join(tmpdir(), "things-api-undo-test-"));
+    try {
+      writeFileSync(
+        join(dir, "2026-07.jsonl"),
+        `${JSON.stringify(record({ ts: "2026-07-05T10:00:00Z", op: "b" }))}\n{"torn`,
+      );
+      writeFileSync(
+        join(dir, "2026-06.jsonl"),
+        `${JSON.stringify(record({ ts: "2026-06-01T10:00:00Z", op: "a" }))}\n`,
+      );
+      const records = readAuditRecords(dir);
+      expect(records.map((r) => r.op)).toEqual(["a", "b"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty for a missing directory", () => {
+    expect(readAuditRecords("/nonexistent/audit")).toEqual([]);
+  });
+});
+
+describe("planUndo — creations invert to deletes", () => {
+  it("todo.add → todo.delete (to Trash)", () => {
+    const plan = planUndo(record({ op: "todo.add", uuid: "NEW-1" }), NOW);
+    expect(plan.kind).toBe("invertible");
+    expect(plan.steps).toEqual([{ op: "todo.delete", params: { uuid: "NEW-1" } }]);
+  });
+
+  it("project.duplicate → project.delete of the copy", () => {
+    const plan = planUndo(record({ op: "project.duplicate", uuid: "COPY-1" }), NOW);
+    expect(plan.steps[0]).toEqual({ op: "project.delete", params: { uuid: "COPY-1" } });
+  });
+
+  it("area.add → PERMANENT area.delete flagged with the ack", () => {
+    const plan = planUndo(record({ op: "area.add", uuid: "AREA-1" }), NOW);
+    expect(plan.kind).toBe("invertible");
+    expect(plan.steps[0]?.options?.dangerouslyPermanent).toBe(true);
+    expect(plan.notes.join(" ")).toContain("PERMANENT");
+  });
+
+  it("a create whose uuid was never discovered is irreversible", () => {
+    const plan = planUndo(record({ op: "todo.add", uuid: null }), NOW);
+    expect(plan.kind).toBe("irreversible");
+  });
+});
+
+describe("planUndo — status flips", () => {
+  it("todo.complete with pre open → todo.reopen", () => {
+    const plan = planUndo(record({ op: "todo.complete", pre: { status: "open" } }), NOW);
+    expect(plan.steps).toEqual([{ op: "todo.reopen", params: { uuid: "U-1" } }]);
+  });
+
+  it("todo.reopen restores the exact pre status (canceled)", () => {
+    const plan = planUndo(record({ op: "todo.reopen", pre: { status: "canceled" } }), NOW);
+    expect(plan.steps[0]?.op).toBe("todo.cancel");
+  });
+
+  it("todo.complete on an already-resolved item is irreversible", () => {
+    const plan = planUndo(record({ op: "todo.complete", pre: { status: "completed" } }), NOW);
+    expect(plan.kind).toBe("irreversible");
+  });
+});
+
+describe("planUndo — delete / restore", () => {
+  it("todo.delete → todo.restore with the Inbox caveat", () => {
+    const plan = planUndo(record({ op: "todo.delete", pre: { trashed: false } }), NOW);
+    expect(plan.steps).toEqual([{ op: "todo.restore", params: { uuid: "U-1" } }]);
+    expect(plan.notes.join(" ")).toContain("Inbox");
+  });
+
+  it("todo.restore → todo.delete", () => {
+    const plan = planUndo(record({ op: "todo.restore" }), NOW);
+    expect(plan.steps[0]?.op).toBe("todo.delete");
+  });
+
+  it("project.delete is irreversible (E15 covers to-dos only)", () => {
+    const plan = planUndo(record({ op: "project.delete" }), NOW);
+    expect(plan.kind).toBe("irreversible");
+    expect(plan.reason).toContain("Put Back");
+  });
+});
+
+describe("planUndo — field updates", () => {
+  it("restores title/notes/deadline from pre-values", () => {
+    const plan = planUndo(
+      record({
+        op: "todo.update",
+        requested: { title: "New", notes: "new body" },
+        pre: { title: "Old", notes: "old body" },
+      }),
+      NOW,
+    );
+    expect(plan.steps).toEqual([
+      { op: "todo.update", params: { uuid: "U-1", title: "Old", notes: "old body" } },
+    ]);
+  });
+
+  it("re-schedule from the Inbox inverts to a move back to the Inbox", () => {
+    const plan = planUndo(
+      record({
+        op: "todo.update",
+        requested: { when: "today" },
+        pre: { start: "inbox", startDate: null, todaySection: null, reminder: null },
+      }),
+      NOW,
+    );
+    expect(plan.steps).toEqual([{ op: "todo.move", params: { uuid: "U-1", inbox: true } }]);
+  });
+
+  it("re-schedule from a date restores when=<date> and the old reminder", () => {
+    const plan = planUndo(
+      record({
+        op: "todo.update",
+        requested: { when: "today" },
+        pre: { start: "someday", startDate: "2026-07-09", todaySection: null, reminder: "15:00" },
+      }),
+      NOW,
+    );
+    expect(plan.steps).toEqual([
+      { op: "todo.update", params: { uuid: "U-1", when: "2026-07-09", reminder: "15:00" } },
+    ]);
+  });
+
+  it("a reminder set on today inverts to an explicit clear", () => {
+    const plan = planUndo(
+      record({
+        op: "todo.update",
+        requested: { when: "today", reminder: "10:00" },
+        pre: { start: "active", startDate: "2026-07-05", todaySection: "today", reminder: null },
+      }),
+      NOW,
+    );
+    expect(plan.steps).toEqual([
+      { op: "todo.update", params: { uuid: "U-1", when: "today", reminder: null } },
+    ]);
+  });
+
+  it("a reminder set on a DATE cannot be cleared (sticky) — noted, not attempted", () => {
+    const plan = planUndo(
+      record({
+        op: "todo.update",
+        requested: { when: "2026-07-09", reminder: "10:00" },
+        pre: { start: "someday", startDate: "2026-07-09", todaySection: null, reminder: null },
+      }),
+      NOW,
+    );
+    const step = plan.steps[0];
+    expect(step?.params["when"]).toBe("2026-07-09");
+    expect("reminder" in (step?.params ?? {})).toBe(false);
+    expect(plan.notes.join(" ")).toContain("sticky");
+  });
+
+  it("today+evening membership restores as when=evening when the date is today", () => {
+    const plan = planUndo(
+      record({
+        op: "todo.update",
+        requested: { when: "someday" },
+        pre: { start: "active", startDate: "2026-07-05", todaySection: "evening", reminder: null },
+      }),
+      NOW,
+    );
+    expect(plan.steps[0]?.params["when"]).toBe("evening");
+  });
+});
+
+describe("planUndo — moves", () => {
+  it("restores the previous project when it was captured", () => {
+    const plan = planUndo(
+      record({ op: "todo.move", requested: { project: {} }, pre: { "project.uuid": "P-OLD" } }),
+      NOW,
+    );
+    expect(plan.steps).toEqual([
+      { op: "todo.move", params: { uuid: "U-1", project: { uuid: "P-OLD" } } },
+    ]);
+  });
+
+  it("area moves capture the old project as a Ref — restored from it", () => {
+    const plan = planUndo(
+      record({
+        op: "todo.move",
+        requested: { area: {} },
+        pre: { "area.uuid": null, project: { uuid: "P-OLD", title: "Old" } },
+      }),
+      NOW,
+    );
+    expect(plan.steps[0]?.params["project"]).toEqual({ uuid: "P-OLD" });
+  });
+
+  it("an unknown prior container is irreversible, not guessed", () => {
+    const plan = planUndo(
+      record({ op: "todo.move", requested: { project: {} }, pre: { "project.uuid": null } }),
+      NOW,
+    );
+    expect(plan.kind).toBe("irreversible");
+  });
+
+  it("project.move restores the old area; no-area-before is irreversible", () => {
+    const back = planUndo(record({ op: "project.move", pre: { "area.uuid": "A-OLD" } }), NOW);
+    expect(back.steps[0]).toEqual({
+      op: "project.move",
+      params: { uuid: "U-1", area: { uuid: "A-OLD" } },
+    });
+    const gone = planUndo(record({ op: "project.move", pre: { "area.uuid": null } }), NOW);
+    expect(gone.kind).toBe("irreversible");
+  });
+});
+
+describe("planUndo — tags, checklist, entities, reorder", () => {
+  it("todo.set-tags restores the pre tag set", () => {
+    const plan = planUndo(
+      record({ op: "todo.set-tags", requested: { tags: ["b"] }, pre: { tags: ["a", "c"] } }),
+      NOW,
+    );
+    expect(plan.steps[0]?.params["tags"]).toEqual(["a", "c"]);
+  });
+
+  it("checklist replacement restores titles with the ack + state caveat", () => {
+    const plan = planUndo(
+      record({ op: "todo.replace-checklist", pre: { checklistTitles: ["x", "y"] } }),
+      NOW,
+    );
+    expect(plan.steps[0]?.options?.acknowledgeChecklistReset).toBe(true);
+    expect(plan.notes.join(" ")).toContain("unrecoverable");
+  });
+
+  it("tag.update with a pre-null parent notes the E19 dead end", () => {
+    const plan = planUndo(
+      record({
+        op: "tag.update",
+        requested: { parent: "work" },
+        pre: { parent: null, title: "deep" },
+      }),
+      NOW,
+    );
+    expect(plan.steps[0]?.params["title"]).toBe("deep");
+    expect("parent" in (plan.steps[0]?.params ?? {})).toBe(false);
+    expect(plan.notes.join(" ")).toContain("E19");
+  });
+
+  it("native reorder inverts to the pre-rank sequence", () => {
+    const plan = planUndo(
+      record({
+        op: "reorder",
+        uuid: null,
+        requested: { scope: "today", uuids: ["A", "B"] },
+        pre: { A: 20, B: 10 },
+      }),
+      NOW,
+    );
+    expect(plan.steps[0]).toEqual({
+      op: "reorder",
+      params: { scope: "today", uuids: ["B", "A"] },
+    });
+  });
+
+  it("bounce reorder summaries (no pre-ranks) are irreversible with guidance", () => {
+    const plan = planUndo(
+      record({ op: "reorder", uuid: null, requested: { scope: "evening", uuids: ["A"] } }),
+      NOW,
+    );
+    expect(plan.kind).toBe("irreversible");
+    expect(plan.reason).toContain("legs");
+  });
+
+  it("permanent ops are irreversible", () => {
+    for (const op of ["area.delete", "tag.delete", "trash.empty", "project.complete"]) {
+      expect(planUndo(record({ op }), NOW).kind).toBe("irreversible");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`things undo [--last N]` unwinds the last N successful mutations by compiling INVERSE operations from the audit trail's recorded pre-values, then running each inverse through the same guarded, verified pipeline as any mutation. Nothing is guessed: a concurrently-edited target surfaces as blocked/verify-failed, and operations with no validated inverse surface are reported **irreversible** with the reason.

### What inverts

| Undone op | Inverse |
|---|---|
| `todo.complete` / `todo.cancel` (pre status open) | `todo.reopen` |
| `todo.reopen` | complete or cancel, per the recorded pre status |
| `todo.update` | field restore (title/notes/deadline); `when` reconstructed from captured start/startDate/todaySection — including a move back to the Inbox and reminder re-attachment; `startDate == today` maps back to the today/evening keywords so reminder clears stay possible |
| `todo.delete` | `todo.restore` (the Phase-14 E15 primitive; Inbox-landing caveat noted) |
| `todo.restore` | `todo.delete` |
| creations (`todo/project.add`, duplicates, `area/tag.add`) | delete of the discovered uuid — created areas/tags delete **permanently**, gated behind `--dangerously-permanent` |
| `todo.move` / `project.move` | move back to the captured prior container; unknown prior containers are irreversible, not guessed |
| `todo.set-tags` / `todo.replace-checklist` | restore the pre set (checklist per-item state honestly noted as unrecoverable) |
| `area.update` / `tag.update` | restore pre title/tags/parent/shortcut (un-nest-to-root noted as the E19 dead end) |
| native `reorder` | re-apply the pre-rank sequence |

**Irreversible (reported, never attempted):** permanent deletes (`area/tag.delete`, `trash.empty`), `project.delete` (E15 covers to-dos only), `project.complete` (no validated project reopen; the cascade completed children too), bounce-reorder summaries (their `when=` legs are separate, individually undoable records).

### Mechanics

- Targets = audit records with `result: "ok"`, newest first; inverse mutations audit as actor `undo:<actor>` and are excluded from later selection (no undo-the-undo loops).
- Unwinding stops at the first failed inverse — the state no longer matches the trail, so continuing would compound divergence.
- `--dry-run` emits every inverse plan (steps + fidelity notes) without executing; JSONL per-item results + summary; exit 3 on any failed/partial.
- Library surface: `client.write.undo(options, onItem)`.

## Verification

- **263 unit tests** (was 226): pure `planUndo` coverage across every op class (29 cases), plus engine tests for selection, execution, the permanent gate, dry-run, unwind-stop, and undo-record exclusion.
- **Full `npm run lab:regress` ALL GREEN**: e2e smoke now **70 steps, 0 failures** in a fresh VM clone — live complete→undo→reopen and delete→undo→restore round-trips against the real app, verified read-after-write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)