### PR TITLE
docs(lab): bank scf2 verdicts — backdating unlocked, sidebar closed, someday reorder scope

### DIFF
--- a/docs/capability-matrix.md
+++ b/docs/capability-matrix.md
@@ -15,11 +15,11 @@ The **Shortcuts** column: the L5 golden sitting is DONE (2026-07-09) and the fir
 | Create | ✅ | ✅ | 🧪 | tags must pre-exist (app silently drops unknowns); reminder via `when=<list>@<time>` |
 | Update title/notes | ✅ (+append/prepend) | 🟡 partial | 🧪 | notes modes newline-joined (E04/E05) |
 | Schedule (today/evening/someday/date) | ✅ | 🟡 | 🧪 | 🚫 on repeating templates (crash — hard-blocked) |
-| Set reminder | ✅ today/evening/date | ⛔ no property | 🧪 (`set-detail` `"14:30"` string no-ops, scf P3a — format experiments queued) | deterministic time emitter routes around the bare-hour parser trap (oddity 2d) |
+| Set reminder | ✅ today/evening/date | ⛔ no property | 🚫 (scf2 P3a — every format no-ops; `Edit Items → Reminder Time` can only CLEAR) | deterministic time emitter routes around the bare-hour parser trap (oddity 2d) |
 | Clear reminder | 🟡 today/evening only | ⛔ | ✅ **incl. DATED** (scf P3b, `set-detail` Reminder Time = `""`) | dated reminders are STICKY on URL (R20/R21, oddity 2e) — Shortcuts is the ONLY surface that clears them, and it's headless (output-class consent) |
 | Set/clear deadline | ✅ | 🟡 | 🧪 | |
 | Complete / cancel / reopen | ✅ | ✅ | 🧪 | |
-| Move to project/area (+existing heading) | ✅ | 🟡 no heading | 🧪 | unknown destinations guarded (app is a silent no-op) |
+| Move to project/area (+existing heading) | ✅ | 🟡 no heading | 🚫 text value (scf2 P2b — `set-detail` Parent with a uuid string DETACHES the item instead of moving it, oddity 5l); entity-typed variant 🧪 | unknown destinations guarded (app is a silent no-op) |
 | Move to Inbox | 🚫 | ✅ | 🧪 | de-schedules (E06) |
 | Detach from ALL containers (keep schedule) | ✅ empty `list-id=` (P21/P22) | 🚫 (all nil spellings fail) | 🧪 | |
 | Tags: replace/clear | ✅ (empty set clears, P14) | ✅ `set tag names` | 🧪 | add/merge is a client-side read-merge-replace |
@@ -30,7 +30,8 @@ The **Shortcuts** column: the L5 golden sitting is DONE (2026-07-09) and the fir
 | Restore from Trash | 🚫 | 🟡 → Inbox, de-scheduled (E15) | 🧪 | prior container/schedule not restored |
 | Permanently delete ONE item | 🚫 | 🚫 (all spellings fail, B0/A5) | ✅ interactive (S-delperm, Delete Immediately) | Shortcuts hard-deletes one row (no tombstone) — but the delete consent has NO "Always Allow", so it's tier-3 user-present, never headless. `trash.empty` is the only autonomous hard-delete (all-or-nothing) |
 | Convert to project | 🚫 (E16) | 🚫 | 🚫 (no Convert action exists) | dead on every surface (catalog sweep, L5) |
-| Backdate Completion/Creation Date | 🧪 (json at-creation attrs?) | 🧪 (`completion date` property?) | 🧪 (`set-detail`; first probe INVALID, scf P4 — re-probe queued) | GTD-migration wish — no surface proven or disproven yet |
+| Backdate Completion/Creation Date (existing item) | 🚫 (`update?completion-date=`/`creation-date=` silent no-ops, scf2 P4c — oddity 2g) | ✅ (`set completion date` / `set creation date` property writes, scf2 P4b) | 🚫 (`set-detail` dead in every format, scf2 P4a) | AppleScript is the ONLY surface |
+| Backdated import (completed at creation) | ✅ `things:///json` `creation-date`/`completion-date` attrs, exact values honored (scf2 P4d) | 🧪 (make-then-set two-step, untested) | 🚫 | the logbook-import / GTD-migration path |
 
 ## Projects
 
