### PR TITLE
docs: living capability matrix (CRUD x vector wish-list) + repo CLAUDE.md maintenance contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# things-api — repo instructions
+
+## Living documents — keep them current (part of every change)
+
+- **[docs/capability-matrix.md](docs/capability-matrix.md)** — the CRUD × vector wish-list/checklist. Update it in the SAME change as: any operation-catalog edit (`src/write/operations.ts`), any vector-matrix edit, any new probe verdict, or any gap opened/closed.
+- **[docs/things-app-oddities.md](docs/things-app-oddities.md)** — the future Cultured Code bug report. Record every newly discovered app bug/quirk THE MOMENT it is found, with probe evidence.
+- **[docs/gaps.md](docs/gaps.md)** — roadmap: one entry per phase, updated when a phase lands.
+- **CHANGELOG.md** — every user-visible change goes under `## Unreleased`.
+
+## Safety rails (non-negotiable)
+
+- Production Things DB (this host): READS ONLY, and only via `scripts/prod-read.sh` (one stable command shape — ad-hoc shapes re-trigger macOS consent). NEVER write to production; never point new binary shapes at the prod container (even `doctor`).
+- Writes go exclusively through official app surfaces (URL scheme / AppleScript / Shortcuts) — never direct SQLite writes. All write probing happens in disposable Tart VMs (`docs/lab/`).
+
+## Conventions
+
+- Verify `npm run check` by EXIT CODE, never by grepping piped output. Run `npm run fmt` before committing (oxfmt also formats committed JSON).
+- Feature branches (`mg/<topic>`), PRs for the audit trail, self-merge after CI is fine.
+- All consumer-facing copy (CLI `--help`, MCP tool descriptions, exported JSDoc) follows [docs/design/surface-copy.md](docs/design/surface-copy.md) — behavior and side effects only; banned-vocabulary regression tests enforce it.
+- Guest e2e bundles ship node + dist + commander ONLY — heavyweight deps (MCP SDK, zod) must stay lazily imported from CLI actions.

