### PR TITLE
feat(write): tag un-nest unlocked via the AppleScript property-delete form (P28–P30)

### DIFF
--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -52,7 +52,7 @@ Unless the Shortcuts campaign (Phase 11) yields real heading capabilities, the A
 | Capability | Why it's dead |
 |---|---|
 | Convert to-do ↔ project | `move to do ... to list "Projects"` errors: `Can't get list "Projects"` — the sidebar entry isn't a scriptable list (E16). No other surface known. |
-| Un-nest a tag to root | `set parent tag ... to missing value` errors (−1700): the property accepts only a tag specifier (E19). Workaround: re-parent under a scratch root tag, or fix in the app. |
+| Un-nest a tag to root | **SHIPPED 2026-07-07**: `tag update --unnest` via AppleScript's property-DELETE form (P29). The set-form still errors (E19/P28), and the old scratch-parent workaround idea was dead anyway (P16 cascade delete). |
 | Sidebar AREA ordering | `move area ... to before area ...` errors (location specifier unsupported, O13); the private reorder command has no area-of-areas form. Areas order by their `"index"` — UI-only. |
 
 ## Ordering (LANDED — Phase 8, `things reorder` / `write.reorder`)
@@ -92,5 +92,6 @@ Fills: **headings in existing projects** (unique), maybe heading-archive + remin
 11. **Phase 17 (DONE 2026-07-06)** — seam hygiene (contracts into core, diagnose()/capabilitiesTable() as library functions) + `things mcp` stdio MCP server (16 tools over the same ThingsClient). Task #36.
 12. **Phase 18 (DONE 2026-07-06)** — P-suite (18 probes, [docs/lab/p-suite-results.md](lab/p-suite-results.md)): project cancel/reopen/restore all WORK; granular checklist states via things:///json WORKS; un-schedule + clear-container semantics pinned; empty-replacement clears validated. Closed permanently: project/todo area removal, tag un-nest (parent-delete CASCADE-DELETES children — new tag.delete hazard needed), top-level sidebar ordering. Task #37.
 13. **Phase 19 (DONE 2026-07-06)** — the P-suite verdicts shipped: `project cancel/reopen/restore` (reopen composite with the P03 cascade-window `--restore-children`; undo now reverses project complete/cancel/delete), one-step container detach (`todo move --detach`, `project move --detach`; URL empty params), URL vector for project moves, granular checklist ops (`todo checklist --check/--uncheck/--add/--remove/--rename/--move-item` over things:///json with per-item states preserved), empty-set tag/checklist clears, H-TAG-SUBTREE-DELETE guard. Task #38.
+14. **P-suite third sweep (2026-07-07)** — P28–P30: tag un-nest UNLOCKED via the AppleScript property-DELETE form (P29 — `delete parent tag of tag X`); shipped as `tag update --unnest` (undo re-nests / un-nests symmetrically). Empty-string and move-verb spellings rejected (P28/P30). Suite locked at 30 probes.
 
-Permanently out of reach (documented + guarded, revisit per Things release): repeat creation/rule-editing; checklist granular writes; to-do↔project conversion; tag un-nest to root; sidebar area ordering.
+Permanently out of reach (documented + guarded, revisit per Things release): repeat creation/rule-editing; to-do↔project conversion; project/to-do area-removal via AppleScript or json (URL empty-param is the sole path — shipped); sidebar (area + top-level project) ordering. Formerly listed, since CLOSED: checklist granular writes (P18, Phase 19), tag un-nest (P29).

--- a/docs/lab/p-suite-results.md
+++ b/docs/lab/p-suite-results.md
@@ -45,6 +45,18 @@ Follow-up probes after Mike's "no stone unturned" review: URL empty params, `upd
 
 The empty-URL-parameter replacement pattern (first seen for `tags=`/`checklist-items=`, P14/P15) turns out to generalize to CONTAINERS — undocumented but consistent. Three surfaces now exhibit three behaviors for the same intent (AppleScript errors, json silently ignores, URL empty clears) — oddities §5g.
 
+## Tag un-parenting, third sweep (P28–P30)
+
+The last unturned stones, aimed at the tag `parent` property (tags have no URL/json surface, so AppleScript spellings were the only candidates left):
+
+| Probe | Finding | Verdict |
+|---|---|---|
+| P28 | `set parent tag of tag X to ""` — rejected. | unsupported |
+| P29 | **`delete parent tag of tag X` WORKS: parent → NULL, both tags intact.** The AppleScript property-DELETE form succeeds where `set … to missing value` (E19) and `""` (P28) error. **Un-nesting to root is unlocked** — implemented as `tag update --unnest`. | supported |
+| P30 | `move tag X to application "Things3"` — rejected. | unsupported |
+
+P29 supersedes E19's dead-end verdict and retires P16's motivation for a sacrificial-parent workaround (which was itself dead — cascade delete). The nil-inconsistency picture for oddities §5g grows to four behaviors on one intent family: `set → missing value` errors, `set → ""` errors, json `null` silently no-ops, `delete <property>` works.
+
 To-do "remove all containers keeping the schedule": **one URL write** (`update?list-id=`) per P21/P22 — the two-step Inbox-bounce composite is no longer needed for container clearing (it remains the documented pattern only for clearing a DATED reminder, R20/R21).
 
 ## Empty replacements (P14–P15)

--- a/docs/things-app-oddities.md
+++ b/docs/things-app-oddities.md
@@ -122,8 +122,8 @@ Without an x-callback, the version command has no visible output — its only ob
 ### 5f. AppleScript `delete tag` on a parent tag silently destroys the entire subtree
 Deleting a tag that has child tags cascade-deletes the children too — permanently (no Trash for tags), with no confirmation and no error through the AppleScript channel. Combined with tag deletion already being unrecoverable, one scripted delete of a parent can wipe a whole tag hierarchy the caller never named. *(P16, 2026-07-06)*
 
-### 5g. Removing a container link: three surfaces, three different behaviors
-Detaching a project from its area (or a to-do from its project/area) behaves differently on every automation surface: **AppleScript rejects** `set area/project … to missing value` (and `""`) with an error; **the `json` command silently ignores** `"area-id": null` / `"list-id": null` (zero delta, no signal); and **the URL scheme quietly supports it** via an EMPTY parameter (`update?list-id=` / `update-project?area-id=` clear the link cleanly, matching the empty-`tags=` replacement pattern) — undocumented, discovered by probing. One capability, one error, one silent no-op, one undocumented success. *(P08–P11, P21/P22/P24, P25/P26 — 2026-07-06)*
+### 5g. Removing a link (container/parent): four different behaviors for one intent
+Clearing a relationship behaves differently on every automation spelling: **AppleScript rejects** `set area/project/parent tag … to missing value` (E19/P08/P10/P11) and `set … to ""` (P27/P28) with errors; **the `json` command silently ignores** `"area-id": null` / `"list-id": null` (zero delta, no signal — P25/P26); **the URL scheme quietly supports container clears** via an EMPTY parameter (`update?list-id=` / `update-project?area-id=` — P21/P22/P24, undocumented, matches the empty-`tags=` replacement pattern); and **AppleScript's property-DELETE form works for tag parents** (`delete parent tag of tag X` un-nests cleanly, P29 — while the set-form of the very same property errors). One intent family: two error spellings, one silent no-op, two undocumented successes on two different surfaces. *(2026-07-06/07)*
 
 ---
 

--- a/lab/guest/e2e-write-smoke.sh
+++ b/lab/guest/e2e-write-smoke.sh
@@ -149,6 +149,8 @@ run_step 0 "move back to Inbox (de-schedules)" todo move "$REM" --inbox
 run_step 0 "area update: rename + tags" area update LAB-AREA-B --title "E2E-AREA-RENAMED" --tags lab-tag-1
 run_step 0 "tag add for update tests" tag add e2e-parent
 run_step 0 "tag update: re-parent + shortcut" tag update lab-tag-2 --parent e2e-parent --shortcut 8
+run_step 0 "tag update: UN-NEST to root (P29 property-delete)" tag update lab-tag-2 --unnest
+run_step 2 "unnest is exclusive with --parent" tag update lab-tag-2 --parent e2e-parent --unnest
 
 echo "== batch + changes (Phase 13) =="
 SINCE=$(date -v-2M +%Y-%m-%dT%H:%M:%S)

--- a/lab/suites/p-suite.json
+++ b/lab/suites/p-suite.json
@@ -1,6 +1,6 @@
 {
   "suite": "p",
-  "description": "Gap-closure campaign (Phase 18, 2026-07-06): project cancel/reopen + cascade semantics and stopDate timing (undo heuristic), trashed-project restore candidates, project/to-do area removal, container-clear + schedule/deadline survival, empty tag/checklist replacement, parent-tag deletion orphan behavior, top-level project ordering, and the json checklist-states unlock (hazard-quarantined). Expectations are DISCOVERY GUESSES until the first run locks them. EXTENDED 2026-07-06b: sidebar-order read oracle, ephemeral-area chain, URL empty list-id/area-id container clears, update-project?area-id move, AppleScript empty-string nil, json-null container clears (hazard).",
+  "description": "Gap-closure campaign (Phase 18, 2026-07-06): project cancel/reopen + cascade semantics and stopDate timing (undo heuristic), trashed-project restore candidates, project/to-do area removal, container-clear + schedule/deadline survival, empty tag/checklist replacement, parent-tag deletion orphan behavior, top-level project ordering, and the json checklist-states unlock (hazard-quarantined). Expectations are DISCOVERY GUESSES until the first run locks them. EXTENDED 2026-07-06b: sidebar-order read oracle, ephemeral-area chain, URL empty list-id/area-id container clears, update-project?area-id move, AppleScript empty-string nil, json-null container clears (hazard). EXTENDED 2026-07-06c: P28-P30 \u2014 the last tag-un-parent stones (empty-string nil, delete-property, move verb; tags have no URL/json surface, so AppleScript spellings are the only remaining candidates).",
   "probes": [
     {
       "id": "P01",
@@ -1320,6 +1320,146 @@
         ]
       },
       "settleSeconds": 3
+    },
+    {
+      "id": "P28",
+      "title": "tag un-parent, empty-string nil: `set parent tag of tag X to \"\"` (P27 tried this on a project's AREA, never on a tag parent)",
+      "vector": "applescript",
+      "operation": "tag.unparent-empty-string",
+      "appState": "running-background",
+      "setup": [
+        {
+          "osascript": "tell application \"Things3\" to make new tag with properties {name:\"P28-C-P\"}"
+        },
+        {
+          "osascript": "tell application \"Things3\" to make new tag with properties {name:\"P28-C\"}"
+        },
+        {
+          "osascript": "tell application \"Things3\" to set parent tag of tag \"P28-C\" to tag \"P28-C-P\""
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTag c JOIN TMTag p ON c.parent=p.uuid WHERE c.title='P28-C' AND p.title='P28-C-P'"
+        }
+      ],
+      "commands": [
+        {
+          "osascript": "tell application \"Things3\" to set parent tag of tag \"P28-C\" to \"\""
+        },
+        {
+          "sleep": 2
+        }
+      ],
+      "expect": {
+        "verdict": "unsupported",
+        "tier": 0,
+        "allowNonzeroExit": true,
+        "assertions": [
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTag",
+            "where": {
+              "title": "P28-C"
+            },
+            "fields": ["parent"]
+          }
+        ]
+      }
+    },
+    {
+      "id": "P29",
+      "title": "tag un-parent WORKS: `delete parent tag of tag X` sets parent=NULL (the property-delete form succeeds where set-to-missing-value errors, E19 \u2014 un-nest is unlocked)",
+      "vector": "applescript",
+      "operation": "tag.unparent-delete-property",
+      "appState": "running-background",
+      "setup": [
+        {
+          "osascript": "tell application \"Things3\" to make new tag with properties {name:\"P29-C-P\"}"
+        },
+        {
+          "osascript": "tell application \"Things3\" to make new tag with properties {name:\"P29-C\"}"
+        },
+        {
+          "osascript": "tell application \"Things3\" to set parent tag of tag \"P29-C\" to tag \"P29-C-P\""
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTag c JOIN TMTag p ON c.parent=p.uuid WHERE c.title='P29-C' AND p.title='P29-C-P'"
+        }
+      ],
+      "commands": [
+        {
+          "osascript": "tell application \"Things3\" to delete parent tag of tag \"P29-C\""
+        },
+        {
+          "sleep": 2
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "allowNonzeroExit": false,
+        "assertions": [
+          {
+            "kind": "fieldEquals",
+            "table": "TMTag",
+            "where": {
+              "title": "P29-C"
+            },
+            "field": "parent",
+            "value": null
+          },
+          {
+            "kind": "rowExists",
+            "table": "TMTag",
+            "where": {
+              "title": "P29-C-P"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "id": "P30",
+      "title": "tag un-parent via the move verb: `move tag X to application` (move is how both trash-restores worked, P06/E15; never pointed at a tag)",
+      "vector": "applescript",
+      "operation": "tag.unparent-move",
+      "appState": "running-background",
+      "setup": [
+        {
+          "osascript": "tell application \"Things3\" to make new tag with properties {name:\"P30-C-P\"}"
+        },
+        {
+          "osascript": "tell application \"Things3\" to make new tag with properties {name:\"P30-C\"}"
+        },
+        {
+          "osascript": "tell application \"Things3\" to set parent tag of tag \"P30-C\" to tag \"P30-C-P\""
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTag c JOIN TMTag p ON c.parent=p.uuid WHERE c.title='P30-C' AND p.title='P30-C-P'"
+        }
+      ],
+      "commands": [
+        {
+          "osascript": "tell application \"Things3\" to move tag \"P30-C\" to application \"Things3\""
+        },
+        {
+          "sleep": 2
+        }
+      ],
+      "expect": {
+        "verdict": "unsupported",
+        "tier": 0,
+        "allowNonzeroExit": true,
+        "assertions": [
+          {
+            "kind": "fieldUnchanged",
+            "table": "TMTag",
+            "where": {
+              "title": "P30-C"
+            },
+            "fields": ["parent"]
+          }
+        ]
+      }
     }
   ]
 }

--- a/src/cli/commands/writes.ts
+++ b/src/cli/commands/writes.ts
@@ -900,19 +900,27 @@ export function registerWriteCommands(program: Command): void {
       .command("update <target>")
       .description(
         "Rename a tag (assignments survive — E02), nest it under an existing tag (E03), " +
-          "and/or set its keyboard shortcut (E10). Vector: applescript, tier 0. " +
-          "Un-nesting to root and clearing a shortcut are unprobed — not offered.",
+          "UN-NEST it to root (--unnest, P29 — the property-delete form; exclusive with " +
+          "--parent), and/or set its keyboard shortcut (E10). Vector: applescript, tier 0. " +
+          "Clearing a shortcut is unprobed — not offered.",
       )
       .option("--title <text>", "new name")
       .option("--parent <name>", "existing tag to nest under")
+      .option("--unnest", "move the tag to the root of the hierarchy")
       .option("--shortcut <char>", "keyboard shortcut character"),
   ).action(async (target: string, opts: WriteFlagOpts & Record<string, unknown>) => {
     if (
       opts["title"] === undefined &&
       opts["parent"] === undefined &&
+      opts["unnest"] === undefined &&
       opts["shortcut"] === undefined
     ) {
-      process.stderr.write("error: pass --title, --parent, and/or --shortcut\n");
+      process.stderr.write("error: pass --title, --parent, --unnest, and/or --shortcut\n");
+      process.exitCode = ExitCode.Usage;
+      return;
+    }
+    if (opts["parent"] !== undefined && opts["unnest"] === true) {
+      process.stderr.write("error: --parent and --unnest are exclusive\n");
       process.exitCode = ExitCode.Usage;
       return;
     }
@@ -922,6 +930,7 @@ export function registerWriteCommands(program: Command): void {
         {
           ...(opts["title"] !== undefined && { title: opts["title"] as string }),
           ...(opts["parent"] !== undefined && { parent: opts["parent"] as string }),
+          ...(opts["unnest"] === true && { unnest: true }),
           ...(opts["shortcut"] !== undefined && { shortcut: opts["shortcut"] as string }),
         },
         writeOptionsFrom(opts),

--- a/src/write/commands.ts
+++ b/src/write/commands.ts
@@ -1060,9 +1060,13 @@ const tagUpdate: CommandSpec<"tag.update"> = {
     if (
       params.title === undefined &&
       params.parent === undefined &&
+      params.unnest === undefined &&
       params.shortcut === undefined
     ) {
-      throw new RangeError("tag.update needs title, parent, and/or shortcut");
+      throw new RangeError("tag.update needs title, parent, unnest, and/or shortcut");
+    }
+    if (params.parent !== undefined && params.unnest === true) {
+      throw new RangeError("parent and unnest are exclusive");
     }
     const pre = emptyPreState();
     pre.entityTarget = resolveTag(db, params.target);
@@ -1078,6 +1082,7 @@ const tagUpdate: CommandSpec<"tag.update"> = {
     if (params.parent !== undefined) {
       assert.push({ field: "parent", equals: pre.parentTag?.resolved?.uuid ?? "" });
     }
+    if (params.unnest === true) assert.push({ field: "parent", equals: null });
     if (params.shortcut !== undefined) assert.push({ field: "shortcut", equals: params.shortcut });
     return {
       mode: "entity-updated",
@@ -1095,6 +1100,12 @@ const tagUpdate: CommandSpec<"tag.update"> = {
       lines.push(
         `set parent tag of tag id ${id} to tag id ${q(pre.parentTag?.resolved?.uuid ?? "")}`,
       );
+    }
+    if (params.unnest === true) {
+      // The property-DELETE form is the only working un-nest spelling (P29):
+      // `set parent tag … to missing value` errors (E19). By NAME, exactly
+      // as probed — resolveTag already guaranteed the title is unique.
+      lines.push(`delete parent tag of tag ${q(pre.entityTarget?.resolved?.title ?? "")}`);
     }
     if (params.shortcut !== undefined) {
       lines.push(`set keyboard shortcut of tag id ${id} to ${q(params.shortcut)}`);

--- a/src/write/operations.ts
+++ b/src/write/operations.ts
@@ -203,8 +203,13 @@ export interface TagUpdateParams {
   /** uuid or unique case-insensitive title. */
   target: string;
   title?: string;
-  /** Existing tag to nest under (un-nesting to root is unprobed — not offered). */
+  /** Existing tag to nest under (E03). Exclusive with unnest. */
   parent?: string;
+  /**
+   * Un-nest to root via the AppleScript property-delete form (P29 — the one
+   * spelling that works; `set parent tag to missing value` errors, E19).
+   */
+  unnest?: boolean;
   /** Single character (clearing to none is unprobed — not offered). */
   shortcut?: string;
 }

--- a/src/write/undo.ts
+++ b/src/write/undo.ts
@@ -10,8 +10,7 @@
  *
  * Honesty rules:
  *  - Ops with no validated inverse surface are reported IRREVERSIBLE with
- *    the reason (permanent deletes, project completion cascades, un-nesting
- *    a tag to root — E19, project→no-area — unprobed).
+ *    the reason (permanent deletes, empty-trash, project→no-area — unprobed).
  *  - Partial inversions carry notes (todo.delete undo restores to the Inbox
  *    de-scheduled; checklist per-item state is unrecoverable).
  *  - Inverse mutations are audited under an `undo:`-prefixed actor and are
@@ -610,11 +609,9 @@ export function planUndo(record: AuditRecord, now: Date): UndoPlan {
       const shortcut = preField(record, "shortcut");
       if (title !== undefined) patch["title"] = title;
       if (typeof parent === "string" && parent !== "") patch["parent"] = parent;
-      else if (parent === null) {
-        notes.push(
-          "the tag was un-nested before the op — un-nesting to root is IMPOSSIBLE via " +
-            "automation (E19); fix the parent in the app",
-        );
+      else if (parent === null && record.requested["parent"] !== undefined) {
+        // The op nested a previously-root tag: un-nest it back (P29).
+        patch["unnest"] = true;
       }
       if (typeof shortcut === "string") patch["shortcut"] = shortcut;
       else if (shortcut === null && record.requested["shortcut"] !== undefined) {

--- a/src/write/vectors/applescript.ts
+++ b/src/write/vectors/applescript.ts
@@ -129,8 +129,10 @@ export const APPLESCRIPT_MATRIX: VectorMatrix = {
     support: "yes",
     disruption: 0,
     validation: "validated",
-    evidence: ["E02", "E03", "E10"],
-    notes: "rename (assignments survive), re-parent existing, keyboard shortcut",
+    evidence: ["E02", "E03", "E10", "P29"],
+    notes:
+      "rename (assignments survive), re-parent existing, keyboard shortcut, un-nest to root " +
+      "via the property-delete form (P29 — `set … to missing value` errors, E19)",
   },
   "tag.delete": {
     support: "yes",

--- a/test/cli/help-contract.test.ts
+++ b/test/cli/help-contract.test.ts
@@ -118,6 +118,7 @@ describe("write-command help states the contract", () => {
     expect(areaHelp).toContain("H-UNKNOWN-TAG");
     const tagHelp = helpFor("tag", "update");
     expect(tagHelp).toContain("--parent");
+    expect(tagHelp).toContain("--unnest");
     expect(tagHelp).toContain("--shortcut");
     expect(tagHelp).toContain("unprobed");
   });

--- a/test/engine/write-r9b.test.ts
+++ b/test/engine/write-r9b.test.ts
@@ -329,6 +329,30 @@ describe("move to inbox / duplicate / entity updates", () => {
     expect(calls[0]).toContain(`set parent tag of tag id "${child}" to tag id "${parent}"`);
   });
 
+  it("tag.update --unnest compiles the property-delete form and verifies parent=null (P29)", async () => {
+    const parent = seedTag(fixture.db, "work");
+    const child = seedTag(fixture.db, "deep", parent);
+    const { vector, calls } = fakeVector("applescript", AS_MATRIX, () => {
+      fixture.db.prepare("UPDATE TMTag SET parent = NULL WHERE uuid = ?").run(child);
+    });
+    const result = await runMutation(deps([vector]), "tag.update", {
+      target: "deep",
+      unnest: true,
+    });
+    expect(result.kind).toBe("ok");
+    expect(calls[0]).toContain('delete parent tag of tag "deep"');
+    if (result.kind === "ok") expect(result.observed?.["parent"]).toBeNull();
+  });
+
+  it("tag.update rejects parent + unnest together", async () => {
+    seedTag(fixture.db, "work");
+    seedTag(fixture.db, "deep");
+    const { vector } = fakeVector("applescript", AS_MATRIX, null);
+    await expect(
+      runMutation(deps([vector]), "tag.update", { target: "deep", parent: "work", unnest: true }),
+    ).rejects.toThrow(/exclusive/);
+  });
+
   it("tag.update to an unknown parent is blocked (H-UNKNOWN-TAG)", async () => {
     seedTag(fixture.db, "deep");
     const { vector, calls } = fakeVector("applescript", AS_MATRIX, null);

--- a/test/unit/undo-plan.test.ts
+++ b/test/unit/undo-plan.test.ts
@@ -283,7 +283,7 @@ describe("planUndo — tags, checklist, entities, reorder", () => {
     expect(plan.notes.join(" ")).toContain("unrecoverable");
   });
 
-  it("tag.update with a pre-null parent notes the E19 dead end", () => {
+  it("tag.update that nested a root tag inverts via unnest (P29)", () => {
     const plan = planUndo(
       record({
         op: "tag.update",
@@ -292,9 +292,9 @@ describe("planUndo — tags, checklist, entities, reorder", () => {
       }),
       NOW,
     );
+    expect(plan.kind).toBe("invertible");
+    expect(plan.steps[0]?.params["unnest"]).toBe(true);
     expect(plan.steps[0]?.params["title"]).toBe("deep");
-    expect("parent" in (plan.steps[0]?.params ?? {})).toBe(false);
-    expect(plan.notes.join(" ")).toContain("E19");
   });
 
   it("native reorder inverts to the pre-rank sequence", () => {


### PR DESCRIPTION
## Summary

The last unturned stones from the container/parent-removal review — three nil spellings aimed at the tag `parent` property (tags have no URL/json surface, so AppleScript was the only remaining candidate family):

| Probe | Spelling | Verdict |
|---|---|---|
| P28 | `set parent tag of tag X to ""` | rejected |
| P29 | **`delete parent tag of tag X`** | **WORKS — parent → NULL, both tags intact** |
| P30 | `move tag X to application` | rejected |

P29 supersedes E19's dead-end verdict: the property-**delete** form succeeds where `set … to missing value` errors. Shipped as:

- **`things tag update --unnest`** (exclusive with `--parent`) — compiles the probe-exact by-name property-delete, verifies `parent = null` through the standard pipeline.
- **Undo upgrade**: an operation that nested a previously-root tag now inverts via unnest (previously an "impossible via automation" note).
- **Oddities §5g upgraded** for the Cultured Code report: one intent family now shows FOUR behaviors — two error spellings, one silent no-op (json null), and two undocumented successes on two different surfaces (URL empty params for containers, property-delete for tag parents).

## Verification

- P-suite locked at **30 probes**, acceptance ×2 (`p-20260707-002643`, `p-20260707-003012`), `lab:compare` identical verdicts.
- Guest e2e **92/92 steps, 0 failures** — live re-parent → un-nest round-trip + the exclusivity guard against the real app.
- **325 unit tests**: engine unnest + verify, param exclusivity, undo plan inversion, help-contract lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)