### PR TITLE
Phase 20 (part 2): sweep CLI help + exported JSDoc to the surface-copy contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Server `instructions` now carry a live inventory read at server start — areas, tag hierarchy (`parent > child`), open project titles (capped at 100) — plus the reference and scheduling vocabulary, degrading to conventions-only when the database is unreadable.
 - Tools carry MCP annotations (`readOnlyHint` on reads/capabilities/doctor, `destructiveHint` on permanent deletes and the generic mutation entries).
 - New surface-copy contract ([docs/design/surface-copy.md](docs/design/surface-copy.md)): tool descriptions state consumer-visible behavior and side effects only — pipeline/audit/lab vocabulary is banned (regression-tested) and lives in `docs/` and the `capabilities` output. Shared parameter vocabulary moved to `src/surface-copy.ts` so CLI help and MCP schemas cannot drift apart.
+- The same contract now governs the CLI and the library JSDoc: every `--help` string, the AGENT NOTES block, and the exported `ThingsClient`/operation-params docs were rewritten in consumer voice (hazard ids, probe-evidence ids, vector/tier framing, and audit/verification mechanics replaced with the behavior they imply); a help-wide banned-vocabulary test locks it in. The lab evidence remains in `docs/lab/`, the write-layer internals, and the `capabilities` output.
 
 ## 0.3.0 — 2026-07-07
 

--- a/docs/design/surface-copy.md
+++ b/docs/design/surface-copy.md
@@ -18,7 +18,7 @@ This contract governs every consumer-facing description string: MCP tool descrip
 
 ## Enforcement
 
