### PR TITLE
L5 sitting prep: build cards + staged S-suite + assist scripts

### DIFF
--- a/docs/lab/l5-build-cards.md
+++ b/docs/lab/l5-build-cards.md
@@ -1,0 +1,72 @@
+# L5 sitting — build cards
+
+Step-by-step cards for the resumed L5 sitting ([golden-runbook §5](golden-runbook.md)): ~30–45 min of Mike driving the **golden** VM GUI. Everything here was pre-written so the sitting needs zero doc-spelunking. **Scheduling forcer: the golden's trial window closes ~2026-07-18 — if the sitting slips past it, the golden rebuild runbook comes first.**
+
+State going in (from the 2026-07-03 sitting): §5.1 is DONE (Shortcuts first-run + Allow Running Scripts). All four proxies exist in **draft** state with picker-bound/static entity fields. The three mutation proxies need **restructuring to Find→act chains** — the Items/Project fields are app-entity parameters and never take raw string variables; only a `Find Items` action's output binds into them.
+
+## Card 0 — boot + connect (host terminal, ~3 min)
+
+```sh
+source lab/scripts/env.sh          # sets TART_HOME
+tart run things-lab-golden-v1 &    # windowed, or --no-graphics + Screen Sharing
+IP=$(tart ip things-lab-golden-v1) # retry until it answers
+```
+
+- **Airgap + pin BEFORE any app launches**: `lab/scripts/vmssh` (or the runbook §1 alias) → `sudo route -n delete default; sudo systemsetup -setusingnetworktime off; sudo date 070512002026`.
+- Connect: Screen Sharing → `vnc://$IP`, admin/admin (or use the Tart window).
+- Sanity: Shortcuts → Settings → Advanced → **Allow Running Scripts** still checked.
+
+## Card 1 — restructure `things-proxy-create-heading` (~8 min)
+
+Input contract: `{"title": …, "project": …}`. Open the draft in the Shortcuts editor; target state, actions in order:
+
+1. **Get Dictionary from** *Shortcut Input* (should already exist).
+2. **Find Items** (Things): click *Show More* → **Type = Project**; filter **Name** *is* → insert the dictionary value for key `project` (Get Value for Key); **Limit 1**.
+3. **Create Heading**: **Title** ← dictionary value for key `title`; **Project** ← step 2's output ("Items" magic variable) via the Gesture Appendix below — this is the field that must STOP being picker-bound.
+4. Ensure the last action's result is the shortcut output (add **Stop and Output** if the editor demands an explicit one).
+
+While the Find Items filter list is open: **note whether ID is offered as a filter field** (upgrades addressing from name to uuid in a v2). Don't switch to it this sitting — the staged S-suite addresses by name.
+
+## Card 2 — restructure `things-proxy-edit-title` (~5 min)
+
+Input contract: `{"find": …, "title": …}`.
+
+1. **Get Dictionary from** *Shortcut Input*.
+2. **Find Items**: **Name** *is* ← dictionary `find`, **Limit 1** (no Type filter — it must find headings too; if the filter UI *forces* a type, note what types exist — a Heading type here is itself a finding).
+3. **Set Title of** ← step 2's output **to** ← dictionary `title`.
+4. Output the result.
+
+## Card 3 — restructure `things-proxy-delete-items` (~5 min)
+
+Input contract: `{"find": …}`.
+
+1. **Get Dictionary from** *Shortcut Input*.
+2. **Find Items**: **Name** *is* ← dictionary `find`, **Limit 1**.
+3. **Delete** ← step 2's output. **Leave any "immediately delete" toggle OFF** (Trash, not hard delete — but note the toggle's existence/wording: a Shortcuts hard-delete would close the permanent-delete wish-list gap).
+4. Output the result.
+
+## Card 4 — verify `things-proxy-find-items` (~2 min)
+
+Built ✓ on 2026-07-03 (`{"search": …}` bound, no filters/sort). Just open it and confirm the binding survived; the S-campaign inspects its structured output for identifiers.
+
+**Abort criterion (from §5.2):** if even Find-chained output refuses to bind into an entity field, stop restructuring — that finding means parameterized proxies are infeasible; headings stay UI-only, and the campaign shrinks to the read probe.
+
+## Card 5 — action-catalog observation sweep (~5 min, high value)
+
+With Shortcuts open anyway: add a scratch shortcut, insert each Things action once, expand *Show More*, and note (screenshots welcome — they land in session notes) the full parameter list of: **Add To-Do**, **Add Project**, **Edit** (whatever edit actions exist), **Create Heading**, **Find Items**, and anything unexpected. Specifically hunting: repeat parameters (documented absent — confirm), tags fields, reminder fields, attachment/convert/move actions, heading rename/move/delete verbs. Delete the scratch shortcut afterwards. This scopes the S-campaign beyond the four proxies.
+
+## Card 6 — consent absorption (§5.3, scripted + Allow clicks, ~5 min)
+
+Run each proxy once over SSH so macOS's per-shortcut consents fire; click **Allow** on each prompt in Screen Sharing. Driver: `lab/scripts/l5-consent-absorb.sh` (creates a sacrificial `L5-CONSENT-PROJ`, runs all four proxies against it, trashes it, exports signed `.shortcut` copies to `lab/shortcuts/`). Residue: one trashed project — recorded in metadata; probe assertions tolerate it.
+
+## Card 7 — freeze (§5.4, scripted, ~3 min)
+
+`lab/scripts/l5-freeze.sh`: quits Shortcuts + Things, verifies `shortcuts list` shows all four proxies, truncates `~/things-lab/events.ndjson`, reminds which `golden-v1-metadata.json` fields to update (`humanLayersDone` += L5, consent residue note), and stops the VM. Golden is never booted again — the S-campaign runs in clones.
+
+## Gesture Appendix — binding a magic variable into an entity field (§5.2a)
+
+First gesture that works, use everywhere:
+
+1. Click the field → look at the very top of the popover, above the entity list (empty row = variable slot); scroll up for a "Select Variable" entry.
+2. Right-click (ctrl-click) the blue field chip → "Select Variable" / "Insert Variable".
+3. Click the Find Items action so its result token is visible, then drag the "Items" pill onto the entity field below.

