### PR TITLE
feat(cli): dual-mode bin launcher — dev checkouts run live TS source

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ things capabilities --op todo.delete   # what's possible, per vector, with evide
 
 Things 3 installed and launched once, Node ≥ 24, and a handful of one-time macOS consents / Things settings depending on what you use (file-access consent for reads; "Enable Things URLs" + Automation consents for writes). **See [docs/setup.md](docs/setup.md)** — including the dedicated-automation-Mac checklist. `things doctor` validates your setup and prints remediation for anything missing.
 
+### Development install
+
+To get a global `things` command that runs the live TypeScript source (no build step — Node ≥ 24 strips types natively):
+
+```sh
+npm link            # symlink this checkout as the global things-api package
+asdf reshim nodejs  # once, if you use asdf: expose the new `things` shim
+```
+
+Edits under `src/` take effect immediately. The bin launcher ([bin/things.js](bin/things.js)) prefers `src/` when present and falls back to `dist/`, so published installs (`npm i -g things-api`, `npx things-api`) run the compiled output with identical behavior.
+
 ## Core principles
 
 - **Reads** go directly to Things' local SQLite database (read-only, WAL-aware). **Writes** go exclusively through official app surfaces — URL scheme, AppleScript, Shortcuts — never direct DB writes (sync corruption).

--- a/bin/things.js
+++ b/bin/things.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env -S node --disable-warning=ExperimentalWarning
+// Dev checkouts (npm link) run live TS source via Node's type stripping;
+// published tarballs ship only dist + bin, so src is absent and dist is used.
+import { existsSync } from "node:fs";
+
+const src = new URL("../src/cli/main.ts", import.meta.url);
+const entry = existsSync(src) ? src : new URL("../dist/cli/main.js", import.meta.url);
+const { runCli } = await import(entry.href);
+runCli();

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "description": "Typed TypeScript library + CLI for Things 3 (Cultured Code) — verified writes, audit trail, schema-drift detection",
   "license": "UNLICENSED",
   "bin": {
-    "things": "./dist/cli/main.js"
+    "things": "./bin/things.js"
   },
   "files": [
+    "bin",
     "dist"
   ],
   "type": "module",

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -48,10 +48,19 @@ export function buildProgram(): Command {
   return program;
 }
 
+export function runCli(): void {
+  const program = buildProgram();
+  program.exitOverride((err) => {
+    process.exit(err.exitCode === 0 ? ExitCode.Ok : ExitCode.Usage);
+  });
+  program.parse();
+}
+
 // Direct-run detection must survive the npm .bin symlink (argv[1] ends with
 // "things", not "main.js") — resolve through realpath and compare to this
 // module. Caught by scripts/pack-smoke.sh: a name-suffix check made the
-// installed bin a silent no-op.
+// installed bin a silent no-op. The bin/things.js launcher bypasses this by
+// calling runCli() explicitly.
 const isDirectRun = ((): boolean => {
   const invoked = process.argv[1];
   if (invoked === undefined) return false;
@@ -62,9 +71,5 @@ const isDirectRun = ((): boolean => {
   }
 })();
 if (isDirectRun) {
-  const program = buildProgram();
-  program.exitOverride((err) => {
-    process.exit(err.exitCode === 0 ? ExitCode.Ok : ExitCode.Usage);
-  });
-  program.parse();
+  runCli();
 }


### PR DESCRIPTION
## Summary

Makes `npm link` yield a global `things` command that runs the **live TypeScript source** (Node ≥24 native type stripping, no build step), while keeping the published-package path (`npm i -g things-api` / `npx things-api`) on compiled JS with identical behavior.

- **`bin/things.js`** — new launcher: prefers `../src/cli/main.ts` when present (dev checkout via `npm link`; a stale `dist/` can never shadow source), falls back to `../dist/cli/main.js` (published tarballs ship no `src`). The shipped bin must stay JS because Node refuses to type-strip `.ts` under `node_modules`; linked checkouts escape that via realpath resolution.
- **`src/cli/main.ts`** — extract exported `runCli()` from the direct-run block; the realpath direct-run guard (correctly) rejects importing shims, so the launcher calls it explicitly.
- **`package.json`** — `bin` → `./bin/things.js`, `files` gains `bin`.
- **README** — dev-install note (`npm link` + `asdf reshim nodejs`).

## Verification

- `node bin/things.js --help` — launcher → src path ✅
- `npm link && asdf reshim nodejs`; `things --version` / `things capabilities --json` from an unrelated cwd ✅
- Live-edit probe: edited a help string in `src/cli/main.ts`, change appeared in `things --help` with no build ✅
- `npm run smoke:pack` GREEN — tarball ships `bin`+`dist` (no `src`), installed bin picks the `dist` branch ✅
- `npm run check` — typecheck, lint, fmt, 371 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)