### PR TITLE
docs(lab): durable probe backlog + S-campaign follow-up script

### DIFF
--- a/docs/lab/probe-backlog.md
+++ b/docs/lab/probe-backlog.md
@@ -1,0 +1,36 @@
+# Probe backlog & in-flight validation plan
+
+Durable plan (survives context compaction). Written 2026-07-09 after the L5 sitting. Tracks (A) the autonomous S-campaign follow-up probes, (B) the PR #42 ops validation, and (C) parked work. Update the "STATUS" lines as each lands.
+
+## ⟹ RESUME HERE (post-compaction execution order)
+
+Mike compacts the context, THEN this runs. Nothing is running now (no VMs). Do, in order:
+
+1. **Bank §A results.** The probe run in `lab/scripts/research-scampaign-followups.sh` ALREADY RAN — raw evidence is on disk at `lab/artifacts/things-run-scf-20260709-041543/report.txt` (+ `final.sqlite`). NOT yet analyzed or banked. Read it, extract the P1–P4 verdicts (heading reorder / set-detail Parent / Reminder on scheduled + dated-clear / Completion+Creation backdating), and fold them into `docs/lab/s-campaign-results.md`, `docs/capability-matrix.md`, and `docs/things-app-oddities.md` (per the CLAUDE.md living-doc contract). Commit on a branch → PR → merge.
+2. **Validate PR #42** (§B). Decided approach: run `npm run lab:regress` as a NO-REGRESSION check (it exercises the reorder pipeline/guards/pre-state I changed + the guest e2e). Hand-authoring new recurring suite probes was deferred — unattended, a malformed ordering-assertion would block the merge on 40-min iterations, and the four ops are already validated by the A1–A6 real-app probes + 382 unit/engine tests. If regress is double-green → merge PR #42 (`mg/phase21b-ops`, currently OPEN). If it fails, diagnose (that's the check working).
+3. Optionally then author careful recurring suite probes (§B step 1) with an iteration budget, and pick up §C.
+
+Everything below is the detailed spec. `git log` on `main`: #40/#41/#43 merged; #42 open (ops, awaiting this regress).
+
+## A. S-campaign autonomous follow-up probes — `lab/scripts/research-scampaign-followups.sh`
+
+Run in ONE disposable clone (golden `things-lab-golden-v1`, stopped/frozen 2026-07-09; clones inherit the Shortcuts output-class Always-Allow grants, so `set-detail`/`find-items`/`create-heading` run headless — deadline-wrap every `shortcuts run` so a consent-didn't-transfer surprise can't wedge). All four are autonomous (no human click). Evidence → `docs/lab/s-campaign-results.md` + capability-matrix/oddities.
+
+- **P1 — heading reorder via the private command (Mike's sharp question).** The `_private_experimental_ reorder to dos in project id <P>` command is misleadingly named — it accepts PROJECT uuids in an area scope (O14, class inheritance). Untested: does it accept HEADING uuids (type=2) as project children? Use seed `LAB-PROJ-HEADINGS` (Dwr1MiANqMFvAWddgGgzVX) with headings Alpha (5saDdJcodvWARN9Ct2nQsT) + Beta (M7QEqPbk6v9jZZ6CBiyaP3). Reorder `with ids "<Beta>,<Alpha>"`; compare the headings' `"index"` before/after. Outcome ∈ {reorders them (heading ordering UNLOCKS — correct the "unautomatable" claim), errors (heading ∉ `to do` class), no-op}. STATUS: pending.
+- **P2 — `set-detail` Parent = move a heading to another project.** create-heading (headless) makes a heading in project A; `set-detail {id:<heading>, detail:"Parent", value:<project B uuid>}`; check `TMTask.project` of the heading. Also try it on a to-do (re-parent between projects). STATUS: pending.
+- **P3 — `set-detail` Reminder Time on a SCHEDULED item + clear a DATED reminder.** (a) to-do `when=today`, set-detail Reminder Time "14:30" → expect `reminderTime=970981376`. (b) to-do with a DATED reminder (`when=2026-07-10@09:00` via URL), then set-detail Reminder Time to ""/clear → does it CLEAR? (the sticky-dated-reminder gap, oddity 2e — the one thing URL can't do). STATUS: pending.
+- **P4 — Completion Date / Creation Date backdating.** Complete a to-do, `set-detail {detail:"Completion Date", value:<past ISO>}` → check `stopDate`. `set-detail {detail:"Creation Date", value:<past ISO>}` → check `creationDate`. No other surface writes these (GTD migration use case). STATUS: pending.
+- **P5 (NEEDS A HUMAN CLICK — not in this script)** — delete a NON-empty heading: do the children re-parent to the project root (expected), orphan, or cascade-delete? Delete-class consent re-prompts every run (oddity 5j), so this waits for a human. STATUS: parked.
+
+## B. PR #42 validation (project tags/reminders, tag-shortcut clear, inbox reorder)
+
+1. Recurring regression probes added to the suites (encode the A1–A6 deltas): e-suite (project tags URL+AS, project reminder, tag shortcut CLEAR) + o-suite (inbox reorder). STATUS: pending.
+2. `npm run lab:regress` (7 suites + guest e2e, ~40 min) — proves no regression AND the new probes pass. STATUS: pending.
+3. On double-green → merge PR #42. STATUS: pending.
+
+## C. Parked (bigger, not auto-runnable now) — task #7
+
+- Lab runner/DSL **Shortcuts vector** support (write JSON input to a guest file + `shortcuts run --input-path`; interactive delete-class handling) so `s-suite.json` becomes a real recurring suite.
+- **Distribution/onboarding**: produce signed / iCloud-shareable proxies from a network Mac with an Apple ID; a `things setup shortcuts` import + first-run-consent flow. (Golden is airgapped + Apple-ID-less, so it can only make unsigned copies.)
+- **Headings doctrine decision** (gaps §0): flatten-only vs dual-mode, now that Shortcuts delivers the lifecycle.
+- **Availability layer** (Phase 21b remainder): advisory `availability(env)` per vector; doctor reads `uriSchemeEnabled`; correct the `feature-disabled` classifier to key on `uriSchemeEnabled`, not a null token.

--- a/lab/scripts/research-scampaign-followups.sh
+++ b/lab/scripts/research-scampaign-followups.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# S-campaign autonomous follow-ups (docs/lab/probe-backlog.md §A). ONE clone.
+# P1 heading reorder via the private command; P2 set-detail Parent (heading
+# move); P3 set-detail Reminder on a scheduled item + dated-reminder clear;
+# P4 Completion/Creation date backdating. All autonomous — Shortcuts
+# output-class consent is inherited from the golden (deadline-wrapped so a
+# consent-didn't-transfer surprise can't wedge). Discovery: no assertions.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+source lab/scripts/env.sh
+
+VM="things-run-scf-$(date +%Y%m%d-%H%M%S)"
+OUT="lab/artifacts/$VM"; mkdir -p "$OUT"
+REPORT="$OUT/report.txt"
+note() { echo "[scf] $*" | tee -a "$REPORT"; }
+cleanup() { echo "[scf] teardown: $VM"; tart stop "$VM" >/dev/null 2>&1 || true; tart delete "$VM" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+# Seed uuids (from seed-manifest.json).
+PROJ_HEADINGS="Dwr1MiANqMFvAWddgGgzVX"
+ALPHA="5saDdJcodvWARN9Ct2nQsT"
+BETA="M7QEqPbk6v9jZZ6CBiyaP3"
+PROJ_PLAIN="933TCvzMgM3MLvpKPcjheC"
+
+note "cloning golden -> $VM"
+tart clone things-lab-golden-v1 "$VM"
+(tart run "$VM" --no-graphics >"$OUT/tart-run.log" 2>&1 &)
+IP=$(lab_wait_for_ssh "$VM" 300)
+note "ssh up at $IP"
+lab_ssh "$IP" 'sudo route -n delete default >/dev/null 2>&1 || true'
+lab_ssh "$IP" 'ping -c1 -t2 1.1.1.1 >/dev/null 2>&1 && exit 1 || exit 0'
+lab_ssh "$IP" 'sudo systemsetup -setusingnetworktime off >/dev/null 2>&1; sudo date 070512002026 >/dev/null'
+lab_ssh "$IP" 'cat > /tmp/gsql.sh && chmod +x /tmp/gsql.sh' <<'EOF'
+#!/bin/bash
+FMT=(-header -column); if [ "$1" = "-q" ]; then FMT=(-noheader -list); shift; fi
+DB=$(echo ~/Library/Group\ Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-*/Things\ Database.thingsdatabase/main.sqlite)
+exec sqlite3 "${FMT[@]}" "file:$DB?mode=ro" "$1"
+EOF
+gsql() { lab_ssh "$IP" "/tmp/gsql.sh $(printf '%q' "$1")"; }
+gq() { lab_ssh "$IP" "/tmp/gsql.sh -q $(printf '%q' "$1")"; }
+gas() { lab_ssh "$IP" "osascript -e $(printf '%q' "$1") 2>&1" || true; }
+gurl() { lab_ssh "$IP" "open -g $(printf '%q' "$1")"; sleep 2; }
+proxy() { # proxy <name> <json>  (deadline-wrapped; headless if consent inherited)
+  note "-- shortcuts run $1  $2"
+  lab_ssh "$IP" "printf '%s' $(printf '%q' "$2") > /tmp/scf-in.json; perl -e 'alarm 60; exec @ARGV' shortcuts run $(printf '%q' "$1") --input-path /tmp/scf-in.json --output-path /tmp/scf-out.txt 2>&1; echo \"[exit \$?]\"; cat /tmp/scf-out.txt 2>/dev/null; echo" 2>&1 | tee -a "$REPORT" || true
+  sleep 1
+}
+uuid_of() { local t="$1" typ="${2:-}" w="title='$1' AND trashed=0" u i; [ -n "$typ" ] && w="$w AND type=$typ"; for i in $(seq 1 12); do u=$(gq "SELECT uuid FROM TMTask WHERE $w ORDER BY creationDate DESC LIMIT 1"); [ -n "$u" ] && { echo "$u"; return 0; }; sleep 1; done; return 1; }
+
+note "warm-up: launch Things, quit, relaunch"
+lab_ssh "$IP" 'open -g -a Things3; sleep 12'
+lab_ssh "$IP" 'osascript -e "tell application \"Things3\" to quit"; sleep 3'
+lab_ssh "$IP" 'open -g -a Things3; sleep 8'
+
+note "sanity: is Shortcuts output-class consent inherited by the clone? (find-items should be headless)"
+proxy things-proxy-find-items '{"search":"LAB-PROJ-PLAIN"}'
+
+# ------------------------------------------------- P1 heading reorder (native)
+note "== [P1] heading reorder via the private command (heading uuids as project children) =="
+note "-- pre: heading index order in LAB-PROJ-HEADINGS:"
+gsql "SELECT uuid, title, type, \"index\" FROM TMTask WHERE project='$PROJ_HEADINGS' AND type=2 ORDER BY \"index\"" | tee -a "$REPORT"
+note "-- attempt: reorder to dos in project id with ids Beta,Alpha:"
+gas "tell application \"Things3\" to _private_experimental_ reorder to dos in project id \"$PROJ_HEADINGS\" with ids \"$BETA,$ALPHA\"" | tee -a "$REPORT"
+sleep 2
+note "-- post: heading index order (did Beta move above Alpha?):"
+gsql "SELECT uuid, title, type, \"index\" FROM TMTask WHERE project='$PROJ_HEADINGS' AND type=2 ORDER BY \"index\"" | tee -a "$REPORT"
+note "-- also confirm the headings' CHILDREN weren't ripped out (heading FK intact):"
+gsql "SELECT title, heading FROM TMTask WHERE project IS NULL AND heading IN ('$ALPHA','$BETA') ORDER BY heading" | tee -a "$REPORT"
+
+# --------------------------------------------- P2 set-detail Parent (heading move)
+note "== [P2] set-detail Parent: move a heading to another project =="
+proxy things-proxy-create-heading "{\"title\":\"SCF-HEAD-MV\",\"project\":\"$PROJ_HEADINGS\"}"
+HMV=$(uuid_of "SCF-HEAD-MV" 2 || true)
+note "-- created heading: ${HMV:-<none>} (pre project should be $PROJ_HEADINGS)"
+gsql "SELECT uuid, title, type, project FROM TMTask WHERE title='SCF-HEAD-MV'" | tee -a "$REPORT"
+if [ -n "${HMV:-}" ]; then
+  proxy things-proxy-set-detail "{\"id\":\"$HMV\",\"detail\":\"Parent\",\"value\":\"$PROJ_PLAIN\"}"
+  note "-- post: heading project (moved to $PROJ_PLAIN?):"
+  gsql "SELECT uuid, title, type, project FROM TMTask WHERE uuid='$HMV'" | tee -a "$REPORT"
+fi
+
+# ---------------------------------- P3 set-detail Reminder (scheduled + dated clear)
+note "== [P3] set-detail Reminder Time on a SCHEDULED to-do =="
+gurl "things:///add?title=SCF-REM-SCHED&when=today"
+RS=$(uuid_of "SCF-REM-SCHED" 0 || true)
+note "-- pre: $RS"; gsql "SELECT title, start, startDate, reminderTime FROM TMTask WHERE uuid='$RS'" | tee -a "$REPORT"
+[ -n "${RS:-}" ] && proxy things-proxy-set-detail "{\"id\":\"$RS\",\"detail\":\"Reminder Time\",\"value\":\"14:30\"}"
+note "-- post (hope reminderTime=970981376):"; gsql "SELECT title, start, startDate, reminderTime FROM TMTask WHERE uuid='$RS'" | tee -a "$REPORT"
+
+note "== [P3b] clear a DATED reminder via set-detail (the sticky gap, oddity 2e) =="
+gurl "things:///add?title=SCF-REM-DATED&when=2026-07-10@09:00"
+RD=$(uuid_of "SCF-REM-DATED" 0 || true)
+note "-- pre (reminderTime set on a future date):"; gsql "SELECT title, startDate, reminderTime FROM TMTask WHERE uuid='$RD'" | tee -a "$REPORT"
+if [ -n "${RD:-}" ]; then
+  note "-- attempt clear via empty value:"
+  proxy things-proxy-set-detail "{\"id\":\"$RD\",\"detail\":\"Reminder Time\",\"value\":\"\"}"
+  note "-- post (reminderTime NULL = dated-clear UNLOCKED):"; gsql "SELECT title, startDate, reminderTime FROM TMTask WHERE uuid='$RD'" | tee -a "$REPORT"
+fi
+
+# ----------------------------------- P4 Completion/Creation date backdating
+note "== [P4] Completion Date + Creation Date backdating via set-detail =="
+gurl "things:///add?title=SCF-BACKDATE"
+BD=$(uuid_of "SCF-BACKDATE" 0 || true)
+if [ -n "${BD:-}" ]; then
+  note "-- complete it, then backdate Completion Date to 2025-01-15:"
+  gurl "things:///update?id=$BD&completed=true"
+  sleep 1
+  gsql "SELECT title, status, stopDate, creationDate FROM TMTask WHERE uuid='$BD'" | tee -a "$REPORT"
+  proxy things-proxy-set-detail "{\"id\":\"$BD\",\"detail\":\"Completion Date\",\"value\":\"2025-01-15\"}"
+  note "-- post Completion Date (stopDate changed to a 2025 epoch?):"
+  gsql "SELECT title, status, stopDate, datetime(stopDate,'unixepoch') AS stop_h FROM TMTask WHERE uuid='$BD'" | tee -a "$REPORT"
+  note "-- backdate Creation Date to 2024-06-01:"
+  proxy things-proxy-set-detail "{\"id\":\"$BD\",\"detail\":\"Creation Date\",\"value\":\"2024-06-01\"}"
+  gsql "SELECT title, creationDate, datetime(creationDate,'unixepoch') AS created_h FROM TMTask WHERE uuid='$BD'" | tee -a "$REPORT"
+fi
+
+note "== copying DB out =="
+lab_ssh "$IP" 'DB=$(echo ~/Library/Group\ Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-*/Things\ Database.thingsdatabase/main.sqlite); sqlite3 "$DB" ".backup /tmp/scf.sqlite"'
+lab_scp "$LAB_SSH_USER@$IP:/tmp/scf.sqlite" "$OUT/final.sqlite" || true
+note "GREEN — report: $REPORT"
+trap - EXIT; cleanup


### PR DESCRIPTION
Durable post-compaction execution plan (`docs/lab/probe-backlog.md`) + the autonomous S-campaign follow-up probe script. Docs + lab tooling only.

- **§A** — heading reorder via the private command, `set-detail` Parent (heading move), Reminder on a scheduled item + dated-clear, Completion/Creation backdating. Script has already run once; raw evidence in `lab/artifacts/things-run-scf-20260709-041543/` (not yet banked).
- **§B** — PR #42 no-regression `lab:regress` validation (recurring suite probes deferred to avoid unattended spurious-failure loops; ops already validated by A1–A6 + 382 tests).
- **§C** — parked: Shortcuts runner integration, signed-proxy distribution, headings doctrine, availability layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)