### PR TITLE
chore(release): prepare for public npm publish under MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mike Greiling
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,8 @@
 {
   "name": "things-api",
   "version": "0.3.0",
-  "private": true,
   "description": "Typed TypeScript library + CLI for Things 3 (Cultured Code) — verified writes, audit trail, schema-drift detection",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "bin": {
     "things": "./bin/things.js"
   },


### PR DESCRIPTION
## Summary

Prepares `things-api` for its first public npm publish.

- Remove `"private": true` — the only thing blocking `npm publish`.
- License the project **MIT** (`license` field + `LICENSE` file). Chosen over Apache-2.0 for simplicity and ecosystem norms; permissive so the CLI/library is free to install, use, and contribute to.

No source changes.

## Verified

- `npm pack --dry-run` — tarball ships `README` + `LICENSE` + `bin/things.js` + `dist/**` only (181 files, no src/test/lab/docs).
- `npm run check` — typecheck, lint, fmt, 371 tests green (same gate `prepublishOnly` re-runs).
- `npm run smoke:pack` — packed tarball installs and the `things` bin works end-to-end.

## Publish (manual, after merge)

Registry auth is interactive, so publishing is done by hand from `main`:

```sh
npm login
npm publish   # prepublishOnly runs check + build automatically
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)