--- a/lab/scripts/l5-consent-absorb.sh
+++ b/lab/scripts/l5-consent-absorb.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# L5 §5.3 — consent absorption + signed export (scripted assist for the sitting).
+#
+# Runs AGAINST THE GOLDEN (things-lab-golden-v1) during the L5 sitting, AFTER
+# Mike has restructured the four proxies (l5-build-cards.md Cards 1–4). Runs
+# each proxy once so macOS's per-shortcut consent prompts fire — Mike clicks
+# **Allow** on each in Screen Sharing — then exports signed copies to
+# lab/shortcuts/ for the repo audit trail.
+#
+# Sacrificial fixtures: creates L5-CONSENT-PROJ, exercises every proxy against
+# it, trashes it afterwards (residue: one trashed project — recorded in
+# metadata; probe assertions tolerate it).
+#
+# NOTE: this touches the GOLDEN, so it is a sanctioned-sitting operation only.
+# Never run it outside an L5 sitting. It does NOT freeze the image — run
+# l5-freeze.sh after.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+source lab/scripts/env.sh
+
+GOLDEN="things-lab-golden-v1"
+IP=$(tart ip "$GOLDEN" 2>/dev/null) || { echo "golden not running — boot it first (l5-build-cards.md Card 0)" >&2; exit 1; }
+mkdir -p lab/shortcuts
+
+echo "[l5-consent] golden at $IP"
+echo "[l5-consent] verifying the four proxies exist…"
+LIST=$(lab_ssh "$IP" 'shortcuts list 2>/dev/null')
+echo "$LIST"
+for s in things-proxy-create-heading things-proxy-edit-title things-proxy-delete-items things-proxy-find-items; do
+  echo "$LIST" | grep -qx "$s" || { echo "[l5-consent] MISSING proxy: $s — finish Cards 1–4 first" >&2; exit 1; }
+done
+
+echo "[l5-consent] creating sacrificial L5-CONSENT-PROJ…"
+lab_ssh "$IP" "open -g 'things:///add-project?title=L5-CONSENT-PROJ'"
+sleep 3
+
+run_proxy() { # run_proxy <name> <json-input>
+  echo "[l5-consent] >>> running $1  (CLICK: Allow the consent prompt in Screen Sharing)"
+  lab_ssh "$IP" "shortcuts run $(printf '%q' "$1") -i $(printf '%q' "$2")" 2>&1 || true
+  sleep 3
+}
+
+# One run per proxy absorbs its consent. Inputs are harmless against the
+# sacrificial project (heading created, titled, then the project trashed).
+run_proxy things-proxy-find-items    '{"search":"L5-CONSENT-PROJ"}'
+run_proxy things-proxy-create-heading '{"title":"L5-CONSENT-HEAD","project":"L5-CONSENT-PROJ"}'
+run_proxy things-proxy-edit-title     '{"find":"L5-CONSENT-HEAD","title":"L5-CONSENT-HEAD-RN"}'
+run_proxy things-proxy-delete-items   '{"find":"L5-CONSENT-HEAD-RN"}'
+
+echo "[l5-consent] trashing the sacrificial project…"
+lab_ssh "$IP" 'osascript -e "tell application \"Things3\" to delete project \"L5-CONSENT-PROJ\""' 2>&1 || true
+sleep 2
+
+echo "[l5-consent] exporting signed proxy copies -> lab/shortcuts/"
+for s in things-proxy-create-heading things-proxy-edit-title things-proxy-delete-items things-proxy-find-items; do
+  # `shortcuts export` requires GUI context; run it and pull the file. If the
+  # CLI export is unavailable on this macOS, fall back to a manual File >
+  # Export note (recorded, not fatal).
+  if lab_ssh "$IP" "shortcuts export $(printf '%q' "$s") -o /tmp/$s.shortcut" 2>/dev/null; then
+    lab_scp "$LAB_SSH_USER@$IP:/tmp/$s.shortcut" "lab/shortcuts/$s.shortcut" && echo "  exported $s.shortcut"
+  else
+    echo "  [warn] CLI export unavailable for $s — export manually via Shortcuts File > Export and drop into lab/shortcuts/"
+  fi
+done
+
+echo "[l5-consent] DONE. Verify consent stuck by re-running one proxy WITHOUT a prompt, then run l5-freeze.sh."

