### PR TITLE
docs(lab): bank scf follow-up probe verdicts (heading reorder + dated-reminder clear)

### DIFF
--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -15,8 +15,8 @@ The **Shortcuts** column: the L5 golden sitting is DONE (2026-07-09) and the fir
 | Create | ✅ | ✅ | 🧪 | tags must pre-exist (app silently drops unknowns); reminder via `when=<list>@<time>` |
 | Update title/notes | ✅ (+append/prepend) | 🟡 partial | 🧪 | notes modes newline-joined (E04/E05) |
 | Schedule (today/evening/someday/date) | ✅ | 🟡 | 🧪 | 🚫 on repeating templates (crash — hard-blocked) |
-| Set reminder | ✅ today/evening/date | ⛔ no property | 🧪 | deterministic time emitter routes around the bare-hour parser trap (oddity 2d) |
-| Clear reminder | 🟡 today/evening only | ⛔ | 🧪 | dated reminders are STICKY (R20/R21, oddity 2e) — workaround: bounce via `when=today` first |
+| Set reminder | ✅ today/evening/date | ⛔ no property | 🧪 (`set-detail` `"14:30"` string no-ops, scf P3a — format experiments queued) | deterministic time emitter routes around the bare-hour parser trap (oddity 2d) |
+| Clear reminder | 🟡 today/evening only | ⛔ | ✅ **incl. DATED** (scf P3b, `set-detail` Reminder Time = `""`) | dated reminders are STICKY on URL (R20/R21, oddity 2e) — Shortcuts is the ONLY surface that clears them, and it's headless (output-class consent) |
 | Set/clear deadline | ✅ | 🟡 | 🧪 | |
 | Complete / cancel / reopen | ✅ | ✅ | 🧪 | |
 | Move to project/area (+existing heading) | ✅ | 🟡 no heading | 🧪 | unknown destinations guarded (app is a silent no-op) |
@@ -30,6 +30,7 @@ The **Shortcuts** column: the L5 golden sitting is DONE (2026-07-09) and the fir
 | Restore from Trash | 🚫 | 🟡 → Inbox, de-scheduled (E15) | 🧪 | prior container/schedule not restored |
 | Permanently delete ONE item | 🚫 | 🚫 (all spellings fail, B0/A5) | ✅ interactive (S-delperm, Delete Immediately) | Shortcuts hard-deletes one row (no tombstone) — but the delete consent has NO "Always Allow", so it's tier-3 user-present, never headless. `trash.empty` is the only autonomous hard-delete (all-or-nothing) |
 | Convert to project | 🚫 (E16) | 🚫 | 🚫 (no Convert action exists) | dead on every surface (catalog sweep, L5) |
+| Backdate Completion/Creation Date | 🧪 (json at-creation attrs?) | 🧪 (`completion date` property?) | 🧪 (`set-detail`; first probe INVALID, scf P4 — re-probe queued) | GTD-migration wish — no surface proven or disproven yet |
 
 ## Projects
 
@@ -61,7 +62,8 @@ Doctrine: headings were treated as nonexistent (flatten) until the S-campaign se
 | Create heading in an EXISTING project | 🚫 | 🚫 | ✅ (S02, `Create Heading`) | **only Shortcuts delivers this** — the marquee gap, now closed |
 | Rename a heading | 🚫 | 🚫 | ✅ (S03, `Edit Items → Set Title`) | |
 | Delete a heading | 🚫 | 🚫 | ✅ (S04, removes the row) | non-empty-heading child re-parenting unprobed |
-| Move a heading | 🚫 | 🚫 | 🧪 (`set-detail` Parent?) | unprobed candidate |
+| Move a heading | 🚫 | 🚫 | 🚫 (scf P2 — `set-detail` Parent is an exit-0 silent no-op) | dead on every surface |
+| Reorder headings within a project | 🚫 | ✅ native (scf P1 — the private reorder command accepts heading uuids) | ➖ | children follow their heading (FK intact); the command is misleadingly named "reorder to dos" |
 
 ## Areas
 