@@ -97,9 +98,10 @@ Doctrine: headings were treated as nonexistent (flatten) until the S-campaign se
 | Project headings (the headings themselves) | ✅ native (experimental) | heading uuids accepted (scf P1); heading-*scoped* child order still unautomatable (O06) |
 | Area members (to-dos OR projects) | ✅ native (experimental) | never mixed in one request (O14) |
 | Inbox | ✅ native (experimental) | full reversed wire list re-ranked exactly (A6); joins today/project/area as a validated scope |
+| Someday | 🧪 native surface PROVEN (scf2 P6h) — op wire-up pending | same private command; appears to follow the Inbox reversed-wire convention — lock with a 3-item probe before shipping |
 | Checklist items | ✅ | granular move via stateful rewrite |
-| Sidebar: areas | 🚫 (O13) | |
-| Sidebar: top-level projects | 🚫 (P17) | reads provisional too (P19) |
+| Sidebar: areas | 🚫 (O13 + scf2 P6e/f/g) | exhaustively closed 2026-07-09: move-to-location errors (−1700), `set index` read-only (−10006), private reorder no-ops on area uuids; sdef has no other command |
+| Sidebar: top-level projects | 🚫 (P17 + scf2 P6a–d) | same sweep; reads provisional too (P19). Anytime view order mirrors the sidebar (same "index" columns) but nothing writes them |
 | Anytime/Someday aggregate views | ⛔ | no independent order — derived from container order |
 
 ## Repeating items

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -59,7 +59,7 @@ The flatten-by-default plan: project reads return one FLAT to-do list in UI orde
 ## Ordering (LANDED — Phase 8, `things reorder` / `write.reorder`)
 
 - Shipped: Today (native, bucket-0 members incl. scheduled projects — O01/O12), project + area scopes (native, un-headed children only — O06), Evening via verified bounce (O07/O08). Native is experimental-gated (config `allow-experimental` + sdef canary); see [docs/lab/o-suite-results.md](lab/o-suite-results.md).
-- Remaining gaps: heading-scoped ordering (unautomatable, O06); sidebar area-among-areas ordering (DEAD — O13, see Tier-2 verdicts); checklist-item order (likely unautomatable — no granular checklist surface anywhere). Projects WITHIN an area now reorder natively (O14, Phase 14b), and headings within a project reorder natively too (scf P1, 2026-07-09).
+- Remaining gaps: heading-scoped ordering (unautomatable, O06); sidebar ordering — **EXHAUSTIVELY CLOSED as UI-only 2026-07-09** (scf2 P6a–g: every move-to-location spelling errors −1700, `set index` is read-only −10006, the sole private command no-ops on project AND area uuids in Anytime scope, and the sdef contains no other private verb); checklist-item order (likely unautomatable — no granular checklist surface anywhere). Projects WITHIN an area reorder natively (O14), headings within a project reorder natively (scf P1), and **Someday is a newly proven native scope** (scf2 P6h — reversed-wire convention to lock before wiring the op).
 
 ## Read-layer gaps
 