-A contract test scans every MCP tool description, schema description, and the server instructions for the banned vocabulary of rule 2. When it fails, rewrite the sentence in consumer terms or move the detail into `docs/`.
+Contract tests scan every MCP tool description, schema description, and the server instructions (`test/mcp/server.test.ts`) and every CLI `--help` string (`test/cli/help-contract.test.ts`) for the banned vocabulary of rule 2. When one fails, rewrite the sentence in consumer terms or move the detail into `docs/`.
 
 ## Where the internals live instead
 

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -15,7 +15,9 @@ export function registerDoctor(program: Command): void {
   program
     .command("doctor")
     .description(
-      "Check environment health: database location, schema fingerprint vs baseline, app presence. " +
+      "Check environment health: database location, database schema compatibility, app " +
+        "presence, and any one-time setup still needed (macOS permissions, the app's " +
+        "'Enable Things URLs' setting) — with steps to fix. " +
         "Exit 0 healthy; 5 schema drift (writes disabled); 7 environment problem.",
     )
     .option("--json", "emit versioned JSON envelope on stdout")

--- a/src/cli/commands/writes.ts
+++ b/src/cli/commands/writes.ts
@@ -1,7 +1,9 @@
 /**
- * Write commands. Every command's --help states its disruption tier, default
- * vector, and the hazards that may block it — help text is the agent API.
- * No interactive prompts: risky semantics require explicit flags.
+ * Write commands. Help text is the agent API: every command's --help states
+ * its behavior, side effects, and required confirmation flags in consumer
+ * voice (docs/design/surface-copy.md) — internals stay in docs/ and the
+ * capabilities/dry-run OUTPUT. No interactive prompts: risky semantics
+ * require explicit flags.
  */
 import type { Command } from "commander";
 
@@ -36,15 +38,12 @@ function addWriteFlags(cmd: Command): Command {
   return cmd
     .option("--json", "emit versioned JSON envelope on stdout")
     .option("--db <path>", "explicit database path")
-    .option(
-      "--dry-run",
-      "plan only: compiled invocation (token-redacted), tier, hazards, expected delta — nothing executes",
-    )
-    .option("--vector <id>", "force a write vector: url-scheme | applescript")
-    .option("--allow-disruptive", "permit disruption tier 2 (focus steal)")
-    .option("--allow-very-disruptive", "permit disruption tier 3 (UI navigation/modals)")
-    .option("--verify-timeout <ms>", "read-after-write verification deadline")
-    .option("--actor <name>", "audit attribution (default: config/profile actor)");
+    .option("--dry-run", "preview the planned change and its expected effect; nothing executes")
+    .option("--vector <id>", "force how the change is delivered: url-scheme | applescript")
+    .option("--allow-disruptive", "permit changes that briefly steal window focus")
+    .option("--allow-very-disruptive", "permit changes that visibly drive the Things UI")
+    .option("--verify-timeout <ms>", "how long to wait for the change to take effect")
+    .option("--actor <name>", "author name recorded for this change (default: from config)");
 }
 
 function writeOptionsFrom(opts: WriteFlagOpts, extra: Partial<WriteOptions> = {}): WriteOptions {
@@ -257,9 +256,10 @@ export function registerWriteCommands(program: Command): void {
     todo
       .command("add <title>")
       .description(
-        "Create a to-do (vector: url-scheme, tier 0 with Things running). " +
-          "Hazards: H-UNKNOWN-TAG, H-UNKNOWN-DESTINATION, H-AMBIGUOUS-HEADING, " +
-          "H-REOPEN-RESOLVED-PROJECT (--acknowledge-project-reopen).",
+        "Create a to-do; its uuid is printed on success. Tags, projects, areas, and " +
+          "headings must name existing items — unknown or ambiguous references are " +
+          "rejected. Adding into a completed/canceled project reopens that project — " +
+          "requires --acknowledge-project-reopen.",
       )
       .option("--notes <text>", "notes body")
       .option("--when <value>", "today | evening | anytime | someday | YYYY-MM-DD")
@@ -306,14 +306,13 @@ export function registerWriteCommands(program: Command): void {
     todo
       .command("update <uuid>")
       .description(
-        "Update title/notes/when/reminder/deadline (vector: url-scheme, tier 0). " +
-          "Hazard: H-REPEAT-SCHEDULE — when/deadline on a repeating template is hard-blocked " +
-          "(the URL write crashes Things); title/notes stay allowed. " +
-          "Reminders (H-REMINDER-SCOPE): --reminder needs --when today|evening|YYYY-MM-DD; " +
-          "when re-scheduling WITHOUT --reminder an existing reminder is auto-preserved. " +
-          "--clear-reminder clears on today|evening only — DATED reminders are sticky " +
-          "(no URL clear path, R20/R21). " +
-          "--append-notes/--prepend-notes join with a newline (exclusive with --notes).",
+        "Update title/notes/when/reminder/deadline. Schedule and deadline changes are not " +
+          "available for repeating to-dos (title/notes are). --reminder needs --when " +
+          "today|evening|YYYY-MM-DD; when re-scheduling WITHOUT --reminder an existing " +
+          "reminder is auto-preserved. --clear-reminder works while the to-do is scheduled " +
+          "for today|evening — a DATED reminder can only be changed, not cleared " +
+          "(re-schedule to today first). --append-notes/--prepend-notes join with a " +
+          "newline (exclusive with --notes).",
       )
       .option("--title <text>", "new title")
       .option("--notes <text>", "replace notes")
@@ -321,7 +320,7 @@ export function registerWriteCommands(program: Command): void {
       .option("--prepend-notes <text>", "prepend to existing notes (newline-joined)")
       .option("--when <value>", "today | evening | anytime | someday | YYYY-MM-DD")
       .option("--reminder <HH:mm>", "set a reminder (24h); requires --when today|evening|date")
-      .option("--clear-reminder", "clear the reminder (today|evening only — dated are sticky)")
+      .option("--clear-reminder", "clear the reminder (works while scheduled today|evening)")
       .option("--deadline <date>", "YYYY-MM-DD")
       .option("--clear-deadline", "remove the deadline"),
   ).action(async (uuid: string, opts: WriteFlagOpts & Record<string, unknown>) => {
@@ -368,8 +367,7 @@ export function registerWriteCommands(program: Command): void {
       todo
         .command(`${verb} <uuid>`)
         .description(
-          `${verb[0]?.toUpperCase()}${verb.slice(1)} a to-do (tier 0; verified read-after-write). ` +
-            "Hazard: H-REPEAT-SCHEDULE — blocked on repeating templates.",
+          `${verb[0]?.toUpperCase()}${verb.slice(1)} a to-do. Not available for repeating to-dos.`,
         ),
     ).action(async (uuid: string, opts: WriteFlagOpts) => {
       await runWrite(opts, (c) => c.write[method](uuid, writeOptionsFrom(opts)));
@@ -380,18 +378,16 @@ export function registerWriteCommands(program: Command): void {
     todo
       .command("move <uuid>")
       .description(
-        "Move to a project/area (vector: url-scheme; applescript for project/area). " +
-          "Hazards: H-UNKNOWN-DESTINATION (silent no-op otherwise), H-AMBIGUOUS-HEADING, " +
-          "H-REOPEN-RESOLVED-PROJECT, H-REPEAT-SCHEDULE.",
+        "Move a to-do into a project or area (optionally under an existing heading), back " +
+          "to the Inbox, or out of every container. Unknown or ambiguous destinations are " +
+          "rejected. Moving into a completed/canceled project reopens that project — " +
+          "requires --acknowledge-project-reopen.",
       )
       .option("--project <ref>", "destination project (uuid or unique name)")
       .option("--area <ref>", "destination area (uuid or unique name)")
       .option("--heading <name>", "existing heading in the destination project")
-      .option("--inbox", "move back to the Inbox — de-schedules (vector: applescript, E06)")
-      .option(
-        "--detach",
-        "remove ALL container links (project/area/heading) keeping the schedule (P21/P22)",
-      )
+      .option("--inbox", "move back to the Inbox — removes any schedule")
+      .option("--detach", "remove ALL container links (project/area/heading) keeping the schedule")
       .option("--acknowledge-project-reopen", "allow moving into a completed/canceled project"),
   ).action(async (uuid: string, opts: WriteFlagOpts & Record<string, unknown>) => {
     const project = containerRef(opts["project"] as string | undefined);
@@ -430,9 +426,8 @@ export function registerWriteCommands(program: Command): void {
     todo
       .command("duplicate <uuid>")
       .description(
-        "Duplicate a to-do (vector: url-scheme, tier 0; validated E07 — exact copy of " +
-          "title/notes, new uuid discovered by verification). AppleScript refuses duplication " +
-          "(E08). Hazard: H-REPEAT-SCHEDULE — blocked on repeating templates (unvalidated).",
+        "Duplicate a to-do — an exact copy; the copy's uuid is printed on success. Not " +
+          "available for repeating to-dos.",
       ),
   ).action(async (uuid: string, opts: WriteFlagOpts) => {
     await runWrite(opts, (c) => c.write.duplicateTodo(uuid, writeOptionsFrom(opts)));
@@ -442,9 +437,9 @@ export function registerWriteCommands(program: Command): void {
     todo
       .command("tags <uuid>")
       .description(
-        "Set or extend tags (tier 0). --set REPLACES the full tag set (validated semantics); " +
-          "--add merges with current tags. Hazard: H-UNKNOWN-TAG (unknown tags are otherwise " +
-          "silently ignored by the app).",
+        "Set or extend a to-do's tags. --set REPLACES the full tag set (an empty value " +
+          "clears all tags); --add merges with the current tags. Tags must name existing " +
+          "tags — unknown tags are rejected.",
       )
       .option("--set <list>", "comma-separated tag names: full replacement")
       .option("--add <list>", "comma-separated tag names: merge with existing"),
@@ -467,13 +462,13 @@ export function registerWriteCommands(program: Command): void {
     todo
       .command("checklist <uuid>")
       .description(
-        "Checklist operations (tier 0). WHOLESALE: --item (repeatable) replaces the list — " +
-          "destroys per-item state, hazard H-CHECKLIST-REPLACE requires " +
+        "Edit a to-do's checklist. WHOLESALE: --item (repeatable) replaces the whole list, " +
+          "discarding the existing items and their checked states — requires " +
           "--acknowledge-checklist-reset when items exist. GRANULAR (one per call): " +
-          "--add/--remove/--check/--uncheck/--rename+--to/--move-item+--to-position — " +
-          "reads current items+states and rewrites via things:///json with states PRESERVED " +
-          "(P18; the reset ack is implied). Items are matched by exact title (loud on " +
-          "ambiguity); item uuids are not stable across any rewrite.",
+          "--add/--remove/--check/--uncheck/--rename+--to/--move-item+--to-position change " +
+          "a single item with every other item's checked state PRESERVED (no reset flag " +
+          "needed). Items are matched by exact title — ambiguous titles are rejected; item " +
+          "uuids are not stable across any edit.",
       )
       .option("--item <text>", "wholesale: checklist item in order (repeatable)", collect, [])
       .option("--acknowledge-checklist-reset", "accept wholesale replacement of existing items")
@@ -556,8 +551,8 @@ export function registerWriteCommands(program: Command): void {
     todo
       .command("delete <uuid>")
       .description(
-        "Move a to-do to the Trash (vector: applescript, tier 0; restorable via " +
-          "`things todo restore`). Hazard: H-REPEAT-SCHEDULE — blocked on repeating templates.",
+        "Move a to-do to the Trash (recover with `things todo restore`). Not available " +
+          "for repeating to-dos.",
       ),
   ).action(async (uuid: string, opts: WriteFlagOpts) => {
     await runWrite(opts, (c) => c.write.deleteTodo(uuid, writeOptionsFrom(opts)));
@@ -567,10 +562,9 @@ export function registerWriteCommands(program: Command): void {
     todo
       .command("restore <uuid>")
       .description(
-        "Restore a TRASHED to-do (vector: applescript, tier 0; validated E15 — the UI's " +
-          "'Put Back', scripted). The item un-trashes into the Inbox, DE-SCHEDULED: its prior " +
-          "list/schedule are not restored. Blocked unless the target is a trashed to-do " +
-          "(H-UNKNOWN-DESTINATION); trashed projects must be restored in the app.",
+        "Restore a TRASHED to-do: it returns to the Inbox, DE-SCHEDULED — its previous " +
+          "list and schedule are not restored. Only trashed to-dos qualify; for projects " +
+          "use `things project restore`.",
       ),
   ).action(async (uuid: string, opts: WriteFlagOpts) => {
     await runWrite(opts, (c) => c.write.restoreTodo(uuid, writeOptionsFrom(opts)));
@@ -581,7 +575,7 @@ export function registerWriteCommands(program: Command): void {
   addWriteFlags(
     project
       .command("add <title>")
-      .description("Create a project (vector: url-scheme, tier 0).")
+      .description("Create a project; its uuid is printed on success.")
       .option("--notes <text>", "notes body")
       .option("--area <ref>", "destination area (uuid or unique name)")
       .option("--when <value>", "today | evening | anytime | someday | YYYY-MM-DD")
@@ -609,8 +603,8 @@ export function registerWriteCommands(program: Command): void {
     project
       .command("update <uuid>")
       .description(
-        "Update project title/notes/when/deadline (vector: url-scheme, tier 0). " +
-          "--append-notes/--prepend-notes join with a newline (E18; exclusive with --notes).",
+        "Update a project's title/notes/when/deadline. --append-notes/--prepend-notes " +
+          "join with a newline (exclusive with --notes).",
       ),
   )
     .option("--title <text>", "new title")
@@ -654,9 +648,8 @@ export function registerWriteCommands(program: Command): void {
     project
       .command("move <uuid>")
       .description(
-        "Move a project to another area (E14/P23, tier 0) or DETACH it from its area " +
-          "(--detach; URL empty area-id, P24 — the only surface that can). Status and " +
-          "schedule are untouched. Hazard: H-UNKNOWN-DESTINATION.",
+        "Move a project to another area, or DETACH it from its current area (--detach). " +
+          "Status and schedule are untouched. Unknown areas are rejected.",
       )
       .option("--area <ref>", "destination area (uuid or unique name)")
       .option("--detach", "remove the current area assignment (exclusive with --area)"),
@@ -681,13 +674,12 @@ export function registerWriteCommands(program: Command): void {
     project
       .command("cancel <uuid>")
       .description(
-        "Cancel a project (vector: url-scheme, tier 0; validated P01). The URL write " +
-          "auto-cancels open children with NO prompt — hazard H-PROJECT-COMPLETE-CHILDREN " +
-          "requires an explicit --children policy; completed children are untouched.",
+        "Cancel a project. Canceling also cancels its open to-dos, so an explicit " +
+          "--children policy is required; already-completed children are never altered.",
       )
       .requiredOption(
         "--children <policy>",
-        "require-resolved (block if open children) | auto-cancel (verified cascade)",
+        "require-resolved (error if open to-dos remain) | auto-cancel (cancel them too)",
       ),
   ).action(async (uuid: string, opts: WriteFlagOpts & { children: string }) => {
     await runWrite(opts, (c) =>
@@ -703,13 +695,12 @@ export function registerWriteCommands(program: Command): void {
     project
       .command("reopen <uuid>")
       .description(
-        "Reopen a completed/canceled project (vector: url-scheme, tier 0; validated " +
-          "P02/P05 — completed=false / canceled=false per the current status). Children " +
-          "stay resolved unless --restore-children also reopens the ones the cascade " +
-          "resolved (detected by the <2s stopDate window, P03; children resolved earlier " +
-          "are never touched, P04). Exit 3 if any child restore fails.",
+        "Reopen a completed/canceled project. Its children stay completed/canceled unless " +
+          "--restore-children also reopens the ones that were resolved together with the " +
+          "project — children resolved earlier are never touched. Exit 3 if any child " +
+          "restore fails.",
       )
-      .option("--restore-children", "also reopen cascade-resolved children (verified per child)"),
+      .option("--restore-children", "also reopen the children resolved with the project"),
   ).action(async (uuid: string, opts: WriteFlagOpts & { restoreChildren?: boolean }) => {
     const started = Date.now();
     let client: ThingsClient | null = null;
@@ -761,9 +752,8 @@ export function registerWriteCommands(program: Command): void {
     project
       .command("restore <uuid>")
       .description(
-        "Restore a TRASHED project IN PLACE (vector: applescript, tier 0; validated P06): " +
-          "only the trashed flag flips — schedule, area, and children keep their state. " +
-          "Blocked unless the target is a trashed project.",
+        "Restore a TRASHED project IN PLACE: schedule, area, and children all keep their " +
+          "state. Only trashed projects qualify.",
       ),
   ).action(async (uuid: string, opts: WriteFlagOpts) => {
     await runWrite(opts, (c) => c.write.restoreProject(uuid, writeOptionsFrom(opts)));
@@ -773,9 +763,8 @@ export function registerWriteCommands(program: Command): void {
     project
       .command("duplicate <uuid>")
       .description(
-        "Duplicate a project INCLUDING its children (vector: url-scheme, tier 0; validated " +
-          "E17 — update-project?duplicate=true). The copy's uuid is discovered by " +
-          "verification. Hazard: H-REPEAT-SCHEDULE — blocked on repeating projects (unvalidated).",
+        "Duplicate a project INCLUDING its children; the copy's uuid is printed on " +
+          "success. Not available for repeating projects.",
       ),
   ).action(async (uuid: string, opts: WriteFlagOpts) => {
     await runWrite(opts, (c) => c.write.duplicateProject(uuid, writeOptionsFrom(opts)));
@@ -785,13 +774,12 @@ export function registerWriteCommands(program: Command): void {
     project
       .command("complete <uuid>")
       .description(
-        "Complete a project (vector: url-scheme, tier 0). The URL write auto-completes open " +
-          "children with NO prompt (validated) — hazard H-PROJECT-COMPLETE-CHILDREN therefore " +
-          "requires an explicit --children policy; the cascade is verified, not assumed.",
+        "Complete a project. Completing also completes its open to-dos, so an explicit " +
+          "--children policy is required.",
       )
       .requiredOption(
         "--children <policy>",
-        "require-resolved (block if open children) | auto-complete (verified cascade)",
+        "require-resolved (error if open to-dos remain) | auto-complete (complete them too)",
       ),
   ).action(async (uuid: string, opts: WriteFlagOpts & { children: string }) => {
     await runWrite(opts, (c) =>
@@ -807,8 +795,8 @@ export function registerWriteCommands(program: Command): void {
     project
       .command("delete <uuid>")
       .description(
-        "Move a project to the Trash (vector: applescript, tier 0). DB semantics are shallow " +
-          "(validated A24B): children keep their links; Trash membership is derived.",
+        "Move a project to the Trash; its children go with it (recover with `things " +
+          "project restore`).",
       ),
   ).action(async (uuid: string, opts: WriteFlagOpts) => {
     await runWrite(opts, (c) => c.write.deleteProject(uuid, writeOptionsFrom(opts)));
@@ -818,10 +806,7 @@ export function registerWriteCommands(program: Command): void {
   addWriteFlags(
     area
       .command("add <title>")
-      .description(
-        "Create an area (vector: applescript — the URL scheme cannot; tier 0). " +
-          "Optionally tag it with EXISTING tags.",
-      )
+      .description("Create an area, optionally tagged with EXISTING tags.")
       .option("--tags <list>", "comma-separated existing tag names"),
   ).action(async (title: string, opts: WriteFlagOpts & Record<string, unknown>) => {
     const tags = splitCsv(opts["tags"] as string | undefined);
@@ -833,8 +818,8 @@ export function registerWriteCommands(program: Command): void {
     area
       .command("update <target>")
       .description(
-        "Rename an area and/or replace its tags (vector: applescript, tier 0; E01). " +
-          "Target by uuid or unique name. Hazard: H-UNKNOWN-TAG for --tags.",
+        "Rename an area and/or replace its tags (the full set; tags must name existing " +
+          "tags). Target by uuid or unique name.",
       )
       .option("--title <text>", "new name")
       .option("--tags <list>", "comma-separated EXISTING tag names (full replacement)"),
@@ -861,8 +846,9 @@ export function registerWriteCommands(program: Command): void {
     area
       .command("delete <target>")
       .description(
-        "Delete an area PERMANENTLY (vector: applescript, tier 0). Areas skip the Trash " +
-          "(validated A25); contained to-dos are trashed. Requires --dangerously-permanent.",
+        "Delete an area PERMANENTLY — areas do not go to the Trash, so this cannot be " +
+          "undone; requires --dangerously-permanent. The area's to-dos move to the Trash; " +
+          "its projects remain, no longer assigned to any area.",
       )
       .option("--dangerously-permanent", "accept permanent, unrecoverable deletion"),
   ).action(async (target: string, opts: WriteFlagOpts & Record<string, unknown>) => {
@@ -882,10 +868,7 @@ export function registerWriteCommands(program: Command): void {
   addWriteFlags(
     tag
       .command("add <name>")
-      .description(
-        "Create a tag (vector: applescript — the URL scheme cannot; tier 0). " +
-          "--parent nests it under an existing tag.",
-      )
+      .description("Create a tag; --parent nests it under an existing tag.")
       .option("--parent <name>", "existing parent tag"),
   ).action(async (name: string, opts: WriteFlagOpts & Record<string, unknown>) => {
     await runWrite(opts, (c) =>
@@ -899,10 +882,9 @@ export function registerWriteCommands(program: Command): void {
     tag
       .command("update <target>")
       .description(
-        "Rename a tag (assignments survive — E02), nest it under an existing tag (E03), " +
-          "UN-NEST it to root (--unnest, P29 — the property-delete form; exclusive with " +
-          "--parent), and/or set its keyboard shortcut (E10). Vector: applescript, tier 0. " +
-          "Clearing a shortcut is unprobed — not offered.",
+        "Rename a tag (existing assignments follow the rename), nest it under an existing " +
+          "tag, UN-NEST it to the root (--unnest; exclusive with --parent), and/or set its " +
+          "keyboard shortcut. Clearing a shortcut is not supported.",
       )
       .option("--title <text>", "new name")
       .option("--parent <name>", "existing tag to nest under")
@@ -942,10 +924,10 @@ export function registerWriteCommands(program: Command): void {
     tag
       .command("delete <target>")
       .description(
-        "Delete a tag PERMANENTLY (vector: applescript, tier 0). Assignments cascade " +
-          "(validated A26) and CHILD TAGS are cascade-deleted too (P16) — hazard " +
-          "H-TAG-SUBTREE-DELETE requires --acknowledge-subtree when children exist. " +
-          "Requires --dangerously-permanent.",
+        "Delete a tag PERMANENTLY — tags do not go to the Trash, so this cannot be " +
+          "undone; requires --dangerously-permanent. The tag is removed from every item, " +
+          "and ALL of its nested child tags are deleted with it — requires " +
+          "--acknowledge-subtree when children exist.",
       )
       .option("--dangerously-permanent", "accept permanent, unrecoverable deletion")
       .option("--acknowledge-subtree", "accept cascade-deletion of ALL descendant tags"),
@@ -968,8 +950,8 @@ export function registerWriteCommands(program: Command): void {
     trash
       .command("empty")
       .description(
-        "Empty the Trash: PERMANENTLY deletes every trashed row (vector: applescript, tier 0; " +
-          "validated A27 — no tombstones with sync off). Requires --dangerously-permanent.",
+        "Empty the Trash: PERMANENTLY deletes every trashed item — this cannot be undone. " +
+          "Requires --dangerously-permanent.",
       )
       .option("--dangerously-permanent", "accept permanent, unrecoverable deletion"),
   ).action(async (rawOpts: WriteFlagOpts & Record<string, unknown>, cmd: Command) => {
@@ -993,10 +975,10 @@ export function registerWriteCommands(program: Command): void {
     .description(
       "Run MANY mutations from JSONL (file, or stdin when omitted/'-'): one op per line, " +
         '{"op": "<kind>", "params": {...}, "options": {...}} — see `things capabilities` for ' +
-        "op kinds and params. Every op runs the FULL pipeline (guards, verified " +
-        "read-after-write, audit) sequentially; per-op results stream as JSONL. No " +
-        "transactions. Per-op options carry acknowledgement flags " +
-        "(acknowledgeChecklistReset, acknowledgeProjectReopen, dangerouslyPermanent). " +
+        "op kinds and params. Ops run sequentially and independently — NO transactions; a " +
+        "failure does not roll back earlier ops. Per-op results stream as JSONL. Per-op " +
+        "options carry the confirmation flags (acknowledgeChecklistReset, " +
+        "acknowledgeProjectReopen, dangerouslyPermanent, acknowledgeTagSubtree). " +
         "--dry-run plans everything without executing; --fail-fast skips the rest after " +
         "the first failure. Exit: 0 all ok · 3 any verify-failed/invalid · 4 any blocked " +
         "· 5 any drift-blocked.",
@@ -1005,7 +987,7 @@ export function registerWriteCommands(program: Command): void {
     .option("--fail-fast", "skip remaining ops after the first failure")
     .option("--json", "JSONL results + summary on stdout (also the default)")
     .option("--db <path>", "explicit database path")
-    .option("--actor <name>", "audit attribution for the whole batch")
+    .option("--actor <name>", "author name recorded for the whole batch")
     .action(async (file: string | undefined, opts: WriteFlagOpts & Record<string, unknown>) => {
       let raw: string;
       if (file !== undefined && file !== "-") {
@@ -1083,14 +1065,14 @@ export function registerWriteCommands(program: Command): void {
   program
     .command("undo")
     .description(
-      "Undo the last N successful mutations by replaying INVERSE ops from the audit trail " +
-        "(newest first). Each inverse runs the full pipeline: guards, verified " +
-        "read-after-write, audit (as actor `undo:<actor>` — never itself an undo target). " +
-        "IRREVERSIBLE ops are reported, not guessed: permanent deletes, project " +
-        "complete/delete, ops whose pre-state was not captured. Partial restores carry " +
-        "notes (e.g. a delete-undo lands in the Inbox de-scheduled). --dry-run shows every " +
-        "inverse plan without executing. Undoing a CREATED area/tag deletes it permanently " +
-        "— requires --dangerously-permanent. Unwinding stops at the first failed inverse. " +
+      "Undo the last N changes made through things-api, newest first — each undo applies " +
+        "the INVERSE change (recorded as actor `undo:<actor>`, never itself an undo " +
+        "target). Changes made directly in the Things app cannot be undone here. " +
+        "IRREVERSIBLE changes are reported, not guessed: permanent deletes and changes " +
+        "whose prior state is unknown. Partial restores carry notes (e.g. a delete-undo " +
+        "lands in the Inbox de-scheduled). --dry-run shows every inverse plan without " +
+        "executing. Undoing a CREATED area/tag deletes it permanently — requires " +
+        "--dangerously-permanent. Unwinding stops at the first failed inverse. " +
         "Exit: 0 all ok · 3 any failed/partial · 0 with per-item detail otherwise.",
     )
     .option("--last <n>", "how many trailing mutations to undo", "1")
@@ -1098,8 +1080,8 @@ export function registerWriteCommands(program: Command): void {
     .option("--dangerously-permanent", "allow inverses that delete areas/tags permanently")
     .option("--json", "JSONL per-item results + summary on stdout (also the default)")
     .option("--db <path>", "explicit database path")
-    .option("--verify-timeout <ms>", "read-after-write verification deadline per inverse op")
-    .option("--actor <name>", "audit attribution (recorded as undo:<name>)")
+    .option("--verify-timeout <ms>", "how long to wait for each inverse change to take effect")
+    .option("--actor <name>", "author name recorded for the undo (as undo:<name>)")
     .action(async (opts: WriteFlagOpts & Record<string, unknown>) => {
       let client: ThingsClient | null = null;
       try {
@@ -1148,12 +1130,12 @@ export function registerWriteCommands(program: Command): void {
       .description(
         "Reorder items within Today, This Evening, a project, or an area — uuids are placed " +
           "at the TOP in the given order; unlisted members keep their relative order below. " +
-          "Strategies: native (private sdef command — EXPERIMENTAL, requires `things config " +
-          "set allow-experimental true`; today/project/area) and bounce (verified when= " +
-          `round-trips; today/evening, max ${BOUNCE_MAX_ITEMS} items). Evening is bounce-only: ` +
-          "the native command silently de-evenings items (O03). Headed project children are " +
-          "rejected (O06). Area scope reorders to-dos (O05/O10) OR projects (O14) — never " +
-          "mixed in one request. Hazard: H-REORDER-SCOPE.",
+          "Strategies: native (EXPERIMENTAL — requires `things config set allow-experimental " +
+          "true` and may stop working after a Things update; today/project/area) and bounce " +
+          `(today/evening, max ${BOUNCE_MAX_ITEMS} items; an interrupted run reports which ` +
+          "items were placed). Evening is bounce-only. Project children under headings " +
+          "cannot be reordered. Area scope reorders to-dos OR projects — never mixed in " +
+          "one request.",
       )
       .requiredOption("--scope <scope>", "today | evening | project | area")
       .option("--project <ref>", "project (uuid or unique name) — scope=project")
@@ -1182,8 +1164,9 @@ export function registerWriteCommands(program: Command): void {
   program
     .command("capabilities")
     .description(
-      "Dump the operation × vector support matrix (lab-validated data) — what is possible, " +
-        "at which disruption tier, with which caveats",
+      "Reference for every operation kind (used by `things batch` and the MCP " +
+        "run_operation tool): whether it is supported, its caveats, and the confirmation " +
+        "flags it needs — with the underlying support evidence",
     )
     .option("--op <operation>", "limit to one operation kind")
     .option("--json", "emit versioned JSON envelope on stdout")
@@ -1213,7 +1196,7 @@ export function registerWriteCommands(program: Command): void {
   const config = group(program, "config", "things-api configuration");
   config
     .command("show")
-    .description("Show the effective configuration (profile, disruption policy, audit)")
+    .description("Show the effective configuration (profile, disruption policy, actor)")
     .option("--json", "emit versioned JSON envelope on stdout")
     .option("--db <path>", "explicit database path")
     .action((opts: { json?: boolean; db?: string }) => {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -22,13 +22,13 @@ AGENT NOTES:
   - Every command supports --json: versioned envelope on stdout, logs on stderr.
   - Exit codes are stable: 0 ok, 2 usage, 3 verify-failed, 4 blocked,
     5 drift-blocked, 6 unsupported, 7 environment.
-  - No command ever prompts interactively; risky operations require explicit
-    acknowledgement flags documented in their --help.
-  - Discover the operation x vector support matrix with: things capabilities --json
-  - Every write supports --dry-run: inspect the compiled invocation, disruption
-    tier, hazards, and expected delta without executing anything.
-  - Every mutation is verified by read-after-write and recorded in the audit
-    trail (~/.local/state/things-api/audit/); blocked errors carry remediation.
+  - No command ever prompts interactively; operations with cascading or
+    permanent effects require explicit flags documented in their --help.
+  - Discover the full operation catalog with: things capabilities --json
+  - Every write supports --dry-run: preview the planned change and its
+    expected effect without executing anything.
+  - Failures are loud: a change that does not take effect exits 3; refused
+    changes exit 4 with machine-readable remediation.
 `;
 
 export function buildProgram(): Command {

--- a/src/client.ts
+++ b/src/client.ts
@@ -131,7 +131,7 @@ export interface ThingsClient {
       dest: Omit<TodoMoveParams, "uuid">,
       options?: WriteOptions,
     ): Promise<MutationResult>;
-    /** Full tag replacement (validated semantics, U04). */
+    /** Replace the full tag set (an empty list clears all tags). */
     setTags(uuid: string, tags: string[], options?: WriteOptions): Promise<MutationResult>;
     /** Merge: current direct tags + new ones, then replace. */
     addTags(uuid: string, tags: string[], options?: WriteOptions): Promise<MutationResult>;
@@ -141,18 +141,17 @@ export interface ThingsClient {
       options?: WriteOptions,
     ): Promise<MutationResult>;
     deleteTodo(uuid: string, options?: WriteOptions): Promise<MutationResult>;
-    /** Duplicate via URL `duplicate=true` (E07) — the copy's uuid is discovered by verification. */
+    /** Duplicate a to-do; the copy's uuid is on the result. */
     duplicateTodo(uuid: string, options?: WriteOptions): Promise<MutationResult>;
-    /** Restore a TRASHED to-do (E15): un-trashes into the Inbox, de-scheduled. */
+    /** Restore a TRASHED to-do: it returns to the Inbox, de-scheduled. */
     restoreTodo(uuid: string, options?: WriteOptions): Promise<MutationResult>;
-    /** Detach a to-do from its project/area/heading, keeping the schedule (P21/P22). */
+    /** Detach a to-do from its project/area/heading, keeping the schedule. */
     detachTodo(uuid: string, options?: WriteOptions): Promise<MutationResult>;
     /**
-     * One granular checklist edit (add/remove/check/uncheck/rename/move) —
-     * reads the current items+states, applies the edit, writes the full list
-     * back via things:///json with per-item states preserved (P18). Item
-     * uuids are NOT stable across the rewrite. The checklist-reset ack is
-     * implied: state is preserved by construction.
+     * One granular checklist edit (add/remove/check/uncheck/rename/move):
+     * changes a single item while every other item and its checked state is
+     * preserved (no reset acknowledgement needed). Items are matched by
+     * exact title; item uuids are NOT stable across an edit.
      */
     editChecklist(
       uuid: string,
@@ -170,24 +169,24 @@ export interface ThingsClient {
       policy: Pick<ProjectCompleteParams, "children">,
       options?: WriteOptions,
     ): Promise<MutationResult>;
-    /** Move a project to another area (E14 AppleScript / P23 URL). */
+    /** Move a project to another area. */
     moveProject(uuid: string, area: ContainerRef, options?: WriteOptions): Promise<MutationResult>;
-    /** Detach a project from its area, one verified write (P24 — URL only). */
+    /** Detach a project from its current area. */
     detachProject(uuid: string, options?: WriteOptions): Promise<MutationResult>;
-    /** Cancel a project; the URL write auto-cancels open children (P01) — policy mandatory. */
+    /** Cancel a project — open children are canceled with it, so the children policy is mandatory. */
     cancelProject(
       uuid: string,
       policy: Pick<ProjectCancelParams, "children">,
       options?: WriteOptions,
     ): Promise<MutationResult>;
     /**
-     * Reopen a completed/canceled project (P02/P05). Children stay resolved
-     * unless restoreChildren reopens the cascade-resolved ones (P03 window).
+     * Reopen a completed/canceled project. Children stay resolved unless
+     * restoreChildren reopens the ones resolved together with the project.
      */
     reopenProject(uuid: string, options?: ProjectReopenOptions): Promise<ProjectReopenResult>;
-    /** Restore a TRASHED project IN PLACE (P06) — nothing relocates. */
+    /** Restore a TRASHED project IN PLACE — nothing relocates. */
     restoreProject(uuid: string, options?: WriteOptions): Promise<MutationResult>;
-    /** Duplicate a project INCLUDING children (E17) — copy discovered by verification. */
+    /** Duplicate a project INCLUDING its children; the copy's uuid is on the result. */
     duplicateProject(uuid: string, options?: WriteOptions): Promise<MutationResult>;
     deleteProject(uuid: string, options?: WriteOptions): Promise<MutationResult>;
     addArea(params: AreaAddParams, options?: WriteOptions): Promise<MutationResult>;
@@ -211,8 +210,8 @@ export interface ThingsClient {
      */
     reorder(params: ReorderParams, options?: WriteOptions): Promise<ReorderResult>;
     /**
-     * Run N ops sequentially through the full pipeline (each guarded,
-     * verified, audited). No transactional semantics — per-op results.
+     * Run N ops sequentially and independently — no transactions, a failure
+     * does not roll back earlier ops. Per-op results.
      */
     batch(
       ops: BatchOp[],
@@ -220,16 +219,16 @@ export interface ThingsClient {
       onResult?: (result: BatchItemResult) => void,
     ): Promise<BatchItemResult[]>;
     /**
-     * Undo the last N successful mutations by replaying inverse ops from the
-     * audit trail (each inverse runs the full guarded+verified pipeline).
-     * Irreversible ops are reported as such, never guessed at.
+     * Undo the last N changes made through this client, newest first, by
+     * applying the inverse change. Irreversible changes are reported as
+     * such, never guessed at.
      */
     undo(options?: UndoOptions, onItem?: (item: UndoItemResult) => void): Promise<UndoItemResult[]>;
   };
   close(): void;
 }
 
-/** One granular checklist edit, applied over a stateful wholesale rewrite (P18). */
+/** One granular checklist edit; every other item's checked state is preserved. */
 export type ChecklistEdit =
   | { action: "add"; title: string; /** 1-based insert position (default: append). */ at?: number }
   | { action: "remove"; item: string }

--- a/src/write/operations.ts
+++ b/src/write/operations.ts
@@ -52,9 +52,8 @@ export interface TodoAddParams {
   notes?: string;
   when?: WhenValue;
   /**
-   * Time-of-day reminder, `HH:mm` 24h. Requires when: today|evening (the
-   * only probed combinations, R01–R16); compiled through the deterministic
-   * URL emitter (the app's bare-hour parser is a trap — oddity 2d).
+   * Time-of-day reminder, `HH:mm` 24h. Requires a schedulable `when`
+   * (today, evening, or a date) in the same call.
    */
   reminder?: ReminderTime;
   deadline?: IsoDate;
@@ -62,7 +61,7 @@ export interface TodoAddParams {
   checklistItems?: string[];
   project?: ContainerRef;
   area?: ContainerRef;
-  /** Existing heading inside the target project (placement-only; U09). */
+  /** Existing heading inside the target project (placement only). */
   heading?: string;
 }
 
@@ -70,16 +69,16 @@ export interface TodoUpdateParams {
   uuid: string;
   title?: string;
   notes?: string;
-  /** Append to the existing notes (newline-joined; E04/E11). Exclusive with notes/prependNotes. */
+  /** Append to the existing notes (newline-joined). Exclusive with notes/prependNotes. */
   appendNotes?: string;
-  /** Prepend to the existing notes (newline-joined; E05/E12). Exclusive with notes/appendNotes. */
+  /** Prepend to the existing notes (newline-joined). Exclusive with notes/appendNotes. */
   prependNotes?: string;
   when?: WhenValue;
   /**
    * `HH:mm` sets a reminder (requires when: today|evening in the same call);
-   * null clears it. When `when` is today/evening and this is OMITTED, an
-   * existing reminder is auto-preserved — a bare when= would silently clear
-   * it (R07).
+   * null clears it (today/evening only — a dated reminder can only be
+   * changed, not cleared). When re-scheduling with this OMITTED, an existing
+   * reminder is auto-preserved.
    */
   reminder?: ReminderTime | null;
   deadline?: IsoDate | null;
@@ -95,35 +94,34 @@ export interface TodoMoveParams {
   area?: ContainerRef;
   /** Existing heading inside the destination project. */
   heading?: string;
-  /** Move back to the Inbox (de-schedules; E06). Exclusive with the others. */
+  /** Move back to the Inbox — removes any schedule. Exclusive with the others. */
   inbox?: boolean;
   /**
-   * Detach from the current project/area/heading, keeping schedule and
-   * everything else (URL `list-id=` empty, P21/P22). Exclusive with the others.
+   * Detach from the current project/area/heading, keeping the schedule and
+   * everything else. Exclusive with the others.
    */
   detach?: boolean;
 }
 
 export interface TodoSetTagsParams {
   uuid: string;
-  /** Full replacement set (validated semantics, U04). */
+  /** Full replacement set (an empty list clears all tags). */
   tags: string[];
 }
 
-/** One checklist item in a stateful replacement (P18: json carries states). */
+/** One checklist item in a stateful replacement. */
 export interface ChecklistItemSpec {
   title: string;
-  /** Recreate the item pre-checked (json vector only). */
+  /** Recreate the item pre-checked. */
   completed?: boolean;
 }
 
 export interface TodoReplaceChecklistParams {
   uuid: string;
   /**
-   * Full replacement list. Plain strings ride the classic `checklist-items=`
-   * URL param (all items recreated OPEN — T07); any object entry switches to
-   * the `things:///json` form, which applies per-item completed states (P18).
-   * Item uuids are NOT stable across a rewrite either way.
+   * Full replacement list. Plain strings recreate items unchecked; object
+   * entries can recreate items pre-checked. Item uuids are NOT stable
+   * across a rewrite.
    */
   items: (string | ChecklistItemSpec)[];
 }
@@ -141,9 +139,9 @@ export interface ProjectUpdateParams {
   uuid: string;
   title?: string;
   notes?: string;
-  /** Append to the existing notes (newline-joined; E18). Exclusive with notes/prependNotes. */
+  /** Append to the existing notes (newline-joined). Exclusive with notes/prependNotes. */
   appendNotes?: string;
-  /** Prepend to the existing notes (newline-joined; E18). Exclusive with notes/appendNotes. */
+  /** Prepend to the existing notes (newline-joined). Exclusive with notes/appendNotes. */
   prependNotes?: string;
   when?: WhenValue;
   deadline?: IsoDate | null;
@@ -151,17 +149,17 @@ export interface ProjectUpdateParams {
 
 export interface ProjectMoveParams {
   uuid: string;
-  /** Destination area (uuid or unique name). E14 (AppleScript) / P23 (URL). */
+  /** Destination area (uuid or unique name). */
   area?: ContainerRef;
-  /** Detach from the current area (URL `area-id=` empty, P24). Exclusive with area. */
+  /** Detach from the current area. Exclusive with area. */
   detach?: boolean;
 }
 
 export interface ProjectCompleteParams {
   uuid: string;
   /**
-   * Open-children policy — REQUIRED, no default (T08/U08: URL completion
-   * silently auto-completes open children, unlike the UI prompt).
+   * Open-children policy — REQUIRED, no default: completing a project also
+   * completes its open children.
    */
   children: "require-resolved" | "auto-complete";
 }
@@ -169,8 +167,8 @@ export interface ProjectCompleteParams {
 export interface ProjectCancelParams {
   uuid: string;
   /**
-   * Open-children policy — REQUIRED, no default (P01: URL cancellation
-   * silently auto-cancels open children; completed children are untouched).
+   * Open-children policy — REQUIRED, no default: canceling a project also
+   * cancels its open children; completed children are untouched.
    */
   children: "require-resolved" | "auto-cancel";
 }
@@ -182,7 +180,7 @@ export interface AreaAddParams {
 
 export interface TagAddParams {
   title: string;
-  /** Existing parent tag title (hierarchy; A05). */
+  /** Existing parent tag title to nest under. */
   parent?: string;
 }
 
@@ -203,14 +201,11 @@ export interface TagUpdateParams {
   /** uuid or unique case-insensitive title. */
   target: string;
   title?: string;
-  /** Existing tag to nest under (E03). Exclusive with unnest. */
+  /** Existing tag to nest under. Exclusive with unnest. */
   parent?: string;
-  /**
-   * Un-nest to root via the AppleScript property-delete form (P29 — the one
-   * spelling that works; `set parent tag to missing value` errors, E19).
-   */
+  /** Un-nest the tag to the root of the hierarchy. Exclusive with parent. */
   unnest?: boolean;
-  /** Single character (clearing to none is unprobed — not offered). */
+  /** Single character (clearing to none is not supported). */
   shortcut?: string;
 }
 
@@ -224,16 +219,13 @@ export interface ReorderParams {
   /**
    * Desired order, top-first. May be a SUBSET of the scope's members: the
    * requested uuids are placed at the top in this order and every remaining
-   * member keeps its current relative order below them (the wire list sent
-   * to the app is always the full member list — O01 proved partial sends
-   * work but leave placement underdetermined).
+   * member keeps its current relative order below them.
    */
   uuids: string[];
   /**
    * Omit for the default per scope: native for today/project/area (requires
-   * allowExperimental + the sdef canary), bounce for evening. Today accepts
-   * an explicit "bounce" fallback; project/area are native-only; evening is
-   * bounce-only (O03: native reorder silently de-evenings bucket-1 members).
+   * allowExperimental), bounce for evening. Today accepts an explicit
+   * "bounce" fallback; project/area are native-only; evening is bounce-only.
    */
   strategy?: ReorderStrategy;
 }
@@ -271,14 +263,14 @@ export interface OperationParamsMap {
   "project.restore": UuidParams;
 }
 
-/** Explicit acknowledgements for guarded operations (never defaulted). */
+/** Explicit confirmations for operations with cascading or permanent effects (never defaulted). */
 export interface Acknowledgements {
-  /** H-CHECKLIST-REPLACE: checklist replacement destroys per-item state (T07). */
+  /** Confirm a wholesale checklist replacement that discards existing items and their checked states. */
   acknowledgeChecklistReset?: boolean;
-  /** H-REOPEN-RESOLVED-PROJECT: adding an open child reopens a resolved project (T19). */
+  /** Confirm adding/moving an open item into a completed/canceled project (this reopens the project). */
   acknowledgeProjectReopen?: boolean;
-  /** H-PERMANENT-DELETE: area/tag delete and empty-trash skip the Trash entirely. */
+  /** Confirm a permanent deletion: area/tag delete and empty-trash skip the Trash entirely. */
   dangerouslyPermanent?: boolean;
-  /** H-TAG-SUBTREE-DELETE: deleting a parent tag cascade-deletes its children (P16). */
+  /** Confirm that deleting a parent tag permanently deletes ALL of its descendant tags. */
   acknowledgeTagSubtree?: boolean;
 }

--- a/test/cli/help-contract.test.ts
+++ b/test/cli/help-contract.test.ts
@@ -1,11 +1,14 @@
 /**
  * Help text is the agent API contract (design §3): agents discover the tool
- * through --help, so its load-bearing statements — hazards, ack flag names,
- * vectors, tiers, exit codes — are regression-tested here. These assert the
- * CONTRACT lines, not the full rendering, so cosmetic rewording stays cheap
- * while contract drift fails loudly.
+ * through --help, so its load-bearing statements — behavior, side effects,
+ * confirmation flag names, exit codes — are regression-tested here. These
+ * assert the CONTRACT lines, not the full rendering, so cosmetic rewording
+ * stays cheap while contract drift fails loudly. A companion suite enforces
+ * the consumer-voice rules of docs/design/surface-copy.md.
  */
 import { describe, expect, it } from "vitest";
+
+import type { Command } from "commander";
 
 import { buildProgram } from "../../src/cli/main.ts";
 
@@ -42,35 +45,37 @@ describe("root help", () => {
 });
 
 describe("write-command help states the contract", () => {
-  it("todo add: vector, tier, hazards, ack flag", () => {
+  it("todo add: loud unknown-reference behavior + reopen ack flag", () => {
     const help = helpFor("todo", "add");
-    expect(help).toContain("vector: url-scheme");
-    expect(help).toContain("tier 0");
-    expect(help).toContain("H-UNKNOWN-TAG");
-    expect(help).toContain("H-REOPEN-RESOLVED-PROJECT");
+    expect(help).toContain("unknown or ambiguous references are rejected");
+    expect(help).toContain("reopens that project");
     expect(help).toContain("--acknowledge-project-reopen");
     expect(help).toContain("--dry-run");
   });
 
-  it("todo update: repeating-template hard-block is documented", () => {
+  it("todo update: repeating restriction is documented", () => {
     const help = helpFor("todo", "update");
-    expect(help).toContain("H-REPEAT-SCHEDULE");
-    expect(help).toContain("crashes Things");
+    expect(help).toContain("not available for repeating to-dos");
   });
 
   it("todo checklist: destructive semantics + exact ack flag", () => {
     const help = helpFor("todo", "checklist");
-    expect(help).toContain("H-CHECKLIST-REPLACE");
     expect(help).toContain("--acknowledge-checklist-reset");
-    expect(help).toContain("destroys per-item state");
-    expect(help).toContain("states PRESERVED");
+    expect(help).toContain("discarding the existing items");
+    expect(help).toContain("PRESERVED");
   });
 
-  it("project complete: mandatory children policy + verified cascade", () => {
+  it("project complete: mandatory children policy + cascade behavior", () => {
     const help = helpFor("project", "complete");
     expect(help).toContain("--children <policy>");
-    expect(help).toContain("auto-completes open");
-    expect(help).toContain("verified");
+    expect(help).toContain("also completes its open to-dos");
+  });
+
+  it("project cancel: mandatory children policy + completed-children exemption", () => {
+    const help = helpFor("project", "cancel");
+    expect(help).toContain("--children <policy>");
+    expect(help).toContain("also cancels its open to-dos");
+    expect(help).toContain("never altered");
   });
 
   it("permanent deletes require --dangerously-permanent", () => {
@@ -85,14 +90,27 @@ describe("write-command help states the contract", () => {
     }
   });
 
-  it("doctor: exit-code contract", () => {
-    const help = helpFor("doctor");
-    expect(help).toContain("Exit 0 healthy; 5 schema drift");
+  it("tag delete: subtree cascade + ack flag", () => {
+    const help = helpFor("tag", "delete");
+    expect(help).toContain("nested child tags are deleted with it");
+    expect(help).toContain("--acknowledge-subtree");
   });
 
-  it("capabilities: discovery command exists and mentions vectors", () => {
+  it("area delete: to-dos trashed, projects orphaned", () => {
+    const help = helpFor("area", "delete");
+    expect(help).toContain("to-dos move to the Trash");
+    expect(help).toContain("projects remain");
+  });
+
+  it("doctor: exit-code contract + setup guidance", () => {
+    const help = helpFor("doctor");
+    expect(help).toContain("Exit 0 healthy; 5 schema drift");
+    expect(help).toContain("Enable Things URLs");
+  });
+
+  it("capabilities: discovery command exists", () => {
     const help = helpFor("capabilities");
-    expect(help).toContain("vector");
+    expect(help).toContain("operation kind");
     expect(help).toContain("--op");
   });
 
@@ -100,33 +118,33 @@ describe("write-command help states the contract", () => {
     const help = helpFor("todo", "update");
     expect(help).toContain("--reminder <HH:mm>");
     expect(help).toContain("--clear-reminder");
-    expect(help).toContain("H-REMINDER-SCOPE");
     expect(help).toContain("auto-preserved");
+    expect(help).toContain("can only be changed, not cleared");
     expect(help).toContain("--append-notes");
     expect(help).toContain("--prepend-notes");
   });
 
-  it("todo duplicate: url-only path + template block", () => {
+  it("todo duplicate: exact copy + repeating restriction", () => {
     const help = helpFor("todo", "duplicate");
-    expect(help).toContain("url-scheme");
-    expect(help).toContain("H-REPEAT-SCHEDULE");
+    expect(help).toContain("exact copy");
+    expect(help).toContain("repeating");
   });
 
-  it("area/tag update: setters exist with evidence-scoped caveats", () => {
+  it("area/tag update: setters exist with behavior-scoped caveats", () => {
     const areaHelp = helpFor("area", "update");
     expect(areaHelp).toContain("--title");
-    expect(areaHelp).toContain("H-UNKNOWN-TAG");
+    expect(areaHelp).toContain("must name existing");
     const tagHelp = helpFor("tag", "update");
     expect(tagHelp).toContain("--parent");
     expect(tagHelp).toContain("--unnest");
     expect(tagHelp).toContain("--shortcut");
-    expect(tagHelp).toContain("unprobed");
+    expect(tagHelp).toContain("Clearing a shortcut is not supported");
   });
 
-  it("batch: pipeline guarantees, no transactions, exit codes", () => {
+  it("batch: no transactions, confirmation options, exit codes", () => {
     const help = helpFor("batch");
-    expect(help).toContain("FULL pipeline");
-    expect(help).toContain("No transactions");
+    expect(help).toContain("NO transactions");
+    expect(help).toContain("acknowledgeTagSubtree");
     expect(help).toContain("--fail-fast");
     expect(help).toContain("--dry-run");
     expect(help).toContain("0 all ok");
@@ -160,13 +178,12 @@ describe("write-command help states the contract", () => {
     expect(help).toContain("--limit <n>");
   });
 
-  it("reorder: experimental gate, bounce cap, scope hazards", () => {
+  it("reorder: experimental gate, bounce cap, scope restrictions", () => {
     const help = helpFor("reorder");
     expect(help).toContain("EXPERIMENTAL");
     expect(help).toContain("allow-experimental");
     expect(help).toContain("bounce");
     expect(help).toContain("Evening is bounce-only");
-    expect(help).toContain("H-REORDER-SCOPE");
     expect(help).toContain("--scope <scope>");
     expect(help).toContain("--strategy <name>");
     expect(help).toContain("--dry-run");
@@ -177,21 +194,33 @@ describe("write-command help states the contract", () => {
     const help = helpFor("todo", "restore");
     expect(help).toContain("TRASHED");
     expect(help).toContain("DE-SCHEDULED");
-    expect(help).toContain("applescript");
   });
 
-  it("project move: area destination, evidence-scoped", () => {
+  it("todo move: exclusive destinations incl. inbox de-schedule + detach", () => {
+    const help = helpFor("todo", "move");
+    expect(help).toContain("--inbox");
+    expect(help).toContain("removes any schedule");
+    expect(help).toContain("--detach");
+    expect(help).toContain("keeping the schedule");
+  });
+
+  it("project move: area destination or detach", () => {
     const help = helpFor("project", "move");
     expect(help).toContain("--area <ref>");
-    expect(help).toContain("applescript");
-    expect(help).toContain("H-UNKNOWN-DESTINATION");
+    expect(help).toContain("--detach");
+    expect(help).toContain("Unknown areas are rejected");
   });
 
-  it("project duplicate: children included + template block", () => {
+  it("project reopen: children stay resolved unless restored", () => {
+    const help = helpFor("project", "reopen");
+    expect(help).toContain("--restore-children");
+    expect(help).toContain("resolved together with the project");
+  });
+
+  it("project duplicate: children included + repeating restriction", () => {
     const help = helpFor("project", "duplicate");
     expect(help).toContain("INCLUDING its children");
-    expect(help).toContain("url-scheme");
-    expect(help).toContain("H-REPEAT-SCHEDULE");
+    expect(help).toContain("repeating");
   });
 
   it("upcoming: horizon projections documented as unmaterialized host math", () => {
@@ -202,10 +231,11 @@ describe("write-command help states the contract", () => {
     expect(help).toContain("--tag <ref>");
   });
 
-  it("undo: audit-replay contract — inverse pipeline, irreversibles, permanent gate", () => {
+  it("undo: own-changes-only scope, irreversibles, permanent gate", () => {
     const help = helpFor("undo");
     expect(help).toContain("INVERSE");
     expect(help).toContain("IRREVERSIBLE");
+    expect(help).toContain("cannot be undone here");
     expect(help).toContain("--last <n>");
     expect(help).toContain("--dry-run");
     expect(help).toContain("--dangerously-permanent");
@@ -219,46 +249,37 @@ describe("write-command help states the contract", () => {
     expect(help).toContain('args ["mcp"]');
     expect(help).toContain("live area/tag/project inventory");
   });
+});
 
-  it("project cancel/reopen/restore: lifecycle contract from the P-suite", () => {
-    const cancel = helpFor("project", "cancel");
-    expect(cancel).toContain("--children <policy>");
-    expect(cancel).toContain("auto-cancel");
-    expect(cancel).toContain("H-PROJECT-COMPLETE-CHILDREN");
-    const reopen = helpFor("project", "reopen");
-    expect(reopen).toContain("--restore-children");
-    expect(reopen).toContain("stopDate window");
-    const restore = helpFor("project", "restore");
-    expect(restore).toContain("IN PLACE");
-    expect(restore).toContain("trashed project");
-  });
+describe("surface copy contract (docs/design/surface-copy.md)", () => {
+  // Rule 2: help text states behavior, never mechanism. Internals live in
+  // docs/ and in the capabilities OUTPUT — not in any --help string.
+  const BANNED = [
+    /\bH-[A-Z][A-Z-]+\b/, // hazard ids
+    /\b[A-Z]\d{2}[A-Z]?\b/, // probe-evidence ids (P16, E06, A24B, ...)
+    /vector:/, // "(vector: url-scheme, ...)" framing
+    /\btier \d\b/i,
+    /\bhazard/i,
+    /read-after-write/,
+    /\baudit\b/i,
+    /\b(?:unprobed|probed|unvalidated|validated)\b/i,
+    /\bsdef\b/,
+  ];
 
-  it("detach: one-step container removal documented on both move commands", () => {
-    expect(helpFor("todo", "move")).toContain("--detach");
-    expect(helpFor("project", "move")).toContain("--detach");
-    expect(helpFor("project", "move")).toContain("the only surface");
-  });
+  function allHelp(cmd: Command, path: string[]): [string, string][] {
+    const own: [string, string][] = [
+      [path.join(" ") || "(root)", cmd.helpInformation().replace(/\s+/g, " ")],
+    ];
+    return [...own, ...cmd.commands.flatMap((c) => allHelp(c, [...path, c.name()]))];
+  }
 
-  it("tag delete: subtree cascade hazard + ack flag", () => {
-    const help = helpFor("tag", "delete");
-    expect(help).toContain("H-TAG-SUBTREE-DELETE");
-    expect(help).toContain("--acknowledge-subtree");
-    expect(help).toContain("CHILD TAGS");
-  });
-
-  it("checklist: granular actions with preserved states", () => {
-    const help = helpFor("todo", "checklist");
-    expect(help).toContain("--check <title>");
-    expect(help).toContain("--uncheck <title>");
-    expect(help).toContain("--add <title>");
-    expect(help).toContain("--rename <title>");
-    expect(help).toContain("not stable");
-  });
-
-  it("project update: notes modes documented", () => {
-    const help = helpFor("project", "update");
-    expect(help).toContain("--append-notes");
-    expect(help).toContain("--prepend-notes");
-    expect(help).toContain("exclusive with --notes");
+  it("no --help string leaks internals", () => {
+    const program = buildProgram();
+    for (const [name, text] of allHelp(program as unknown as Command, [])) {
+      for (const pattern of BANNED) {
+        const match = text.match(pattern);
+        expect(match, `"${name}" leaks "${match?.[0] ?? ""}" (${pattern})`).toBeNull();
+      }
+    }
   });
 });


### PR DESCRIPTION
## What

The second half of Phase 20: the consumer-voice contract from [docs/design/surface-copy.md](../blob/main/docs/design/surface-copy.md) (PR #34) now governs the CLI and the exported library JSDoc, not just MCP.

- **Every write command's `--help`** rewritten to state behavior and side effects only. Hazard ids (`H-…`), probe-evidence ids (`P01`, `E06`, …), `(vector: url-scheme, tier 0)` framing, and "verified read-after-write"/audit mechanics are gone from help — replaced by what they *imply*: cascades ("canceling a project also cancels its open to-dos"), permanence ("areas do not go to the Trash, so this cannot be undone"), loud rejection of unknown references, and schedule side effects ("--inbox removes any schedule").
- **AGENT NOTES** keeps the exit-code and no-prompt contract, drops the pipeline/audit internals, and states the failure contract in behavior terms.
- **Exported JSDoc** (`ThingsClient`, operation param types, `Acknowledgements`) swept the same way; the probe citations remain in the write-layer internals (`commands.ts`, `guards.ts`), `docs/lab/`, and the `capabilities` output — which are the designated drill-down surfaces, unchanged.
- **doctor** now also names the one-time setup surface (macOS permissions, "Enable Things URLs") per the contract's onboarding rule.
- **Fixed stale copy**: undo's help still claimed project complete/delete are irreversible — they became reversible in 0.3.0.
- **Enforcement**: help-contract tests re-anchored on the new load-bearing statements (with new contracts for project cancel/reopen, tag subtree delete, area-delete orphaning, and todo move), plus a help-wide banned-vocabulary guardrail mirroring the MCP one — every command's rendered help is scanned recursively.

## Verification

`npm run check` green: 337 tests (28 help-contract tests incl. the new guardrail). No behavior changes — descriptions, JSDoc, and tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)