@@ -92,6 +94,7 @@ Doctrine: headings were treated as nonexistent (flatten) until the S-campaign se
 | Today | ✅ native (experimental gate) or bounce ≤10 | |
 | This Evening | ✅ bounce only | native silently de-evenings (O03) |
 | Project children (un-headed) | ✅ native (experimental) | headed children rejected (O06) |
+| Project headings (the headings themselves) | ✅ native (experimental) | heading uuids accepted (scf P1); heading-*scoped* child order still unautomatable (O06) |
 | Area members (to-dos OR projects) | ✅ native (experimental) | never mixed in one request (O14) |
 | Inbox | ✅ native (experimental) | full reversed wire list re-ranked exactly (A6); joins today/project/area as a validated scope |
 | Checklist items | ✅ | granular move via stateful rewrite |

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -12,7 +12,7 @@ The flatten-by-default plan: project reads return one FLAT to-do list in UI orde
 
 ### 1. Headings in existing projects — SOLVED via Shortcuts (L5 sitting, 2026-07-09)
 - **Create / rename / delete a heading in an existing project all WORK via Shortcuts** (S02/S03/S04, [s-campaign-results.md](lab/s-campaign-results.md)) — `things-proxy-create-heading` / `-edit-title` / `-delete-items`. The sole capability Shortcuts uniquely provides, now proven.
-- Still dead elsewhere: `heading=` never creates (T09/U09), json update op on headings errors (U10), AppleScript has no heading class (A31); native reorder RIPS headed children out (O06) so heading-*scoped ordering* stays unautomatable; heading *move* is an unprobed `set-detail` Parent candidate; non-empty-heading delete (child re-parenting) unprobed.
+- Still dead elsewhere: `heading=` never creates (T09/U09), json update op on headings errors (U10), AppleScript has no heading class (A31); native reorder RIPS headed children out (O06) so heading-*scoped ordering* stays unautomatable; heading *move* is DEAD on every surface (`set-detail` Parent is a silent no-op — scf P2, 2026-07-09); non-empty-heading delete (child re-parenting) unprobed. NEW (scf P1): **the headings THEMSELVES reorder natively** — the private reorder command accepts heading uuids as project children ([s-campaign-results.md](lab/s-campaign-results.md) follow-ups).
 - **Remaining path:** wire a Shortcuts WriteVector (`heading.add/rename/delete`) behind the availability interface (Phase 21b layer), decide flatten-vs-dual-mode (§0). Consent caveat: create/edit are headless (Always-Allow), delete is tier-3 user-present (no Always-Allow — s-campaign-results.md).
 
 ### 2. Repeating items — creation and rule-editing are UI-only, permanently (until CC ships an API)
@@ -59,7 +59,7 @@ The flatten-by-default plan: project reads return one FLAT to-do list in UI orde
 ## Ordering (LANDED — Phase 8, `things reorder` / `write.reorder`)
 
 - Shipped: Today (native, bucket-0 members incl. scheduled projects — O01/O12), project + area scopes (native, un-headed children only — O06), Evening via verified bounce (O07/O08). Native is experimental-gated (config `allow-experimental` + sdef canary); see [docs/lab/o-suite-results.md](lab/o-suite-results.md).
-- Remaining gaps: heading-scoped ordering (unautomatable, O06); sidebar area-among-areas ordering (DEAD — O13, see Tier-2 verdicts); checklist-item order (likely unautomatable — no granular checklist surface anywhere). Projects WITHIN an area now reorder natively (O14, Phase 14b).
+- Remaining gaps: heading-scoped ordering (unautomatable, O06); sidebar area-among-areas ordering (DEAD — O13, see Tier-2 verdicts); checklist-item order (likely unautomatable — no granular checklist surface anywhere). Projects WITHIN an area now reorder natively (O14, Phase 14b), and headings within a project reorder natively too (scf P1, 2026-07-09).
 
 ## Read-layer gaps
 