--- a/lab/scripts/l5-freeze.sh
+++ b/lab/scripts/l5-freeze.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# L5 §5.4 — freeze checklist (scripted assist).
+#
+# Runs AGAINST THE GOLDEN (things-lab-golden-v1) at the END of the L5 sitting,
+# after l5-consent-absorb.sh. Quits Shortcuts + Things, verifies the four
+# proxies are present, truncates the seeding-session monitor noise, prints the
+# metadata edits to make by hand, and stops the VM. Golden is never booted
+# again — the S-campaign clones it.
+#
+# It does NOT edit golden-v1-metadata.json itself (that file is the human-
+# owned image ledger); it prints the exact diff to apply.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+source lab/scripts/env.sh
+
+GOLDEN="things-lab-golden-v1"
+IP=$(tart ip "$GOLDEN" 2>/dev/null) || { echo "golden not running" >&2; exit 1; }
+
+echo "[l5-freeze] quitting Shortcuts + Things…"
+lab_ssh "$IP" 'osascript -e "tell application \"Shortcuts\" to quit"' 2>&1 || true
+lab_ssh "$IP" 'osascript -e "tell application \"Things3\" to quit"' 2>&1 || true
+sleep 3
+
+echo "[l5-freeze] verifying the four proxies survive…"
+LIST=$(lab_ssh "$IP" 'shortcuts list 2>/dev/null')
+OK=1
+for s in things-proxy-create-heading things-proxy-edit-title things-proxy-delete-items things-proxy-find-items; do
+  if echo "$LIST" | grep -qx "$s"; then echo "  ok: $s"; else echo "  MISSING: $s"; OK=0; fi
+done
+[ "$OK" = 1 ] || { echo "[l5-freeze] refusing to freeze — a proxy is missing" >&2; exit 1; }
+
+echo "[l5-freeze] truncating ~/things-lab/events.ndjson (seeding-session noise)…"
+lab_ssh "$IP" ': > ~/things-lab/events.ndjson' 2>&1 || true
+
+echo
+echo "[l5-freeze] ===== APPLY THESE METADATA EDITS BY HAND (docs/lab/golden-v1-metadata.json) ====="
+cat <<'META'
+  - humanLayersDone: append "L5-shortcuts"
+  - deferred: remove the "L5: Shortcuts first-run…" entry
+  - l5Progress: set sittingCompleted: "<today>", clear "remaining", record
+      whether Find Items offered an ID filter (Card 1/2 observation) and any
+      Card 5 action-catalog findings (repeat params, tags/reminder fields,
+      convert/move actions, hard-delete toggle wording)
+  - add: consentResidue: "one trashed L5-CONSENT-PROJ (probe assertions tolerate)"
+  - exported proxies: lab/shortcuts/*.shortcut (git add)
+META
+echo "[l5-freeze] ================================================================================"
+echo
+echo "[l5-freeze] stopping the golden VM…"
+tart stop "$GOLDEN" >/dev/null 2>&1 || true
+echo "[l5-freeze] DONE. Golden frozen. Next: enable s-suite in lab/scripts/regress.sh and run lab:regress in a clone."

--- a/lab/suites/s-suite.json
+++ b/lab/suites/s-suite.json
@@ -1,0 +1,187 @@
+{
+  "suite": "s",
+  "description": "STAGED / NOT YET RUNNABLE — the Shortcuts campaign. Blocked on the L5 golden sitting (docs/lab/golden-runbook.md §5 + docs/lab/l5-build-cards.md): the four proxy shortcuts (things-proxy-create-heading, -edit-title, -delete-items, -find-items) must exist in the golden before these probes resolve. Vector `shortcuts` runs via `exec` calling `shortcuts run <proxy> -i <json>` (Apple exposes no in-suite Shortcuts step; runtime execution is fully scriptable once the proxies are built). Primary target: the heading lifecycle in EXISTING projects — the one gap only Shortcuts fills (gaps.md §1 + §0 headings doctrine). Expectations below are DISCOVERY GUESSES until the first post-L5 run locks them; each probe self-creates its fixtures so seeds stay pristine. Ordered: read probe first (lowest risk, no mutation), then heading create/rename/delete, then the re-verify sweep (to-do<->project conversion, repeat params, project tags/reminders via Shortcuts).",
+  "probes": [
+    {
+      "id": "S01",
+      "title": "READ probe: what identifiers does things-proxy-find-items structured output carry? (uuid? name only?) — lowest-risk proxy, no mutation",
+      "vector": "shortcuts",
+      "operation": "shortcuts.find",
+      "appState": "running-background",
+      "setup": [
+        { "openUrl": "things:///add?title=S01-FINDME&notes=s-suite-read-probe" },
+        { "waitSql": "SELECT uuid FROM TMTask WHERE title='S01-FINDME'" }
+      ],
+      "commands": [
+        {
+          "exec": [
+            "shortcuts",
+            "run",
+            "things-proxy-find-items",
+            "-i",
+            "{\"search\":\"S01-FINDME\"}",
+            "-o",
+            "/tmp/s01-out.txt"
+          ]
+        },
+        { "exec": ["cat", "/tmp/s01-out.txt"] }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [{ "kind": "stdoutMatches", "command": 1, "pattern": "S01-FINDME" }]
+      }
+    },
+    {
+      "id": "S02",
+      "title": "HEADING CREATE in an existing project via things-proxy-create-heading — THE primary S-campaign target (URL/AppleScript both dead, gaps.md §1)",
+      "vector": "shortcuts",
+      "operation": "heading.add",
+      "appState": "running-background",
+      "setup": [
+        { "openUrl": "things:///add-project?title=S02-PROJ" },
+        { "waitSql": "SELECT uuid FROM TMTask WHERE title='S02-PROJ' AND type=1" }
+      ],
+      "commands": [
+        {
+          "exec": [
+            "shortcuts",
+            "run",
+            "things-proxy-create-heading",
+            "-i",
+            "{\"title\":\"S02-HEAD\",\"project\":\"S02-PROJ\"}"
+          ]
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='S02-HEAD' AND type=2",
+          "timeoutSeconds": 15
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          { "kind": "inserted", "table": "TMTask", "where": { "title": "S02-HEAD", "type": 2 } }
+        ]
+      }
+    },
+    {
+      "id": "S03",
+      "title": "HEADING RENAME via things-proxy-edit-title (Set Title of a heading entity)",
+      "vector": "shortcuts",
+      "operation": "heading.rename",
+      "appState": "running-background",
+      "setup": [
+        { "openUrl": "things:///add-project?title=S03-PROJ" },
+        { "waitSql": "SELECT uuid FROM TMTask WHERE title='S03-PROJ' AND type=1" },
+        {
+          "exec": [
+            "shortcuts",
+            "run",
+            "things-proxy-create-heading",
+            "-i",
+            "{\"title\":\"S03-HEAD\",\"project\":\"S03-PROJ\"}"
+          ]
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='S03-HEAD' AND type=2",
+          "timeoutSeconds": 15
+        }
+      ],
+      "commands": [
+        {
+          "exec": [
+            "shortcuts",
+            "run",
+            "things-proxy-edit-title",
+            "-i",
+            "{\"find\":\"S03-HEAD\",\"title\":\"S03-HEAD-RN\"}"
+          ]
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='S03-HEAD-RN' AND type=2",
+          "timeoutSeconds": 15
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "rowExists",
+            "table": "TMTask",
+            "where": { "title": "S03-HEAD-RN", "type": 2 }
+          },
+          { "kind": "rowAbsent", "table": "TMTask", "where": { "title": "S03-HEAD", "type": 2 } }
+        ]
+      }
+    },
+    {
+      "id": "S04",
+      "title": "HEADING DELETE via things-proxy-delete-items (Trash, immediately-delete toggle OFF)",
+      "vector": "shortcuts",
+      "operation": "heading.delete",
+      "appState": "running-background",
+      "setup": [
+        { "openUrl": "things:///add-project?title=S04-PROJ" },
+        { "waitSql": "SELECT uuid FROM TMTask WHERE title='S04-PROJ' AND type=1" },
+        {
+          "exec": [
+            "shortcuts",
+            "run",
+            "things-proxy-create-heading",
+            "-i",
+            "{\"title\":\"S04-HEAD\",\"project\":\"S04-PROJ\"}"
+          ]
+        },
+        {
+          "waitSql": "SELECT uuid FROM TMTask WHERE title='S04-HEAD' AND type=2",
+          "timeoutSeconds": 15
+        }
+      ],
+      "commands": [
+        {
+          "exec": ["shortcuts", "run", "things-proxy-delete-items", "-i", "{\"find\":\"S04-HEAD\"}"]
+        },
+        {
+          "waitSql": "SELECT 1 FROM TMTask WHERE title='S04-HEAD' AND trashed=1",
+          "timeoutSeconds": 15
+        }
+      ],
+      "expect": {
+        "verdict": "supported",
+        "tier": 0,
+        "assertions": [
+          {
+            "kind": "fieldEquals",
+            "table": "TMTask",
+            "where": { "title": "S04-HEAD" },
+            "field": "trashed",
+            "value": 1
+          }
+        ]
+      }
+    },
+    {
+      "id": "S05",
+      "title": "RE-VERIFY (Shortcuts): to-do -> project conversion. AppleScript/URL both dead (E16). Does a Shortcuts action expose it? DISCOVERY — likely unsupported.",
+      "vector": "shortcuts",
+      "operation": "todo.convertToProject",
+      "appState": "running-background",
+      "setup": [
+        { "openUrl": "things:///add?title=S05-TODO" },
+        { "waitSql": "SELECT uuid FROM TMTask WHERE title='S05-TODO' AND type=0" }
+      ],
+      "commands": [
+        {
+          "note": "PLACEHOLDER — no proxy exists for convert; the L5 Card 5 action-catalog sweep decides whether a convert action exists at all. If it does, add a things-proxy-convert and wire it here."
+        }
+      ],
+      "expect": {
+        "verdict": "unsupported",
+        "tier": 0,
+        "assertions": []
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Pre-stages everything the resumed L5 golden sitting needs so it requires zero doc-spelunking and can run before the golden trial closes (~2026-07-18). No `src` changes — docs + lab scaffolding only. The S-suite is **staged, not yet runnable** (blocked on the sitting building the four proxies).

## Contents

- **`docs/lab/l5-build-cards.md`** — step-by-step cards to restructure the four draft proxies into Find→act chains (Cards 1–4), an action-catalog observation sweep (Card 5), plus the gesture appendix for binding a magic variable into an entity field. Picks up from the 2026-07-03 sitting state recorded in `golden-v1-metadata.json`.
- **`lab/suites/s-suite.json`** — the Shortcuts campaign suite (STAGED): S01 read probe + S02–S04 heading create/rename/delete (the primary target only Shortcuts fills) + S05 convert re-verify placeholder. Vector `shortcuts` runs via `exec` calling `shortcuts run <proxy>`.
- **`lab/scripts/l5-consent-absorb.sh`** — §5.3 assist: runs each proxy once so per-shortcut consents fire (Mike clicks Allow), trashes the sacrificial project, exports signed copies to `lab/shortcuts/`.
- **`lab/scripts/l5-freeze.sh`** — §5.4 assist: verifies the four proxies survive, wipes monitor noise, prints the exact `golden-v1-metadata.json` edits, stops the golden.

## Scheduling

The golden's trial window closes ~2026-07-18. If the sitting slips past it, the golden rebuild runbook comes first — so the sitting date is the forcer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)