### PR TITLE
release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,39 @@
 # Changelog
 
-## Unreleased
+## 0.3.0 — 2026-07-07
 
-- **MCP server** (Phase 17): `things mcp` serves the Model Context Protocol over stdio — 16 tools mirroring the library surface (read views incl. occurrence horizon, search, changes, item/project detail, verified mutations via dedicated tools + generic `run_operation`, batch, reorder, undo, capabilities, doctor). Hazard blocks return as structured tool errors with remediation. Exposed from the library as `createThingsMcpServer()`.
-- **Seam hygiene**: machine contracts (JSON envelope, exit codes) moved from `src/cli/` into core (`contracts.ts`); `diagnose()` and `capabilitiesTable()` promoted to library functions (the CLI `doctor`/`capabilities` commands are now thin renderers); `saveConfigKey` and the batch/undo/reorder/view option types exported from the package index.
+The operation catalog grows from 25 to 28 kinds; every new capability is grounded in the 30-probe P-suite campaign ([docs/lab/p-suite-results.md](docs/lab/p-suite-results.md)).
+
+### MCP server (Phase 17)
+
+- `things mcp` serves the Model Context Protocol over stdio — 16 tools mirroring the library surface (read views incl. occurrence horizon, search, changes, item/project detail, verified mutations via dedicated tools + generic `run_operation`, batch, reorder, undo, capabilities, doctor). Hazard blocks return as structured tool errors carrying the guards' remediation text. Exposed from the library as `createThingsMcpServer()`. The SDK loads lazily — every other CLI command boots with a minimal dependency set.
+- Seam hygiene: machine contracts (JSON envelope, exit codes) moved from `src/cli/` into core (`contracts.ts`); `diagnose()` and `capabilitiesTable()` promoted to library functions (the CLI `doctor`/`capabilities` commands are now thin renderers); `saveConfigKey` and the batch/undo/reorder/view option types exported from the package index.
+
+### Project lifecycle (Phases 18–19)
+
+- `things project cancel --children require-resolved|auto-cancel` — the URL write cascades natively (open children → canceled; completed children untouched, P01); the policy is mandatory and the cascade is verified per child, mirroring `project complete`.
+- `things project reopen [--restore-children]` — reopens completed AND canceled projects (P02/P05). The bare op reopens only the project row (exactly the app's behavior — cascade-resolved children stay resolved); `--restore-children` adds verified per-child reopen legs, detecting cascade-resolved children by the <2s stopDate window (P03). Children resolved before the project are never touched (P04).
+- `things project restore` — un-trashes a project IN PLACE (P06): schedule, area link, and children all keep their state.
+- `undo` now reverses project complete/cancel (audit-exact child restore), project delete, and project restore.
+
+### Container detach (Phases 18–19)
+
+- `things todo move <uuid> --detach` — one write clears project/area/heading while the schedule is pinned unchanged (URL empty `list-id=`, P21/P22).
+- `things project move <uuid> --detach` — clears the area (empty `area-id=`, P24); `project move` also gains a URL vector for regular moves (P23). Detach moves are undo-invertible from the captured prior container.
+
+### Granular checklists (Phases 18–19)
+
+- `things todo checklist` gains `--check/--uncheck/--add [--at N]/--remove/--rename/--to`: reads the current items+states from the DB, applies the edit in memory, and writes back through `things:///json` with per-item completed states (P18) — the only surface that recreates items pre-checked. State-preserving edits skip the H-CHECKLIST-REPLACE acknowledgement (nothing is destroyed). Checklist-item uuids are not stable across rewrites; key on title/position.
+- Empty-set clears validated: `todo tags --set ""` and an empty checklist replacement (P14/P15).
+
+### Tags (Phases 18–19)
+
+- `things tag update --unnest` — un-nests a tag to the root of the hierarchy via AppleScript's property-delete form (`delete parent tag of tag X`, P29 — the one spelling that works; `set … to missing value` and `""` error, json `null` silently no-ops). Undo re-nests/un-nests symmetrically.
+- **New hazard `H-TAG-SUBTREE-DELETE`**: deleting a tag that has child tags silently cascade-deletes the whole subtree, permanently (P16) — `tag delete` now blocks unless `--acknowledge-subtree` accompanies `--dangerously-permanent`.
+
+### Closed permanently (documented, guarded)
+
+Container/area removal via AppleScript `missing value`/`""` or json `null` (the URL empty-param is the sole surface); to-do↔project conversion; sidebar ordering (areas, top-level projects — reads stay available via the provisional `"index"` sort); deleting an area orphans its projects to no-area while trashing only its to-dos (P20). The app-oddities catalog (§2f, §5f, §5g) documents the report-worthy inconsistencies for Cultured Code.
 
 ## 0.2.0 — 2026-07-06
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A typed TypeScript library + CLI (`things`) for programmatic interaction with [Things 3](https://culturedcode.com/things/) by Cultured Code.
 
-**Status: read + write layers live (v0.2.0 — see [CHANGELOG.md](CHANGELOG.md)).** Reads go straight to the local SQLite database (UI-exact Today ordering, decoded repeat rules, occurrence projections); writes run a verified pipeline over two lab-validated vectors (URL scheme + AppleScript) with hazard guards, disruption-tier policy, a JSONL audit trail, batch mode, and audit-replay undo. See [docs/design/](docs/design/) for the architecture and VM-lab design, [docs/lab/](docs/lab/harness.md) for the probe harness and campaign results the write layer is grounded in, and [docs/atlas/](docs/atlas/schema-v26.md) for the database↔UI map.
+**Status: read + write + MCP layers live (v0.3.0 — see [CHANGELOG.md](CHANGELOG.md)).** Reads go straight to the local SQLite database (UI-exact Today ordering, decoded repeat rules, occurrence projections); writes run a verified pipeline over two lab-validated vectors (URL scheme + AppleScript) with hazard guards, disruption-tier policy, a JSONL audit trail, batch mode, audit-replay undo, full project lifecycle (complete/cancel/reopen/restore), container detach, granular stateful checklists, and tag hierarchy management incl. un-nesting. See [docs/design/](docs/design/) for the architecture and VM-lab design, [docs/lab/](docs/lab/harness.md) for the probe harness and campaign results the write layer is grounded in, and [docs/atlas/](docs/atlas/schema-v26.md) for the database↔UI map.
 
 ```sh
 things today --json                # read: your Today list, Evening split, UI order

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "things-api",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "things-api",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "things-api",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Typed TypeScript library + CLI for Things 3 (Cultured Code) — verified writes, audit trail, schema-drift detection",
   "license": "UNLICENSED",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -15,7 +15,7 @@ import { registerReadCommands } from "./commands/reads.ts";
 import { registerSnapshot } from "./commands/snapshot.ts";
 import { registerTodoCommands } from "./commands/todo.ts";
 import { registerWriteCommands } from "./commands/writes.ts";
-import { ExitCode } from "../contracts.ts";
+import { ExitCode, PKG_VERSION } from "../contracts.ts";
 
 const AGENT_NOTES = `
 AGENT NOTES:
@@ -36,7 +36,7 @@ export function buildProgram(): Command {
   program
     .name("things")
     .description("Programmatic interface to Things 3 (Cultured Code)")
-    .version("0.0.1")
+    .version(PKG_VERSION)
     .addHelpText("after", AGENT_NOTES);
   registerDoctor(program);
   registerReadCommands(program);

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -12,6 +12,12 @@
 export const API_VERSION = 1;
 
 /**
+ * Package version, surfaced by `things --version` and the MCP serverInfo.
+ * Kept in lockstep with package.json by a contract test.
+ */
+export const PKG_VERSION = "0.3.0";
+
+/**
  * Stable exit-code contract for the `things` CLI (mirrored by MCP error
  * codes). Part of the public API surface consumed by agents and scripts —
  * values must never be renumbered; add new codes at the end.

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,5 +82,5 @@ export { ThingsDbNotFoundError } from "./db/locate.ts";
 export { ThingsDbOpenError } from "./db/connection.ts";
 export type { Baseline, FingerprintStatus, SchemaObservation } from "./db/fingerprint.ts";
 
-export { API_VERSION, ExitCode } from "./contracts.ts";
+export { API_VERSION, ExitCode, PKG_VERSION } from "./contracts.ts";
 export type { Envelope, EnvelopeMeta, ErrorEnvelope, OkEnvelope } from "./contracts.ts";

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { openThings, type OpenOptions, type ThingsClient } from "../client.ts";
+import { PKG_VERSION } from "../contracts.ts";
 import { diagnose } from "../diagnose.ts";
 import { capabilitiesTable } from "../write/capabilities.ts";
 import { OPERATION_KINDS, type OperationKind } from "../write/operations.ts";
@@ -84,7 +85,7 @@ const dryRunShape = {
 const containerRef = (ref: string): { uuid: string; title: string } => ({ uuid: ref, title: ref });
 
 export function createThingsMcpServer(options: McpServerOptions = {}): McpServer {
-  const server = new McpServer({ name: "things-api", version: "0.2.0" });
+  const server = new McpServer({ name: "things-api", version: PKG_VERSION });
 
   // One lazily-opened client for the server's lifetime; SQLite read
   // snapshots are per-statement, so fresh reads see external commits.

--- a/test/unit/contracts.test.ts
+++ b/test/unit/contracts.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 
-import { API_VERSION, errorEnvelope, ExitCode, okEnvelope } from "../../src/contracts.ts";
+import { readFileSync } from "node:fs";
+
+import {
+  API_VERSION,
+  errorEnvelope,
+  ExitCode,
+  okEnvelope,
+  PKG_VERSION,
+} from "../../src/contracts.ts";
 
 describe("exit-code contract", () => {
   it("never renumbers published codes", () => {
@@ -43,5 +51,16 @@ describe("json envelope contract", () => {
     expect(env.ok).toBe(false);
     expect(env.kind).toBe("error");
     expect(env.error.code).toBe("drift-blocked");
+  });
+});
+
+describe("version lockstep", () => {
+  it("PKG_VERSION matches package.json", () => {
+    const pkg = JSON.parse(
+      readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+    ) as {
+      version: string;
+    };
+    expect(PKG_VERSION).toBe(pkg.version);
   });
 });


### PR DESCRIPTION
## Summary

Cuts **v0.3.0**: the Unreleased changelog section is promoted and completed — Phase 17 (MCP server + seam hygiene), Phases 18–19 (the 30-probe P-suite campaign and its shipped verdicts: project cancel/reopen/restore, container detach, granular stateful checklists, empty-set clears, the tag-subtree hazard), and the P28–P30 un-nest unlock. Catalog: 25 → 28 operations.

Housekeeping in this PR:
- README status line refreshed (read + write + MCP, v0.3.0).
- **Version plumbing**: `PKG_VERSION` in `contracts.ts` now feeds `things --version` (which had been stale at `0.0.1` since Phase 0) and the MCP `serverInfo` (stale at `0.2.0`), with a contract test locking it to `package.json`.

## Verification

326 unit tests; `npm run check` green; `npm run smoke:pack` GREEN; `things --version` → `0.3.0`. No behavior changes beyond the version strings — the underlying features shipped in PRs #29–#32 behind full lab gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)