--- a/docs/lab/o-suite-results.md
+++ b/docs/lab/o-suite-results.md
@@ -33,6 +33,7 @@ Subject: the private AppleScript command `_private_experimental_ reorder to dos 
 
 - **O13**: moving areas among areas (sidebar order) is IMPOSSIBLE — AppleScript `move area … to before area` errors ('location specifier'); no other surface known.
 - **O14**: **projects WITHIN an area reorder natively** — the private command accepts project uuids in an area specifier (`project` inherits `to do`, O12 analog); area/type membership untouched. Extends write.reorder's area scope to projects.
+- **scf P1 (2026-07-09)**: **HEADINGS within a project reorder natively too** — the same command accepts heading (`type=2`) uuids in a project specifier; children keep their heading FK and follow. See [s-campaign-results.md](s-campaign-results.md) follow-ups.
 
 ## Not probed (future work)
 

--- a/docs/lab/probe-backlog.md
+++ b/docs/lab/probe-backlog.md
@@ -1,36 +1,49 @@
 # Probe backlog & in-flight validation plan
 
-Durable plan (survives context compaction). Written 2026-07-09 after the L5 sitting. Tracks (A) the autonomous S-campaign follow-up probes, (B) the PR #42 ops validation, and (C) parked work. Update the "STATUS" lines as each lands.
+Durable plan (survives context compaction). Written 2026-07-09 after the L5 sitting; updated 2026-07-09 post-compaction after banking the first scf run. Tracks (A) the S-campaign follow-up probes, (B) the PR #42 ops validation, (C) parked work, and (D) release. Update the "STATUS" lines as each lands.
 
-## ⟹ RESUME HERE (post-compaction execution order)
+## ⟹ RESUME HERE (execution order)
 
-Mike compacts the context, THEN this runs. Nothing is running now (no VMs). Do, in order:
+1. ~~Bank §A round-1 results~~ — **DONE 2026-07-09** (PR #45): verdicts from `lab/artifacts/things-run-scf-20260709-041543/` folded into [s-campaign-results.md](s-campaign-results.md) (follow-ups table), capability-matrix, oddities (2e update + new 5k), gaps, o-suite-results.
+2. **Validate PR #42** (§B): `npm run lab:regress` as a NO-REGRESSION check → merge on double-green. STATUS: pending.
+3. **scf2 re-probe** (§A round 2, below): P4 redo + P3a formats + P2b to-do re-parent + P6 sidebar spellings. Run AFTER regress (one VM at a time). STATUS: pending.
+4. **npm publish** (§D). STATUS: pending.
+5. Parked §C work.
 
-1. **Bank §A results.** The probe run in `lab/scripts/research-scampaign-followups.sh` ALREADY RAN — raw evidence is on disk at `lab/artifacts/things-run-scf-20260709-041543/report.txt` (+ `final.sqlite`). NOT yet analyzed or banked. Read it, extract the P1–P4 verdicts (heading reorder / set-detail Parent / Reminder on scheduled + dated-clear / Completion+Creation backdating), and fold them into `docs/lab/s-campaign-results.md`, `docs/capability-matrix.md`, and `docs/things-app-oddities.md` (per the CLAUDE.md living-doc contract). Commit on a branch → PR → merge.
-2. **Validate PR #42** (§B). Decided approach: run `npm run lab:regress` as a NO-REGRESSION check (it exercises the reorder pipeline/guards/pre-state I changed + the guest e2e). Hand-authoring new recurring suite probes was deferred — unattended, a malformed ordering-assertion would block the merge on 40-min iterations, and the four ops are already validated by the A1–A6 real-app probes + 382 unit/engine tests. If regress is double-green → merge PR #42 (`mg/phase21b-ops`, currently OPEN). If it fails, diagnose (that's the check working).
-3. Optionally then author careful recurring suite probes (§B step 1) with an iteration budget, and pick up §C.
+## A. S-campaign follow-up probes
 
-Everything below is the detailed spec. `git log` on `main`: #40/#41/#43 merged; #42 open (ops, awaiting this regress).
+### Round 1 — `lab/scripts/research-scampaign-followups.sh` — RAN + BANKED (run `things-run-scf-20260709-041543`)
 
-## A. S-campaign autonomous follow-up probes — `lab/scripts/research-scampaign-followups.sh`
+- **P1 — heading reorder via the private command.** STATUS: **WORKS** 🎉 — heading uuids accepted in a project specifier; children follow. Banked.
+- **P2 — `set-detail` Parent = heading move.** STATUS: **SILENT NO-OP** — heading move dead on all surfaces. Banked. (To-do re-parent variant NOT attempted → P2b, round 2.)
+- **P3a — `set-detail` Reminder Time "14:30" on a scheduled to-do.** STATUS: **NO-OP** (text→Date coercion suspect) → format experiments, round 2.
+- **P3b — clear a DATED reminder via empty value.** STATUS: **WORKS** 🎉 — oddity-2e gap closed (Shortcuts-only, headless). Banked.
+- **P4 — Completion/Creation Date backdating.** STATUS: **INVALID RUN** (two script bugs: completion via `things:///update` WITHOUT the auth token → fixture never completed; stale `--output-path` file aliased P4 output to P3b's). → redo, round 2.
+- **P5 (NEEDS A HUMAN CLICK)** — delete a NON-empty heading: do children re-parent, orphan, or cascade? Delete-class consent re-prompts every run (oddity 5j). STATUS: parked.
 