--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -1,0 +1,117 @@
+# Capability matrix — CRUD across write surfaces
+
+**This is a LIVING DOCUMENT and the project's feature wish-list.** Update it in the same change as: any operation-catalog edit (`src/write/operations.ts`), any vector-matrix edit, any new probe verdict, or any gap opened/closed. Its sibling [things-app-oddities.md](things-app-oddities.md) (the future Cultured Code report) has the same contract: record every newly discovered app bug/quirk when it's found, not later. Both reminders also live in the repo `CLAUDE.md`.
+
+Every **read** is complete and vector-independent (direct SQLite): views, detail, tags/areas/projects, search, changes, repeat-rule decoding, occurrence projections. The one read caveat: **sidebar order** (areas, top-level projects) is provisional — AppleScript enumeration does not match the sidebar (P19), so `index`-based reads are best-effort. This matrix therefore tracks **writes**.
+
+Legend: ✅ shipped & lab-validated · 🟡 works with caveats · 🧪 plausible but unprobed (**wish list**) · 🚫 validated dead end (revisit per Things release) · ⛔ the app has no such concept · ➖ not applicable. Probe ids cite [docs/lab/](lab/harness.md) evidence; the authoritative op×vector data is `things capabilities`.
+
+The **Shortcuts** column is almost entirely 🧪: the S-campaign is blocked on the golden image's L5 sitting ([golden-runbook.md §5](lab/golden-runbook.md)).
+
+## To-dos
+
+| Capability | URL scheme | AppleScript | Shortcuts | Notes |
+|---|---|---|---|---|
+| Create | ✅ | ✅ | 🧪 | tags must pre-exist (app silently drops unknowns); reminder via `when=<list>@<time>` |
+| Update title/notes | ✅ (+append/prepend) | 🟡 partial | 🧪 | notes modes newline-joined (E04/E05) |
+| Schedule (today/evening/someday/date) | ✅ | 🟡 | 🧪 | 🚫 on repeating templates (crash — hard-blocked) |
+| Set reminder | ✅ today/evening/date | ⛔ no property | 🧪 | deterministic time emitter routes around the bare-hour parser trap (oddity 2d) |
+| Clear reminder | 🟡 today/evening only | ⛔ | 🧪 | dated reminders are STICKY (R20/R21, oddity 2e) — workaround: bounce via `when=today` first |
+| Set/clear deadline | ✅ | 🟡 | 🧪 | |
+| Complete / cancel / reopen | ✅ | ✅ | 🧪 | |
+| Move to project/area (+existing heading) | ✅ | 🟡 no heading | 🧪 | unknown destinations guarded (app is a silent no-op) |
+| Move to Inbox | 🚫 | ✅ | 🧪 | de-schedules (E06) |
+| Detach from ALL containers (keep schedule) | ✅ empty `list-id=` (P21/P22) | 🚫 (all nil spellings fail) | 🧪 | |
+| Tags: replace/clear | ✅ (empty set clears, P14) | ✅ `set tag names` | 🧪 | add/merge is a client-side read-merge-replace |
+| Checklist: wholesale replace | ✅ (destroys item state — ack required; empty clears, P15) | 🚫 no access (A30) | 🧪 | |
+| Checklist: granular + stateful edits | ✅ `things:///json` per-item `completed` (P18) | 🚫 | 🧪 | item uuids not stable across a rewrite; match by title |
+| Duplicate | ✅ `duplicate=true` | 🚫 refuses (−1717) | 🧪 | |
+| Delete (→ Trash) | 🚫 (tier-3 UI only) | ✅ | 🧪 | |
+| Restore from Trash | 🚫 | 🟡 → Inbox, de-scheduled (E15) | 🧪 | prior container/schedule not restored |
+| Permanently delete ONE item | 🧪 | 🧪 (`delete` on an already-trashed row?) | 🧪 | wish list — today only `trash.empty` (all-or-nothing) |
+| Convert to project | 🚫 (E16) | 🚫 | 🧪 | S-campaign candidate |
+
+## Projects
+
+| Capability | URL scheme | AppleScript | Shortcuts | Notes |
+|---|---|---|---|---|
+| Create (+area, +initial to-dos) | ✅ | ✅ | 🧪 | |
+| Create WITH headings (json payload) | 🧪 | ⛔ | 🧪 | queued small win, independent of Shortcuts (gaps roadmap item 5) |
+| Update title/notes/when/deadline | ✅ (+append/prepend, E18) | 🟡 | 🧪 | 🚫 schedule edits on repeating projects |
+| Set/clear reminder on a project | 🧪 (`when=@time` on update-project?) | ⛔ | 🧪 | wish list — unprobed |
+| Tags on a project | 🧪 (`update-project?tags=` / `set tag names of project`) | 🧪 | 🧪 | wish list — likely closeable, unprobed |
+| Complete (children policy) | ✅ cascades, policy mandatory | 🟡 cascade unvalidated | 🧪 | |
+| Cancel (children policy) | ✅ (P01) | 🚫 | 🧪 | completed children untouched |
+| Reopen (± restore cascade-resolved children) | ✅ (P02/P05; <2s window P03) | 🚫 | 🧪 | children resolved earlier never touched (P04) |
+| Move to area | ✅ (P23) | ✅ (E14) | 🧪 | |
+| Detach from area | ✅ empty `area-id=` (P24) — the ONLY surface | 🚫 (P08/P27) | 🧪 | |
+| Duplicate (incl. children) | ✅ (E17) | 🚫 | 🧪 | |
+| Delete (→ Trash) | 🚫 | ✅ shallow (children keep links) | 🧪 | |
+| Restore IN PLACE | 🚫 | ✅ (P06) | 🧪 | schedule/area/children intact |
+| Convert to to-do | 🚫 | 🚫 | 🧪 | |
+
+## Headings
+
+Doctrine: treat headings as nonexistent in the API surface (flatten) until the S-campaign settles their fate — documented in [gaps.md §0](gaps.md); dual-mode (first-class with Shortcuts, flattened otherwise) is the candidate shape.
+
+| Capability | URL scheme | AppleScript | Shortcuts | Notes |
+|---|---|---|---|---|
+| Place a to-do under an EXISTING heading | ✅ (add + move) | 🚫 | 🧪 | |
+| Create heading at project creation | 🧪 json payload | ⛔ | 🧪 | queued |
+| Create heading in an EXISTING project | 🚫 | 🚫 | 🧪 | **the S-campaign's primary target** |
+| Rename / move / delete a heading | 🚫 | 🚫 | 🧪 | |
+
+## Areas
+
+| Capability | URL scheme | AppleScript | Shortcuts | Notes |
+|---|---|---|---|---|
+| Create (+tags) | 🚫 | ✅ | 🧪 | |
+| Rename / replace tags | 🚫 | ✅ (E01) | 🧪 | empty-set tag clear on areas unprobed |
+| Delete | 🚫 | ✅ PERMANENT | 🧪 | no Trash for areas; to-dos → Trash, projects orphan to no-area (P20) |
+| Restore | ⛔ | ⛔ | ⛔ | deletion is permanent by app design |
+| Sidebar reorder | 🚫 | 🚫 (O13) | 🧪 | |
+
+## Tags
+
+| Capability | URL scheme | AppleScript | Shortcuts | Notes |
+|---|---|---|---|---|
+| Create (+parent) | 🚫 (no command exists) | ✅ | 🧪 | |
+| Rename | 🚫 | ✅ assignments survive (E02) | 🧪 | |
+| Nest under an existing tag | 🚫 | ✅ (E03) | 🧪 | |
+| Un-nest to root | 🚫 | ✅ property-delete form (P29) | 🧪 | the ONE spelling that works |
+| Set keyboard shortcut | 🚫 | ✅ (E10) | 🧪 | |
+| Clear keyboard shortcut | 🚫 | 🧪 `delete keyboard shortcut of tag` (P29 analog) | 🧪 | queued cheap probe |
+| Delete | 🚫 | ✅ PERMANENT, subtree cascades (P16 — ack flag) | 🧪 | |
+
+## Ordering
+
+| Scope | Status | Notes |
+|---|---|---|
+| Today | ✅ native (experimental gate) or bounce ≤10 | |
+| This Evening | ✅ bounce only | native silently de-evenings (O03) |
+| Project children (un-headed) | ✅ native (experimental) | headed children rejected (O06) |
+| Area members (to-dos OR projects) | ✅ native (experimental) | never mixed in one request (O14) |
+| Inbox | 🧪 | wish list — private command scope unprobed |
+| Checklist items | ✅ | granular move via stateful rewrite |
+| Sidebar: areas | 🚫 (O13) | |
+| Sidebar: top-level projects | 🚫 (P17) | reads provisional too (P19) |
+| Anytime/Someday aggregate views | ⛔ | no independent order — derived from container order |
+
+## Repeating items
+
+| Capability | URL scheme | AppleScript | Shortcuts | Notes |
+|---|---|---|---|---|
+| Create a repeating to-do/project | 🚫 (E13 disproven) | 🚫 (error 302) | 🚫 per docs (no repeat parameters in the actions) | re-verify empirically during the S-campaign; permanently UI-only until Cultured Code ships an API |
+| Edit / pause / resume a repeat rule | 🚫 | 🚫 | 🚫 per docs | `rt1_instanceCreationPaused` is DB-only today |
+| Skip / advance the next occurrence | 🧪 | 🧪 | 🧪 | wish list — likely dead, unprobed |
+| Complete a materialized occurrence | ✅ | ✅ | 🧪 | occurrences are normal to-dos |
+| Read rules + project occurrences | ✅ | ➖ | ➖ | decoded read-only; `upcoming --horizon` |
+| Schedule/deadline edits on templates | 🚫 hard-blocked | 🚫 | 🧪 | the URL write crashes Things (oddity §1) |
+
+## Trash & system
+
+| Capability | Status | Notes |
+|---|---|---|
+| Empty Trash (everything) | ✅ AppleScript, PERMANENT | requires the permanent acknowledgement |
+| Permanently delete one item | 🧪 | see To-dos |
+| Enable-Things-URLs introspection | 🧪 | Phase 21b probes: token↔setting lifecycle, disabled-write signature |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -2,6 +2,8 @@
 
 Living register of Things-app capabilities that are missing, thin, or janky in things-api, with evidence refs and the planned path (or the reason none exists). Assessed 2026-07-04, post-Phase-7, mid-Phase-8 (reorder in flight on `mg/phase8-reorder`).
 
+> The full CRUD × vector picture (everything that works, not just the gaps) lives in **[capability-matrix.md](capability-matrix.md)** — the living wish-list/checklist. Keep both current in the same change (see repo `CLAUDE.md`).
+
 ## Headline gaps
 
 ### 0. Headings doctrine (DECIDED 2026-07-06, implementation deferred)


### PR DESCRIPTION
New living document [docs/capability-matrix.md](../blob/mg/capability-matrix/docs/capability-matrix.md): the full CRUD × vector picture per resource type — shipped ✅, caveated 🟡, unprobed wish-list 🧪, validated dead ends 🚫, app non-concepts ⛔ — with probe-evidence ids. Serves as the forward wish-list/checklist Mike asked for.

Repo `CLAUDE.md` (new): maintenance contract making the matrix + docs/things-app-oddities.md updates part of every relevant change, plus the prod-safety rails and repo conventions.

Docs-only; gaps.md cross-links the matrix; repeating-via-Shortcuts marked dead-per-docs (re-verify during the S-campaign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)