--- a/docs/lab/probe-backlog.md
+++ b/docs/lab/probe-backlog.md
@@ -6,7 +6,7 @@ Durable plan (survives context compaction). Written 2026-07-09 after the L5 sitt
 
 1. ~~Bank §A round-1 results~~ — **DONE 2026-07-09** (PR #45): verdicts from `lab/artifacts/things-run-scf-20260709-041543/` folded into [s-campaign-results.md](s-campaign-results.md) (follow-ups table), capability-matrix, oddities (2e update + new 5k), gaps, o-suite-results.
 2. **Validate PR #42** (§B): `npm run lab:regress` as a NO-REGRESSION check → merge on double-green. STATUS: pending.
-3. **scf2 re-probe** (§A round 2, below): P4 redo + P3a formats + P2b to-do re-parent + P6 sidebar spellings. Run AFTER regress (one VM at a time). STATUS: pending.
+3. ~~scf2 re-probe~~ — **RAN + BANKED 2026-07-09** (run `things-run-scf2-20260709-045454`; verdicts in [s-campaign-results.md](s-campaign-results.md) round 2): backdating = AppleScript-only for existing items + json at-creation import; reminder set via set-detail DEAD; set-detail Parent = DETACH footgun (oddity 5l); sidebar ordering exhaustively closed; Someday = new native reorder scope (P6h).
 4. **npm publish** (§D). STATUS: pending.
 5. Parked §C work.
 
@@ -21,7 +21,7 @@ Durable plan (survives context compaction). Written 2026-07-09 after the L5 sitt
 - **P4 — Completion/Creation Date backdating.** STATUS: **INVALID RUN** (two script bugs: completion via `things:///update` WITHOUT the auth token → fixture never completed; stale `--output-path` file aliased P4 output to P3b's). → redo, round 2.
 - **P5 (NEEDS A HUMAN CLICK)** — delete a NON-empty heading: do children re-parent, orphan, or cascade? Delete-class consent re-prompts every run (oddity 5j). STATUS: parked.
 
-### Round 2 — `lab/scripts/research-scf2.sh` (to author) — STATUS: pending
+### Round 2 — `lab/scripts/research-scf2.sh` — RAN + BANKED (run `things-run-scf2-20260709-045454`)
 
 One clone, autonomous. Harness fixes learned from round 1: `proxy()` must `rm -f /tmp/scf-out.txt` before each run; completion must go through AppleScript (`set status of to do id X to completed`) or URL WITH the auth token (read it from the guest defaults/plist as phase21b did).
 
@@ -42,7 +42,8 @@ One clone, autonomous. Harness fixes learned from round 1: `proxy()` must `rm -f
 - **Distribution/onboarding**: signed / iCloud-shareable proxies from a network Mac with an Apple ID; a `things setup shortcuts` import + first-run-consent flow.
 - **Headings doctrine decision** (gaps §0): flatten-only vs dual-mode — Mike's call. New input since: heading REORDER is native/AppleScript (scf P1), heading MOVE is dead everywhere (scf P2).
 - **Availability layer** (Phase 21b remainder): advisory `availability(env)` per vector; doctor reads `uriSchemeEnabled`; correct the `feature-disabled` classifier to key on `uriSchemeEnabled`, not a null token.
-- **Heading reorder op** (`heading.reorder` or fold into project reorder): now that scf P1 proved the surface, wire it into the write pipeline (operations/commands/pre-state/vectors + matrix). Candidate next code phase alongside PR #42's pattern.
+- **Newly-opened ops to implement** (probe-proven, unwired): heading reorder within a project (scf P1); `todo.backdate` — completion/creation date via AppleScript property writes (scf2 P4b); backdated logbook IMPORT via `things:///json` at-creation attrs (scf2 P4d); `reorder` someday scope (scf2 P6h — FIRST lock the reversed-wire convention with a 3-item probe).
+- **Round-3 probe candidates**: 3-item someday-reorder convention lock (autonomous); set-detail Parent with an ENTITY-typed value — a `things-proxy-move-item` whose Parent field takes a second Find Items output (needs a golden sitting to build, human present); P5 non-empty heading delete (human click, delete-class consent).
 
 ## D. Release — publish `things-api` to npm (Mike, 2026-07-09)
 

--- a/docs/lab/s-campaign-results.md
+++ b/docs/lab/s-campaign-results.md
@@ -61,6 +61,22 @@ Autonomous clone run ([`lab/scripts/research-scampaign-followups.sh`](../../lab/
 
 Harness lessons: `proxy()` must `rm -f` the `--output-path` file before each run (stale-output aliasing); `shortcuts run` exits 0 even when `Edit Items` silently fails inside (oddity 5k) — DB delta is the only truth.
 
+
+## Follow-up probes, round 2 (scf2 run `things-run-scf2-20260709-045454`, 2026-07-09)
+
+[`lab/scripts/research-scf2.sh`](../../lab/scripts/research-scf2.sh); raw report + `final.sqlite` under `lab/artifacts/things-run-scf2-20260709-045454/`. Fixture completion verified in-DB before every backdating probe (round 1's confound eliminated).
+
+| # | Question | Verdict | Evidence |
+|---|---|---|---|
+| P4a | Backdate Completion/Creation Date via `set-detail` | **DEAD** | Five value shapes (`1/15/2025`, `January 15, 2025`, `2025-01-15`, `6/1/2024`, `June 1, 2024`) all exit-0 silent no-ops on a VERIFIED-completed fixture. |
+| P4b | Backdate via AppleScript property writes | **WORKS** 🎉 | `set completion date of to do id X to ((current date) - (200 * days))` → `stopDate` 2026-07-05 → **2025-12-17**; `set creation date` → `creationDate` → **2025-05-31**. **Backdating existing items is unlocked, AppleScript-only.** |
+| P4c | Backdate via URL `update?completion-date=` / `creation-date=` (auth token attached) | **SILENT NO-OP** | `completed=true` WITH the token works (round-1 diagnosis confirmed); the date params change nothing (oddity 2g). |
+| P4d | **At-creation backdating via `things:///json` attributes** | **WORKS** 🎉 | `{"completed":true,"creation-date":"2024-06-01T08:00:00Z","completion-date":"2025-01-15T09:00:00Z"}` → row created `status=3`, `stopDate=2025-01-15 09:00`, `creationDate=2024-06-01 08:00` — exact values honored. The logbook-import / GTD-migration path. |
+| P3a | Set Reminder Time via `set-detail`, format sweep | **DEAD** | `2:30 PM`, `14:30`, `7/5/2026 2:30 PM` — all exit-0 no-ops on a scheduled fixture. `Edit Items → Reminder Time` can only CLEAR (P3b); it cannot set. |
+| P2b | `set-detail` Parent on a TO-DO (text uuid value) | **DESTRUCTIVE FOOTGUN** 🚨 | The to-do was not moved to the target project — it was **DETACHED from its project entirely** (`project` → NULL), exit 0. Text→entity coercion fails and CLEARS the parent (oddity 5l). An entity-typed variant (a proxy whose Parent field takes a second `Find Items` output) is unprobed — needs a golden sitting to build. |
+| P6a–g | Sidebar order, exhaustive spelling sweep | **ALL DEAD — sidebar ordering is conclusively UI-only** | `move project id X to before project id Y` → −1700; `move project/area … to beginning of …` → −1700; `set index of project/area` → −10006 (read-only); private reorder with top-level-project uuids (P17 re-check) or AREA uuids in `list "Anytime"` → zero-delta no-ops. Host sdef dump confirms exactly ONE private command exists (`_private_experimental_ reorder to dos in`) — no hidden sidebar verb. |
+| P6h | Private reorder in `list "Someday"` | **WORKS** 🎉 | `LAB-SOMEDAY-1` `"index"` 0 → −901, landing ABOVE the first-listed id — consistent with the Inbox scope's REVERSED wire-list convention (A6). **Someday is a new native reorder scope**; lock the exact convention with a 3-item probe before wiring the op. |
+
 ## Doctrine impact (for Mike)
 
 gaps.md §0 held the headings doctrine as "flatten unless Shortcuts delivers; **dual-mode** candidate (first-class with a Shortcuts vector, flattened otherwise)." **Shortcuts delivered** — create/rename/delete all work — so the dual-mode path is unblocked. The implementation decision (flatten vs dual-mode, and whether to ship the interactive permanent-delete) is Mike's; recorded here, not yet acted on.

--- a/docs/things-app-oddities.md
+++ b/docs/things-app-oddities.md
@@ -44,6 +44,9 @@ On `add`, a `heading=` value that doesn't match an existing heading in the targe
 ### 2f. AppleScript `move project … to list "Anytime"` on a non-trashed project → complete silent no-op
 The command returns success and produces literally zero database delta (not even a modification-date bump). The same command on a *trashed* project un-trashes it — so the identical statement is either a restore or a no-op depending on state the caller may not know, with no signal distinguishing the two. *(P06/P09, 2026-07-06)*
 
+### 2g. `update?completion-date=` / `creation-date=` are silently ignored — while the json importer honors the same attributes
+`things:///update?id=<uuid>&auth-token=<t>&completion-date=2025-01-15` (and `creation-date=`) on a completed to-do changes nothing — no error, no modal, zero delta; `completed=true` in the same command class works. Meanwhile `things:///json` **add** honors `creation-date`/`completion-date` attributes exactly (row created with the given epoch values). The parameter names parse somewhere (no unknown-parameter error either way), the write path just drops them on update. *(scf2 P4c/P4d, 2026-07-09)*
+
 ---
 
 ### 2d. Reminder times with bare hours 1–11 are silently reinterpreted (am/pm heuristic)
@@ -138,7 +141,11 @@ Running a Things Shortcuts action prompts a per-shortcut Shortcuts-Privacy dialo
 
 ### 5k. Shortcuts `Edit Items` reports success even when the edit silently fails
 
-`shortcuts run` exits 0 and the shortcut completes "successfully" even when the `Edit Items` action changed nothing: setting `Parent` on a heading echoes the item back with zero DB delta (scf P2), and setting `Reminder Time` from a plain `"14:30"` text value silently fails to coerce and writes nothing (scf P3a). When the action fails internally it may also produce NO output at all while still exiting 0 (scf P4) — an automation caller gets no error channel whatsoever; the only truth is re-reading the data. *(scf run, 2026-07-09)*
+`shortcuts run` exits 0 and the shortcut completes "successfully" even when the `Edit Items` action changed nothing: setting `Parent` on a heading echoes the item back with zero DB delta (scf P2), and setting `Reminder Time` from a plain `"14:30"` text value silently fails to coerce and writes nothing (scf P3a). When the action fails internally it may also produce NO output at all while still exiting 0 (scf P4) — an automation caller gets no error channel whatsoever; the only truth is re-reading the data. Round 2 widened the blast radius: EVERY date/time-valued detail write fails this way (Completion Date and Creation Date in five formats, Reminder Time in three — scf2 P4a/P3a). *(scf runs, 2026-07-09)*
+
+### 5l. Shortcuts `Edit Items → Parent` with a text value DETACHES the item instead of erroring
+
+Setting the `Parent` detail to a project uuid passed as TEXT does not move the to-do and does not error — it silently CLEARS the to-do's project link (`project` → NULL), leaving the item container-less. The text→entity coercion fails and the action writes the empty result. On a heading row the same call is a pure no-op (project unchanged) — two different silent-failure behaviors for one action depending on row type. A destructive wrong-action with exit 0 is the worst of the silent-failure family: the caller asked for a move and got a detach. *(scf P2 / scf2 P2b, 2026-07-09)*
 
 ---
 

--- a/lab/scripts/research-scf2.sh
+++ b/lab/scripts/research-scf2.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+# S-campaign follow-ups, round 2 (docs/lab/probe-backlog.md §A round 2). ONE clone.
+#   P4  Completion/Creation backdating — redo with a PROPERLY completed fixture
+#       (AS status write, verified in DB) across THREE surfaces: Shortcuts
+#       set-detail (several date-string shapes), AppleScript property writes,
+#       URL update WITH the auth token; plus json at-creation attributes.
+#   P3a set-detail Reminder Time format experiments on a scheduled to-do.
+#   P2b set-detail Parent on a TO-DO (heading variant was a silent no-op).
+#   P6  sidebar-order spelling sweep (Mike's Anytime↔sidebar mirror insight):
+#       move-project location specifier, set index, private reorder with AREA
+#       uuids in list "Anytime", list "Someday" to-dos, sdef private-command grep.
+# Harness fixes from round 1: proxy() clears the stale --output-path file;
+# completion never goes through a token-less update URL. Discovery: no assertions.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+source lab/scripts/env.sh
+
+VM="things-run-scf2-$(date +%Y%m%d-%H%M%S)"
+OUT="lab/artifacts/$VM"; mkdir -p "$OUT"
+REPORT="$OUT/report.txt"
+note() { echo "[scf2] $*" | tee -a "$REPORT"; }
+cleanup() { echo "[scf2] teardown: $VM"; tart stop "$VM" >/dev/null 2>&1 || true; tart delete "$VM" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+# Seed uuids (docs/lab/seed-manifest.json).
+PROJ_PLAIN="933TCvzMgM3MLvpKPcjheC"   # project in LAB-AREA-A
+PROJ_MIXED="Mnwp9RvB4yAB8G5cmhkukZ"   # project in LAB-AREA-B
+AREA_A="7Ck4hAXU36jyaBsy2Fkije"
+AREA_B="2piYxp6UzasLDSvkwY747J"
+SOMEDAY_1="U9Ho5HiBsXAfEVte9rrPm2"    # LAB-SOMEDAY-1
+
+note "cloning golden -> $VM"
+tart clone things-lab-golden-v1 "$VM"
+(tart run "$VM" --no-graphics >"$OUT/tart-run.log" 2>&1 &)
+IP=$(lab_wait_for_ssh "$VM" 300)
+note "ssh up at $IP"
+lab_ssh "$IP" 'sudo route -n delete default >/dev/null 2>&1 || true'
+lab_ssh "$IP" 'ping -c1 -t2 1.1.1.1 >/dev/null 2>&1 && exit 1 || exit 0'
+lab_ssh "$IP" 'sudo systemsetup -setusingnetworktime off >/dev/null 2>&1; sudo date 070512002026 >/dev/null'
+lab_ssh "$IP" 'cat > /tmp/gsql.sh && chmod +x /tmp/gsql.sh' <<'EOF'
+#!/bin/bash
+FMT=(-header -column); if [ "$1" = "-q" ]; then FMT=(-noheader -list); shift; fi
+DB=$(echo ~/Library/Group\ Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-*/Things\ Database.thingsdatabase/main.sqlite)
+exec sqlite3 "${FMT[@]}" "file:$DB?mode=ro" "$1"
+EOF
+gsql() { lab_ssh "$IP" "/tmp/gsql.sh $(printf '%q' "$1")"; }
+gq() { lab_ssh "$IP" "/tmp/gsql.sh -q $(printf '%q' "$1")"; }
+gas() { lab_ssh "$IP" "osascript -e $(printf '%q' "$1") 2>&1" || true; }
+gurl() { lab_ssh "$IP" "open -g $(printf '%q' "$1")"; sleep 2; }
+proxy() { # proxy <name> <json>  (deadline-wrapped; STALE OUTPUT CLEARED each run)
+  note "-- shortcuts run $1  $2"
+  lab_ssh "$IP" "printf '%s' $(printf '%q' "$2") > /tmp/scf-in.json; rm -f /tmp/scf-out.txt; perl -e 'alarm 60; exec @ARGV' shortcuts run $(printf '%q' "$1") --input-path /tmp/scf-in.json --output-path /tmp/scf-out.txt 2>&1; echo \"[exit \$?]\"; cat /tmp/scf-out.txt 2>/dev/null; echo" 2>&1 | tee -a "$REPORT" || true
+  sleep 1
+}
+uuid_of() { local t="$1" typ="${2:-}" w="title='$1' AND trashed=0" u i; [ -n "$typ" ] && w="$w AND type=$typ"; for i in $(seq 1 12); do u=$(gq "SELECT uuid FROM TMTask WHERE $w ORDER BY creationDate DESC LIMIT 1"); [ -n "$u" ] && { echo "$u"; return 0; }; sleep 1; done; return 1; }
+
+note "warm-up: launch Things, quit, relaunch"
+lab_ssh "$IP" 'open -g -a Things3; sleep 12'
+lab_ssh "$IP" 'osascript -e "tell application \"Things3\" to quit"; sleep 3'
+lab_ssh "$IP" 'open -g -a Things3; sleep 8'
+
+TOKEN=$(gq "SELECT uriSchemeAuthenticationToken FROM TMSettings LIMIT 1")
+note "auth token in hand (${#TOKEN} chars)"
+gupd() { gurl "things:///update?id=$1&auth-token=$TOKEN&$2"; }
+
+bd_row() { gsql "SELECT title, status, stopDate, datetime(stopDate,'unixepoch') AS stop_h, datetime(creationDate,'unixepoch') AS created_h FROM TMTask WHERE uuid='$1'" | tee -a "$REPORT"; }
+
+# ============================== P4a — backdating via Shortcuts set-detail
+note "== [P4a] backdating via set-detail (fixture completed via AppleScript, VERIFIED) =="
+gurl "things:///add?title=SCF2-BD-SC"
+BD1=$(uuid_of "SCF2-BD-SC" 0)
+gas "tell application \"Things3\" to set status of to do id \"$BD1\" to completed" | tee -a "$REPORT"
+sleep 1
+note "-- pre (MUST show completed + a 2026 stopDate before the probes mean anything):"
+bd_row "$BD1"
+for v in "1/15/2025" "January 15, 2025" "2025-01-15"; do
+  proxy things-proxy-set-detail "{\"id\":\"$BD1\",\"detail\":\"Completion Date\",\"value\":\"$v\"}"
+  note "-- after Completion Date <- '$v':"; bd_row "$BD1"
+done
+for v in "6/1/2024" "June 1, 2024"; do
+  proxy things-proxy-set-detail "{\"id\":\"$BD1\",\"detail\":\"Creation Date\",\"value\":\"$v\"}"
+  note "-- after Creation Date <- '$v':"; bd_row "$BD1"
+done
+
+# ============================== P4b — backdating via AppleScript property writes
+note "== [P4b] backdating via AppleScript 'completion date' / 'creation date' properties =="
+gurl "things:///add?title=SCF2-BD-AS"
+BD2=$(uuid_of "SCF2-BD-AS" 0)
+gas "tell application \"Things3\" to set status of to do id \"$BD2\" to completed" | tee -a "$REPORT"
+sleep 1
+note "-- pre:"; bd_row "$BD2"
+note "-- set completion date to (current date) - 200 days (~2025-12-17, locale-proof):"
+gas "tell application \"Things3\" to set completion date of to do id \"$BD2\" to ((current date) - (200 * days))" | tee -a "$REPORT"
+sleep 1; bd_row "$BD2"
+note "-- set creation date to (current date) - 400 days (~2025-06-01):"
+gas "tell application \"Things3\" to set creation date of to do id \"$BD2\" to ((current date) - (400 * days))" | tee -a "$REPORT"
+sleep 1; bd_row "$BD2"
+
+# ============================== P4c — backdating via URL update (WITH token)
+note "== [P4c] backdating via URL update?completion-date= (auth token attached) =="
+gurl "things:///add?title=SCF2-BD-URL"
+BD3=$(uuid_of "SCF2-BD-URL" 0)
+gupd "$BD3" "completed=true"
+note "-- pre (completed via tokened update URL — also re-validates the P4 bug diagnosis):"
+bd_row "$BD3"
+gupd "$BD3" "completion-date=2025-01-15"
+note "-- after update?completion-date=2025-01-15:"; bd_row "$BD3"
+gupd "$BD3" "creation-date=2024-06-01"
+note "-- after update?creation-date=2024-06-01:"; bd_row "$BD3"
+
+# ============================== P4d — backdating AT CREATION via things:///json
+note "== [P4d] at-creation backdating via things:///json attributes =="
+JSON_URL=$(python3 - <<'PY'
+import json, urllib.parse
+data = [{"type":"to-do","attributes":{"title":"SCF2-BD-JSON","completed":True,
+  "creation-date":"2024-06-01T08:00:00Z","completion-date":"2025-01-15T09:00:00Z"}}]
+print("things:///json?data=" + urllib.parse.quote(json.dumps(data), safe=""))
+PY
+)
+gurl "$JSON_URL"
+BD4=$(uuid_of "SCF2-BD-JSON" 0 || true)
+note "-- row (did creation/completion-date attrs stick?):"
+[ -n "${BD4:-}" ] && bd_row "$BD4" || note "   (row never appeared — json add rejected?)"
+
+# ============================== P3a — Reminder Time set, format experiments
+note "== [P3a] set-detail Reminder Time formats on a SCHEDULED to-do (expect hour<<26|min<<20) =="
+gurl "things:///add?title=SCF2-REM&when=today"
+RM=$(uuid_of "SCF2-REM" 0)
+rem_row() { gsql "SELECT title, start, startDate, reminderTime FROM TMTask WHERE uuid='$RM'" | tee -a "$REPORT"; }
+note "-- pre:"; rem_row
+for v in "2:30 PM" "14:30" "7/5/2026 2:30 PM"; do
+  proxy things-proxy-set-detail "{\"id\":\"$RM\",\"detail\":\"Reminder Time\",\"value\":\"$v\"}"
+  note "-- after Reminder Time <- '$v' (14:30 = 970981376):"; rem_row
+done
+
+# ============================== P2b — set-detail Parent on a TO-DO
+note "== [P2b] set-detail Parent: re-parent a TO-DO between projects =="
+gurl "things:///add?title=SCF2-RP&list-id=$PROJ_PLAIN"
+RP=$(uuid_of "SCF2-RP" 0)
+note "-- pre (project should be $PROJ_PLAIN):"
+gsql "SELECT title, project, area FROM TMTask WHERE uuid='$RP'" | tee -a "$REPORT"
+proxy things-proxy-set-detail "{\"id\":\"$RP\",\"detail\":\"Parent\",\"value\":\"$PROJ_MIXED\"}"
+note "-- post (moved to $PROJ_MIXED?):"
+gsql "SELECT title, project, area FROM TMTask WHERE uuid='$RP'" | tee -a "$REPORT"
+
+# ============================== P6 — sidebar-order spelling sweep
+note "== [P6] sidebar order: untried spellings (O13 move-area + P17 anytime-projects are dead) =="
+note "-- sdef sweep: every _private_ command + any writable index property:"
+lab_ssh "$IP" 'sdef /Applications/Things3.app 2>/dev/null | grep -o "command name=\"[^\"]*\"" | sort -u' | tee -a "$REPORT"
+lab_ssh "$IP" 'sdef /Applications/Things3.app 2>/dev/null | grep -n "property name=\"index\"" | head -5' | tee -a "$REPORT"
+
+gurl "things:///add-project?title=SCF2-TOP-A"
+gurl "things:///add-project?title=SCF2-TOP-B"
+TA=$(uuid_of "SCF2-TOP-A" 1); TB=$(uuid_of "SCF2-TOP-B" 1)
+top_rows() { gsql "SELECT uuid, title, \"index\" FROM TMTask WHERE type=1 AND area IS NULL AND trashed=0 AND status=0 ORDER BY \"index\"" | tee -a "$REPORT"; }
+area_rows() { gsql "SELECT uuid, title, \"index\" FROM TMArea ORDER BY \"index\"" | tee -a "$REPORT"; }
+note "-- pre, top-level projects:"; top_rows
+
+note "-- [P6a] AppleScript move project to BEFORE another project (location specifier):"
+gas "tell application \"Things3\" to move project id \"$TA\" to before project id \"$TB\"" | tee -a "$REPORT"
+sleep 1; top_rows
+note "-- [P6b] AppleScript move project to BEGINNING of projects:"
+gas "tell application \"Things3\" to move project id \"$TA\" to beginning of projects" | tee -a "$REPORT"
+sleep 1; top_rows
+note "-- [P6c] set index of project (probe the property write):"
+gas "tell application \"Things3\" to set index of project id \"$TA\" to 1" | tee -a "$REPORT"
+sleep 1; top_rows
+note "-- [P6d] private reorder, top-level PROJECT uuids in list \"Anytime\" (P17 re-check with fresh fixtures):"
+gas "tell application \"Things3\" to _private_experimental_ reorder to dos in list \"Anytime\" with ids \"$TB,$TA\"" | tee -a "$REPORT"
+sleep 1; top_rows
+
+note "-- pre, areas:"; area_rows
+note "-- [P6e] private reorder, AREA uuids in list \"Anytime\":"
+gas "tell application \"Things3\" to _private_experimental_ reorder to dos in list \"Anytime\" with ids \"$AREA_B,$AREA_A\"" | tee -a "$REPORT"
+sleep 1; area_rows
+note "-- [P6f] AppleScript move area spellings (O13 was 'to before area'; try beginning):"
+gas "tell application \"Things3\" to move area id \"$AREA_B\" to beginning of areas" | tee -a "$REPORT"
+sleep 1; area_rows
+note "-- [P6g] set index of area:"
+gas "tell application \"Things3\" to set index of area id \"$AREA_B\" to 1" | tee -a "$REPORT"
+sleep 1; area_rows
+
+note "-- [P6h] private reorder in list \"Someday\" (to-do uuids — does the Someday scope exist?):"
+gurl "things:///add?title=SCF2-SOME&when=someday"
+SM=$(uuid_of "SCF2-SOME" 0)
+gsql "SELECT uuid, title, start, \"index\" FROM TMTask WHERE uuid IN ('$SM','$SOMEDAY_1')" | tee -a "$REPORT"
+gas "tell application \"Things3\" to _private_experimental_ reorder to dos in list \"Someday\" with ids \"$SM,$SOMEDAY_1\"" | tee -a "$REPORT"
+sleep 1
+gsql "SELECT uuid, title, start, \"index\" FROM TMTask WHERE uuid IN ('$SM','$SOMEDAY_1')" | tee -a "$REPORT"
+
+note "== copying DB out =="
+lab_ssh "$IP" 'DB=$(echo ~/Library/Group\ Containers/JLMPQHK86H.com.culturedcode.ThingsMac/ThingsData-*/Things\ Database.thingsdatabase/main.sqlite); sqlite3 "$DB" ".backup /tmp/scf2.sqlite"'
+lab_scp "$LAB_SSH_USER@$IP:/tmp/scf2.sqlite" "$OUT/final.sqlite" || true
+note "GREEN — report: $REPORT"
+trap - EXIT; cleanup


### PR DESCRIPTION
Banks the scf2 re-probe run (`things-run-scf2-20260709-045454`) — see s-campaign-results.md round 2.

## Headlines
- **Backdating existing items: UNLOCKED, AppleScript-only** — `set completion date` / `set creation date` property writes work (P4b). URL update date params silently ignored (new oddity 2g); Shortcuts set-detail dead in every format (P4a).
- **Backdated logbook import: UNLOCKED via `things:///json`** — at-creation `creation-date`/`completion-date` attrs honored exactly (P4d). The GTD-migration path.
- **Sidebar ordering: exhaustively closed as UI-only** (P6a–g) — every move-to-location spelling errors (−1700), `set index` is read-only (−10006), the sole private command no-ops on both project and area uuids in Anytime scope, and the host sdef contains exactly ONE private command.
- **Someday is a NEW native reorder scope** (P6h) — reversed-wire convention like Inbox; lock with a 3-item probe before wiring the op.
- **Oddity 5l (destructive footgun)**: Shortcuts `Edit Items → Parent` with a text value DETACHES the to-do from its project instead of moving it, exit 0.
- Reminder Time via set-detail is clear-only — cannot set in any format (P3a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiiUK4qXABDtVKoW7S9Cft