-Run in ONE disposable clone (golden `things-lab-golden-v1`, stopped/frozen 2026-07-09; clones inherit the Shortcuts output-class Always-Allow grants, so `set-detail`/`find-items`/`create-heading` run headless — deadline-wrap every `shortcuts run` so a consent-didn't-transfer surprise can't wedge). All four are autonomous (no human click). Evidence → `docs/lab/s-campaign-results.md` + capability-matrix/oddities.
+### Round 2 — `lab/scripts/research-scf2.sh` (to author) — STATUS: pending
 
-- **P1 — heading reorder via the private command (Mike's sharp question).** The `_private_experimental_ reorder to dos in project id <P>` command is misleadingly named — it accepts PROJECT uuids in an area scope (O14, class inheritance). Untested: does it accept HEADING uuids (type=2) as project children? Use seed `LAB-PROJ-HEADINGS` (Dwr1MiANqMFvAWddgGgzVX) with headings Alpha (5saDdJcodvWARN9Ct2nQsT) + Beta (M7QEqPbk6v9jZZ6CBiyaP3). Reorder `with ids "<Beta>,<Alpha>"`; compare the headings' `"index"` before/after. Outcome ∈ {reorders them (heading ordering UNLOCKS — correct the "unautomatable" claim), errors (heading ∉ `to do` class), no-op}. STATUS: pending.
-- **P2 — `set-detail` Parent = move a heading to another project.** create-heading (headless) makes a heading in project A; `set-detail {id:<heading>, detail:"Parent", value:<project B uuid>}`; check `TMTask.project` of the heading. Also try it on a to-do (re-parent between projects). STATUS: pending.
-- **P3 — `set-detail` Reminder Time on a SCHEDULED item + clear a DATED reminder.** (a) to-do `when=today`, set-detail Reminder Time "14:30" → expect `reminderTime=970981376`. (b) to-do with a DATED reminder (`when=2026-07-10@09:00` via URL), then set-detail Reminder Time to ""/clear → does it CLEAR? (the sticky-dated-reminder gap, oddity 2e — the one thing URL can't do). STATUS: pending.
-- **P4 — Completion Date / Creation Date backdating.** Complete a to-do, `set-detail {detail:"Completion Date", value:<past ISO>}` → check `stopDate`. `set-detail {detail:"Creation Date", value:<past ISO>}` → check `creationDate`. No other surface writes these (GTD migration use case). STATUS: pending.
-- **P5 (NEEDS A HUMAN CLICK — not in this script)** — delete a NON-empty heading: do the children re-parent to the project root (expected), orphan, or cascade-delete? Delete-class consent re-prompts every run (oddity 5j), so this waits for a human. STATUS: parked.
+One clone, autonomous. Harness fixes learned from round 1: `proxy()` must `rm -f /tmp/scf-out.txt` before each run; completion must go through AppleScript (`set status of to do id X to completed`) or URL WITH the auth token (read it from the guest defaults/plist as phase21b did).
+
+- **P4 redo — backdating.** Complete a fixture properly (verify `status=3`/stopDate in DB before proceeding), then: (a) Shortcuts `set-detail` Completion Date with several value shapes (ISO `2025-01-15`, locale `1/15/2025`, `January 15, 2025`); (b) AppleScript `set completion date of to do id X to date "..."`; (c) URL `things:///update?...&completion-date=...` (+auth token). Same trio for Creation Date. Check `stopDate`/`creationDate` deltas after each.
+- **P3a redo — Reminder Time set formats.** On a `when=today` fixture: `set-detail` Reminder Time with `"2:30 PM"`, `"14:30"` re-check, full datetime strings. Expect `reminderTime = hour<<26 | minute<<20`.
+- **P2b — `set-detail` Parent on a TO-DO** (re-parent between projects) — the heading variant no-op'd; does it work for to-dos?
+- **P6 — sidebar order, remaining spellings** (Mike's insight: Anytime view order mirrors sidebar order — consistent with both reading the same `index`; the two probed spellings are dead: O13 `move area to before area` errors, P17 private reorder in `list "Anytime"` with top-level project uuids no-ops). Untried spellings to sweep: (a) AppleScript `move project id X to before project id Y` (location specifier on projects, never probed — O13 only tried areas); (b) `set index of project/area` (property write); (c) private reorder in `list "Anytime"` with AREA uuids; (d) private reorder in `list "Someday"`; (e) grep the full sdef dump for any other `_private_` commands we haven't inventoried. Evidence target: `TMTask."index"` (top-level projects) / `TMArea."index"` (areas).
 
 ## B. PR #42 validation (project tags/reminders, tag-shortcut clear, inbox reorder)
 
-1. Recurring regression probes added to the suites (encode the A1–A6 deltas): e-suite (project tags URL+AS, project reminder, tag shortcut CLEAR) + o-suite (inbox reorder). STATUS: pending.
-2. `npm run lab:regress` (7 suites + guest e2e, ~40 min) — proves no regression AND the new probes pass. STATUS: pending.
-3. On double-green → merge PR #42. STATUS: pending.
+1. `npm run lab:regress` (7 suites + guest e2e, ~40 min) — no-regression check (exercises the reorder pipeline/guards/pre-state PR #42 touches). STATUS: pending.
+2. On double-green → merge PR #42 (`mg/phase21b-ops`, OPEN). STATUS: pending.
+3. Recurring suite probes encoding the A1–A6 deltas (e-suite: project tags URL+AS, project reminder, tag shortcut clear; o-suite: inbox reorder) — deliberately deferred; author later with an iteration budget. STATUS: deferred.
 
-## C. Parked (bigger, not auto-runnable now) — task #7
+## C. Parked (bigger, not auto-runnable now)
 
-- Lab runner/DSL **Shortcuts vector** support (write JSON input to a guest file + `shortcuts run --input-path`; interactive delete-class handling) so `s-suite.json` becomes a real recurring suite.
-- **Distribution/onboarding**: produce signed / iCloud-shareable proxies from a network Mac with an Apple ID; a `things setup shortcuts` import + first-run-consent flow. (Golden is airgapped + Apple-ID-less, so it can only make unsigned copies.)
-- **Headings doctrine decision** (gaps §0): flatten-only vs dual-mode, now that Shortcuts delivers the lifecycle.
+- Lab runner/DSL **Shortcuts vector** support (guest input files + `shortcuts run --input-path`; interactive delete-class handling) so `s-suite.json` becomes a real recurring suite.
+- **Distribution/onboarding**: signed / iCloud-shareable proxies from a network Mac with an Apple ID; a `things setup shortcuts` import + first-run-consent flow.
+- **Headings doctrine decision** (gaps §0): flatten-only vs dual-mode — Mike's call. New input since: heading REORDER is native/AppleScript (scf P1), heading MOVE is dead everywhere (scf P2).
 - **Availability layer** (Phase 21b remainder): advisory `availability(env)` per vector; doctor reads `uriSchemeEnabled`; correct the `feature-disabled` classifier to key on `uriSchemeEnabled`, not a null token.
+- **Heading reorder op** (`heading.reorder` or fold into project reorder): now that scf P1 proved the surface, wire it into the write pipeline (operations/commands/pre-state/vectors + matrix). Candidate next code phase alongside PR #42's pattern.
+
+## D. Release — publish `things-api` to npm (Mike, 2026-07-09)
+
+Unscoped name `things-api` confirmed available; LICENSE (MIT) landed; repo prepped in PR #38. Steps: merge PR #42 first → decide version → move CHANGELOG `## Unreleased` under the version heading → `npm run check` + `npm pack --dry-run` sanity → git tag `vX.Y.Z` → `npm publish` (Mike's npm auth/OTP likely needed). STATUS: pending.

--- a/docs/lab/s-campaign-results.md
+++ b/docs/lab/s-campaign-results.md
@@ -47,6 +47,20 @@ Consequence: a Shortcuts create/edit/set/find vector can run autonomously; a Sho
 - Create To-Do exposes **Parent + Heading** fields (a second heading-placement surface) and a `Start` of On Date / Anytime / Someday only (no Today/Evening/Inbox keywords at creation).
 - `Duplicate Items` exists (could it duplicate a heading? — unprobed).
 
+## Follow-up probes (scf run `things-run-scf-20260709-041543`, 2026-07-09)
+
+Autonomous clone run ([`lab/scripts/research-scampaign-followups.sh`](../../lab/scripts/research-scampaign-followups.sh); raw report + `final.sqlite` under `lab/artifacts/things-run-scf-20260709-041543/`). First fact banked: **output-class Shortcuts consent IS inherited by clones** — every proxy ran headless.
+
+| # | Question | Verdict | Evidence |
+|---|---|---|---|
+| P1 | Does the private reorder command accept **heading** uuids? | **WORKS** 🎉 | `_private_experimental_ reorder to dos in project id … with ids "<Beta>,<Alpha>"` moved Beta above Alpha (`"index"` 0 → −799 vs Alpha −409); both headings' children kept their `heading` FK. **Heading reorder within a project is automatable** (AppleScript, tier 0) — the command is misleadingly named; it takes to-dos, projects (O14), and now headings. |
+| P2 | `set-detail` Parent = heading **move** to another project? | **SILENT NO-OP** | exit 0, item echoed back, `TMTask.project` unchanged. Heading move is now dead on ALL surfaces. (The to-do re-parent variant was not attempted — scf2.) |
+| P3a | `set-detail` Reminder Time `"14:30"` on a SCHEDULED to-do | **NO-OP** (string coercion suspect) | exit 0, `reminderTime` stayed NULL on a `start=1, startDate` set fixture. Likely the text→Date coercion fails silently; format experiments queued (scf2). |
+| P3b | Clear a **DATED** reminder via `set-detail` Reminder Time `""` | **WORKS** 🎉 | `reminderTime` 603979776 → NULL, `startDate` untouched. **Closes the oddity-2e sticky-dated-reminder gap** — the one reminder edit no other surface can make, and it's output-class (headless). |
+| P4 | Completion/Creation Date backdating via `set-detail` | **INVALID RUN** — re-probe (scf2) | Two script bugs: (a) the completion step used `things:///update?…&completed=true` WITHOUT the auth token, so the fixture was never completed (`status=0` in `final.sqlite`); (b) both P4 proxy runs produced NO output, so `cat` served the STALE `--output-path` file from P3b (`SCF-REM-DATED` echoed while targeting `SCF-BACKDATE`). No verdict on backdating itself. |
+
+Harness lessons: `proxy()` must `rm -f` the `--output-path` file before each run (stale-output aliasing); `shortcuts run` exits 0 even when `Edit Items` silently fails inside (oddity 5k) — DB delta is the only truth.
+
 ## Doctrine impact (for Mike)
 
 gaps.md §0 held the headings doctrine as "flatten unless Shortcuts delivers; **dual-mode** candidate (first-class with a Shortcuts vector, flattened otherwise)." **Shortcuts delivered** — create/rename/delete all work — so the dual-mode path is unblocked. The implementation decision (flatten vs dual-mode, and whether to ship the interactive permanent-delete) is Mike's; recorded here, not yet acted on.

--- a/docs/things-app-oddities.md
+++ b/docs/things-app-oddities.md
@@ -76,6 +76,8 @@ The command returns success and produces literally zero database delta (not even
 
 On `when=today` / `when=evening`, re-sending a bare `when=` (no `@time`) **clears** an existing reminder (R07). On a dated schedule it does NOT: `when=2026-07-09` on an item already dated 07-09 with a reminder leaves the reminder intact (R20), and re-dating to `when=2026-07-10` carries the reminder along to the new date (R21). Consequence: **there is no URL-scheme way to remove a reminder from a date-scheduled item** — a caller must bounce it through `when=today` (which clears) and re-date, or use the UI. Whichever behavior is intended, the keyword/date asymmetry is surprising; callers relying on the today/evening clear behavior silently fail on dates. Evidence: R07/R20/R21, 2026-07-05.
 
+**Update 2026-07-09 (scf P3b):** the Shortcuts `Edit Items → Reminder Time` action with an EMPTY value DOES clear a dated reminder (`reminderTime` → NULL, `startDate` untouched). The URL-scheme asymmetry stands, but a workaround now exists outside it — Shortcuts is the only surface that clears a dated reminder in place.
+
 ## 3. UI vs. URL behavioral divergence: project completion
 
 Completing a project **in the UI** with unresolved children prompts ("mark as completed" etc.). Completing the same project via `things:///update-project?...&completed=true` **silently auto-completes every open child** — no prompt, no signal, canceled children left canceled. Same user intent, materially different outcome depending on the surface. For automation this is a destructive default: one URL can mark dozens of children done. *(T08/U08 — cascade behavior verified row-level)*
@@ -133,6 +135,10 @@ There is no scripted way to permanently delete ONE item via AppleScript or URL. 
 
 ### 5j. Shortcuts Privacy consent is asymmetric: "output" actions can be Always-Allowed, "delete" actions cannot
 Running a Things Shortcuts action prompts a per-shortcut Shortcuts-Privacy dialog scoped to a data class (distinct from AppleEvents Automation consent). **Output-class** dialogs ("Allow X to **output** N items" — create/edit/set/find) offer **Don't Allow / Allow Once / Always Allow**. **Delete-class** dialogs ("Allow X to **delete** N items") offer only **Don't Delete / Delete** — there is **no Always-Allow**, so a delete re-prompts on every single run and can never be made headless. A user can grant a create/edit shortcut once and automate it, but can never non-interactively delete through Shortcuts. *(L5 sitting, 2026-07-09)*
+
+### 5k. Shortcuts `Edit Items` reports success even when the edit silently fails
+
+`shortcuts run` exits 0 and the shortcut completes "successfully" even when the `Edit Items` action changed nothing: setting `Parent` on a heading echoes the item back with zero DB delta (scf P2), and setting `Reminder Time` from a plain `"14:30"` text value silently fails to coerce and writes nothing (scf P3a). When the action fails internally it may also produce NO output at all while still exiting 0 (scf P4) — an automation caller gets no error channel whatsoever; the only truth is re-reading the data. *(scf run, 2026-07-09)*
 
 ---
 

--- a/lab/scripts/research-scampaign-followups.sh
+++ b/lab/scripts/research-scampaign-followups.sh
@@ -42,7 +42,7 @@ gas() { lab_ssh "$IP" "osascript -e $(printf '%q' "$1") 2>&1" || true; }
 gurl() { lab_ssh "$IP" "open -g $(printf '%q' "$1")"; sleep 2; }
 proxy() { # proxy <name> <json>  (deadline-wrapped; headless if consent inherited)
   note "-- shortcuts run $1  $2"
-  lab_ssh "$IP" "printf '%s' $(printf '%q' "$2") > /tmp/scf-in.json; perl -e 'alarm 60; exec @ARGV' shortcuts run $(printf '%q' "$1") --input-path /tmp/scf-in.json --output-path /tmp/scf-out.txt 2>&1; echo \"[exit \$?]\"; cat /tmp/scf-out.txt 2>/dev/null; echo" 2>&1 | tee -a "$REPORT" || true
+  lab_ssh "$IP" "printf '%s' $(printf '%q' "$2") > /tmp/scf-in.json; rm -f /tmp/scf-out.txt; perl -e 'alarm 60; exec @ARGV' shortcuts run $(printf '%q' "$1") --input-path /tmp/scf-in.json --output-path /tmp/scf-out.txt 2>&1; echo \"[exit \$?]\"; cat /tmp/scf-out.txt 2>/dev/null; echo" 2>&1 | tee -a "$REPORT" || true
   sleep 1
 }
 uuid_of() { local t="$1" typ="${2:-}" w="title='$1' AND trashed=0" u i; [ -n "$typ" ] && w="$w AND type=$typ"; for i in $(seq 1 12); do u=$(gq "SELECT uuid FROM TMTask WHERE $w ORDER BY creationDate DESC LIMIT 1"); [ -n "$u" ] && { echo "$u"; return 0; }; sleep 1; done; return 1; }


### PR DESCRIPTION
Banks the S-campaign follow-up probe run (`things-run-scf-20260709-041543`) into the living docs, per docs/lab/probe-backlog.md §A.

## Verdicts
- **P1 — heading reorder via the private command: WORKS** 🎉 — heading uuids accepted in a project specifier; children keep their heading FK. Heading reorder is automatable (AppleScript, tier 0).
- **P2 — set-detail Parent heading move: silent no-op** — heading move now a validated dead end on every surface.
- **P3b — dated-reminder CLEAR via empty Reminder Time: WORKS** 🎉 — closes the oddity-2e sticky gap; Shortcuts is the only surface that can, and it's headless (output-class consent).
- **P3a — Reminder Time "14:30" string set: no-op** — coercion suspect; format experiments queued (scf2).
- **P4 — Completion/Creation backdating: INVALID RUN** — two script bugs (update URL without auth token; stale `--output-path` aliasing). Re-probe spec'd as scf2, alongside Mike's sidebar-order spelling sweep (P6).

New oddity **5k**: Shortcuts `Edit Items` exits 0 even when the edit silently fails (no error channel at all).

Also: probe-backlog rewritten with round-2 (scf2) specs + release plan §D; harness fix (`proxy()` clears the stale output file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiiUK4qXABDtVKoW7S9Cft