### PR TITLE
feat(views): anytime/someday container cascade + sidebar grouping; CLI render polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Anytime/Someday view semantics + CLI list polish
+
+- **Anytime container cascade (fix)**: children of projects that are not themselves anytime-visible (someday, future-scheduled, logged, or trashed) no longer appear in `anytime` — the project row represents them, matching the app. Heading-contained children resolve their project through the heading link.
+- **Sidebar-grouped anytime/someday**: both views now return sidebar-ordered sections (area + items; the area-less block first, direct to-dos before each project block) — the same order the app shows in Anytime and the sidebar. The CLI renders one `── <area> ──` header per area; `--json` envelopes and the MCP `read_view` tool carry the new sectioned shape.
+- **`things someday --active-project-items`** (MCP: `read_view {active_project_items}`): also lists someday to-dos inside active projects — the app's "Show items from active projects" toggle. By default someday shows only container-less members and someday project rows, as the app does.
+- **CLI list rendering**: the uuid column pads to the longest uuid in the list (Things uuids vary 21–22 chars), token spacing after the `-`/`P` marker is uniform (previously the gap depended on whether dates/tags were present), and metadata is colorized when stdout is a TTY (deadline red, date yellow, tags cyan, uuid/context dim, area headers bold; `NO_COLOR`/`FORCE_COLOR` honored). Piped output contains no escape codes.
+
+
 ### New write capabilities (Phase 21b)
 
 Grounded in the Phase 21b lab probe campaign ([docs/lab/phase21b-research.md](docs/lab/phase21b-research.md)).

--- a/src/cli/commands/project.ts
+++ b/src/cli/commands/project.ts
@@ -7,31 +7,41 @@ import type { ProjectView } from "../../read/project-view.ts";
 import { formatItem, withClient } from "./reads.ts";
 
 function renderProjectView(view: ProjectView): string[] {
+  const everyItem = [
+    ...view.active,
+    ...view.headings.flatMap((g) => g.items),
+    ...view.later.scheduled.flatMap((d) => d.items),
+    ...view.later.repeating,
+    ...view.later.someday,
+    ...view.logged.slice(0, 10),
+  ];
+  const w = everyItem.reduce((max, i) => Math.max(max, i.uuid.length), 0);
+  const fmt = (i: (typeof everyItem)[number]) => formatItem(i, w);
   const lines: string[] = [
     `${view.project.uuid}  ${view.project.title}`,
     `  area: ${view.project.area?.title ?? "—"}  open: ${view.project.openUntrashedLeafActionsCount}/${view.project.untrashedLeafActionsCount}`,
   ];
-  lines.push("── Active ──", ...(view.active.length ? view.active.map(formatItem) : ["(none)"]));
+  lines.push("── Active ──", ...(view.active.length ? view.active.map(fmt) : ["(none)"]));
   for (const group of view.headings) {
     lines.push(
       `── ${group.heading.title} ──`,
-      ...(group.items.length ? group.items.map(formatItem) : ["(none)"]),
+      ...(group.items.length ? group.items.map(fmt) : ["(none)"]),
     );
   }
   if (view.later.scheduled.length || view.later.repeating.length || view.later.someday.length) {
     lines.push("── Later ──");
     for (const day of view.later.scheduled) {
-      lines.push(`  ${day.date}:`, ...day.items.map(formatItem));
+      lines.push(`  ${day.date}:`, ...day.items.map(fmt));
     }
     if (view.later.repeating.length) {
-      lines.push("  repeating templates:", ...view.later.repeating.map(formatItem));
+      lines.push("  repeating templates:", ...view.later.repeating.map(fmt));
     }
     if (view.later.someday.length) {
-      lines.push("  someday:", ...view.later.someday.map(formatItem));
+      lines.push("  someday:", ...view.later.someday.map(fmt));
     }
   }
   if (view.logged.length)
-    lines.push(`── Logged (${view.logged.length}) ──`, ...view.logged.slice(0, 10).map(formatItem));
+    lines.push(`── Logged (${view.logged.length}) ──`, ...view.logged.slice(0, 10).map(fmt));
   if (view.trashed.length) lines.push(`── Trashed (${view.trashed.length}) ──`);
   return lines;
 }

--- a/src/cli/commands/reads.ts
+++ b/src/cli/commands/reads.ts
@@ -90,7 +90,7 @@ export function formatItem(item: ListItem, uuidWidth = 0): string {
     `${dim(item.uuid.padEnd(uuidWidth))} `,
     marker,
     ...meta,
-    `${item.title}${dim(context)}`,
+    context === "" ? item.title : `${item.title}${dim(context)}`,
   ].join(" ");
 }
 

--- a/src/cli/commands/reads.ts
+++ b/src/cli/commands/reads.ts
@@ -7,7 +7,8 @@ import type { Command } from "commander";
 import { openThings, type ThingsClient } from "../../client.ts";
 import { ThingsDbNotFoundError } from "../../db/locate.ts";
 import { ThingsDbOpenError } from "../../db/connection.ts";
-import { isTodayMember, type ListItem } from "../../read/views.ts";
+import { isTodayMember, type ListItem, type SidebarSection } from "../../read/views.ts";
+import { bold, cyan, dim, magenta, red, yellow } from "../style.ts";
 
 import { errorEnvelope, ExitCode, okEnvelope, type EnvelopeMeta } from "../../contracts.ts";
 
@@ -65,36 +66,71 @@ export function withClient(
   }
 }
 
-export function formatItem(item: ListItem): string {
-  const marks = [
-    item.type === "project" ? "P" : "-",
-    item.repeating.isTemplate ? "↻" : null,
-    item.deadline ? `!${item.deadline}` : null,
-    item.startDate ? `@${item.startDate}` : null,
-    item.tags.length > 0 ? `#${item.tags.map((t) => t.title).join(",#")}` : null,
-    item.status !== "open" ? `[${item.status}]` : null,
-  ]
-    .filter(Boolean)
-    .join(" ");
+/**
+ * One item line: `<uuid>  <marker> [meta …] <title> (container)`. The uuid
+ * column pads to `uuidWidth` (uuids vary 21–22 chars) so the marker column
+ * aligns; exactly one space separates every following token. Meta tokens are
+ * colorized on a TTY only (see ../style.ts) — piped output stays plain.
+ */
+export function formatItem(item: ListItem, uuidWidth = 0): string {
+  const marker = (item.type === "project" ? "P" : "-") + (item.repeating.isTemplate ? "↻" : "");
+  const meta = [
+    item.deadline ? red(`!${item.deadline}`) : null,
+    item.startDate ? yellow(`@${item.startDate}`) : null,
+    item.tags.length > 0 ? cyan(`#${item.tags.map((t) => t.title).join(",#")}`) : null,
+    item.status !== "open" ? magenta(`[${item.status}]`) : null,
+  ].filter((s): s is string => s !== null);
   const context =
     item.type === "to-do" && item.project
       ? ` (${item.project.title})`
       : item.area
         ? ` (${item.area.title})`
         : "";
-  return `${item.uuid}  ${marks.padEnd(2)} ${item.title}${context}`;
+  return [
+    `${dim(item.uuid.padEnd(uuidWidth))} `,
+    marker,
+    ...meta,
+    `${item.title}${dim(context)}`,
+  ].join(" ");
+}
+
+function uuidWidth(items: ListItem[]): number {
+  return items.reduce((w, i) => Math.max(w, i.uuid.length), 0);
 }
 
 function renderList(items: ListItem[]): string[] {
-  return items.length === 0 ? ["(empty)"] : items.map(formatItem);
+  const w = uuidWidth(items);
+  return items.length === 0 ? ["(empty)"] : items.map((i) => formatItem(i, w));
+}
+
+/**
+ * Sidebar-grouped views (anytime/someday): the area-less block renders
+ * headerless first, then one `── <area> ──` header per area, mirroring the
+ * app's layout. `star` prefixes each line with the Today-membership star.
+ */
+function renderSections(sections: SidebarSection[], star = false): string[] {
+  const all = sections.flatMap((s) => s.items);
+  if (all.length === 0) return ["(empty)"];
+  const w = uuidWidth(all);
+  const lines: string[] = [];
+  for (const section of sections) {
+    if (section.area !== null) lines.push(bold(`── ${section.area.title} ──`));
+    for (const item of section.items) {
+      const prefix = star ? `${isTodayMember(item) ? yellow("★") : " "} ` : "";
+      lines.push(`${prefix}${formatItem(item, w)}`);
+    }
+  }
+  return lines;
 }
 
 export function registerReadCommands(program: Command): void {
   const listCommands: Array<{
     name: string;
     description: string;
-    fetch: (client: ThingsClient, tag?: string, exactTag?: boolean) => unknown;
+    fetch: (client: ThingsClient, tag?: string, exactTag?: boolean, extra?: boolean) => unknown;
     render?: (data: never) => string[];
+    /** One extra boolean option: [flags, description, opts-key]. */
+    extraOption?: [string, string, string];
   }> = [
     {
       name: "today",
@@ -126,28 +162,39 @@ export function registerReadCommands(program: Command): void {
     {
       name: "anytime",
       description:
-        "All active items, mirroring the UI: Today members are starred (★), unscheduled items are not",
+        "All active items in the UI's sidebar-mirroring order (area-less first, then per " +
+        "area: direct to-dos, then each project with its members). Today members are " +
+        "starred (★). Children of someday/future-scheduled projects are excluded — the " +
+        "project row represents them",
       fetch: (c, tag, exactTag) =>
         c.read.anytime(
           tag === undefined ? undefined : { tag, ...(exactTag === true && { exactTag }) },
         ),
-      render: (items: ListItem[]) =>
-        items.length === 0
-          ? ["(empty)"]
-          : items.map((i) => `${isTodayMember(i) ? "★" : " "} ${formatItem(i)}`),
+      render: (sections: SidebarSection[]) => renderSections(sections, true),
     },
     {
       name: "someday",
-      description: "Someday items (incubated, undated)",
-      fetch: (c, tag, exactTag) =>
-        c.read.someday(
-          tag === undefined ? undefined : { tag, ...(exactTag === true && { exactTag }) },
-        ),
+      description:
+        "Someday items (incubated, undated) in sidebar order. Project children are " +
+        "represented by their project row; --active-project-items also lists someday " +
+        "to-dos inside active projects (the UI's 'Show items from active projects' toggle)",
+      fetch: (c, tag, exactTag, activeProjectItems) =>
+        c.read.someday({
+          ...(tag !== undefined && { tag }),
+          ...(exactTag === true && { exactTag }),
+          ...(activeProjectItems === true && { activeProjectItems }),
+        }),
+      render: (sections: SidebarSection[]) => renderSections(sections),
+      extraOption: [
+        "--active-project-items",
+        "also list someday to-dos inside active projects",
+        "activeProjectItems",
+      ],
     },
   ];
 
   for (const cmd of listCommands) {
-    program
+    const command = program
       .command(cmd.name)
       .description(cmd.description)
       .option(
@@ -156,15 +203,19 @@ export function registerReadCommands(program: Command): void {
       )
       .option("--exact-tag", "match the named tag only — exclude hierarchy descendants")
       .option("--json", "emit versioned JSON envelope on stdout")
-      .option("--db <path>", "explicit database path")
-      .action((opts: GlobalReadOpts & { tag?: string; exactTag?: boolean }) => {
+      .option("--db <path>", "explicit database path");
+    if (cmd.extraOption) command.option(cmd.extraOption[0], cmd.extraOption[1]);
+    command.action(
+      (opts: GlobalReadOpts & { tag?: string; exactTag?: boolean } & Record<string, unknown>) => {
+        const extra = cmd.extraOption ? opts[cmd.extraOption[2]] === true : undefined;
         withClient(
           opts,
           cmd.name,
-          (c) => cmd.fetch(c, opts.tag, opts.exactTag),
+          (c) => cmd.fetch(c, opts.tag, opts.exactTag, extra),
           (cmd.render ?? renderList) as (d: never) => string[],
         );
-      });
+      },
+    );
   }
 
   program

--- a/src/cli/style.ts
+++ b/src/cli/style.ts
@@ -1,0 +1,26 @@
+/**
+ * ANSI styling for the human-readable CLI output. Colors engage only when
+ * stdout is a TTY, so piped/captured output (agents, scripts, tests) stays
+ * plain text with zero escape bytes. `NO_COLOR` (any value) always disables;
+ * `FORCE_COLOR` (any value except "0") enables even when piped. Only the
+ * base 16-color palette is used — terminals remap those per theme, so both
+ * light and dark backgrounds stay readable.
+ */
+function colorEnabled(): boolean {
+  if (process.env["NO_COLOR"] !== undefined) return false;
+  const force = process.env["FORCE_COLOR"];
+  if (force !== undefined) return force !== "0";
+  return process.stdout.isTTY === true;
+}
+
+const ENABLED = colorEnabled();
+
+const wrap = (open: number, close: number) => (s: string) =>
+  ENABLED ? `\u001b[${open}m${s}\u001b[${close}m` : s;
+
+export const bold = wrap(1, 22);
+export const dim = wrap(2, 22);
+export const red = wrap(31, 39);
+export const yellow = wrap(33, 39);
+export const magenta = wrap(35, 39);
+export const cyan = wrap(36, 39);

--- a/src/client.ts
+++ b/src/client.ts
@@ -30,6 +30,8 @@ import {
   type ChangedItem,
   type ListItem,
   type SearchOptions,
+  type SidebarSection,
+  type SomedayFilter,
   type TodayView,
   type UpcomingFilter,
   type ViewFilter,
@@ -98,9 +100,9 @@ export interface ThingsClient {
   read: {
     today(filter?: ViewFilter): TodayView;
     inbox(filter?: ViewFilter): ListItem[];
-    anytime(filter?: ViewFilter): ListItem[];
+    anytime(filter?: ViewFilter): SidebarSection[];
     upcoming(filter?: UpcomingFilter): ListItem[];
-    someday(filter?: ViewFilter): ListItem[];
+    someday(filter?: SomedayFilter): SidebarSection[];
     logbook(options?: { limit?: number; tag?: string; exactTag?: boolean }): ListItem[];
     trash(options?: { limit?: number }): ListItem[];
     projects(options?: { areaUuid?: string }): Project[];
@@ -345,7 +347,7 @@ export function openThings(options: OpenOptions = {}): ThingsClient {
       inbox: (f) => inboxView(conn.db, f),
       anytime: (f) => anytimeView(conn.db, now(), f),
       upcoming: (f) => upcomingView(conn.db, now(), f),
-      someday: (f) => somedayView(conn.db, f),
+      someday: (f) => somedayView(conn.db, now(), f),
       logbook: (o) => logbookView(conn.db, o),
       trash: (o) => trashView(conn.db, o),
       projects: (o) => projectsView(conn.db, o),

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,13 @@ export type { McpServerOptions } from "./mcp/server.ts";
 export type { UndoItemResult, UndoOptions, UndoPlan, UndoStep } from "./write/undo.ts";
 export type { BatchItemResult, BatchOp, BatchOptions } from "./write/batch.ts";
 export type { ReorderResult } from "./write/reorder.ts";
-export type { SearchOptions, UpcomingFilter, ViewFilter, ChangedItem } from "./read/views.ts";
+export type {
+  SearchOptions,
+  SomedayFilter,
+  UpcomingFilter,
+  ViewFilter,
+  ChangedItem,
+} from "./read/views.ts";
 
 export type {
   Acknowledgements,
@@ -92,7 +98,7 @@ export type {
   TodaySection,
 } from "./model/entities.ts";
 export type { IsoDate } from "./model/dates.ts";
-export type { ListItem, TodayView } from "./read/views.ts";
+export type { ListItem, SidebarSection, TodayView } from "./read/views.ts";
 export type { ProjectView } from "./read/project-view.ts";
 export { ProjectNotFoundError } from "./read/project-view.ts";
 export { ThingsDbNotFoundError } from "./db/locate.ts";

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -221,10 +221,17 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
       description:
         "Read a Things list as the app presents it: today (split into Today and This " +
         "Evening), inbox, anytime, upcoming, someday, logbook, or trash. For upcoming, " +
-        "horizon > 1 also includes future occurrences of repeating items (up to 10 each).",
+        "horizon > 1 also includes future occurrences of repeating items (up to 10 each). " +
+        "anytime/someday return sidebar-ordered sections (area + items; null area = the " +
+        "top-level block); children of someday/future-scheduled projects are excluded " +
+        "from anytime — the project row represents them.",
       inputSchema: {
         view: z.enum(["today", "inbox", "anytime", "upcoming", "someday", "logbook", "trash"]),
         ...tagFilterShape,
+        active_project_items: z
+          .boolean()
+          .optional()
+          .describe("someday only: also list someday to-dos inside active projects"),
         horizon: z
           .number()
           .int()
@@ -258,7 +265,12 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
               }),
             );
           case "someday":
-            return jsonResult(c.read.someday(filter));
+            return jsonResult(
+              c.read.someday({
+                ...filter,
+                ...(args.active_project_items === true && { activeProjectItems: true }),
+              }),
+            );
           case "logbook":
             return jsonResult(
               c.read.logbook({ ...filter, ...(args.limit !== undefined && { limit: args.limit }) }),

--- a/src/read/views.ts
+++ b/src/read/views.ts
@@ -25,12 +25,20 @@
  *             renders Today members with a star; live-verified via screenshot
  *             2026-07-02: starred = in Today, unstarred = unscheduled).
  *             Star equivalence: startDate != NULL && <= today.
+ *             CONTAINER CASCADE (live-verified 2026-07-09): children of a
+ *             project that is not itself anytime-visible (someday/future/
+ *             logged/trashed) are excluded — the project row represents
+ *             them. Result is grouped in sidebar order (SidebarSection[]).
  * - upcoming: start=2 AND startDate > today, PLUS each fixed repeating
  *             template's next occurrence synthesized from
  *             rt1_nextInstanceStartDate (UI parity; opt out via
  *             repeats:false). Occurrence deadline = start − rule.ts
  *             (instance-validated 2026-07-04).
- * - someday:  start=2 AND startDate IS NULL
+ * - someday:  start=2 AND startDate IS NULL, container-less members only
+ *             (project children appear ONLY via the activeProjectItems
+ *             toggle, and only for anytime-active projects — mirrors the
+ *             UI's "Show items from active projects"). Grouped in sidebar
+ *             order like anytime.
  * - logbook:  status IN (2,3), by stopDate DESC
  * - trash:    trashed=1
  *
@@ -40,7 +48,7 @@
 import type { DatabaseSync } from "node:sqlite";
 
 import { addDaysIso, encodePackedDate, localToday } from "../model/dates.ts";
-import type { Project, Todo } from "../model/entities.ts";
+import type { Project, Ref, Todo } from "../model/entities.ts";
 import { mapProject, mapTodo, type TaskRow } from "../model/mappers.ts";
 import { projectOccurrences } from "../model/occurrences.ts";
 import { decodeRecurrenceRule } from "../model/recurrence.ts";
@@ -157,20 +165,153 @@ export function inboxView(db: DatabaseSync, filter?: ViewFilter): ListItem[] {
   return materialize(db, rows);
 }
 
-export function anytimeView(db: DatabaseSync, now?: Date, filter?: ViewFilter): ListItem[] {
+/**
+ * One sidebar-ordered block of a grouped view (anytime/someday): the area
+ * (null = the top-level, area-less block, which the UI renders first) and its
+ * members in UI order — direct to-dos first, then each project block (the
+ * project row immediately followed by its member to-dos).
+ */
+export interface SidebarSection {
+  area: Ref | null;
+  items: ListItem[];
+}
+
+/** An item's own anytime membership: unscheduled-active, or dated <= today. */
+const ANYTIME_SELF = (col: string) =>
+  `((${col}.start = 1 AND (${col}.startDate IS NULL OR ${col}.startDate <= ?))
+    OR (${col}.start = 2 AND ${col}.startDate IS NOT NULL AND ${col}.startDate <= ?))`;
+
+/**
+ * The item's effective project: its own link, or its heading's project for
+ * headed children (heading rows carry the project link).
+ */
+const EFF_PROJECT = `COALESCE(t.project, (SELECT h.project FROM TMTask h WHERE h.uuid = t.heading))`;
+
+/**
+ * Container cascade (live-verified against the UI, 2026-07-09): a to-do
+ * inside a project that is NOT itself anytime-visible (someday or
+ * future-scheduled, logged, or trashed) is absent from Anytime regardless of
+ * the to-do's own start state — the project row alone represents it.
+ * Projects and container-less to-dos pass through. Two binds (packedToday ×2).
+ */
+const PROJECT_ANYTIME_ACTIVE = `(${EFF_PROJECT} IS NULL OR EXISTS (
+     SELECT 1 FROM TMTask p WHERE p.uuid = ${EFF_PROJECT}
+     AND p.trashed = 0 AND p.status = 0 AND ${ANYTIME_SELF("p")}))`;
+
+export function anytimeView(db: DatabaseSync, now?: Date, filter?: ViewFilter): SidebarSection[] {
   const packedToday = encodePackedDate(localToday(now));
   const tf = tagFilter(db, filter);
   // Mirrors UI membership: every active item, including Today members
-  // (starred in the UI) and pending-promotion rows (start=2, past-dated).
+  // (starred in the UI) and pending-promotion rows (start=2, past-dated) —
+  // MINUS children of non-active containers (the project cascade).
   const rows = fetchTaskRows(
     db,
-    `${OPEN} AND (
-       (t.start = 1 AND (t.startDate IS NULL OR t.startDate <= ?))
-       OR (t.start = 2 AND t.startDate IS NOT NULL AND t.startDate <= ?)
-     )${tf.sql} ORDER BY t."index" ASC`,
-    [packedToday, packedToday, ...tf.binds],
+    `${OPEN} AND ${ANYTIME_SELF("t")}
+     AND ${PROJECT_ANYTIME_ACTIVE}${tf.sql} ORDER BY t."index" ASC`,
+    [packedToday, packedToday, packedToday, packedToday, ...tf.binds],
   );
-  return materialize(db, rows);
+  return groupBySidebar(db, materialize(db, rows));
+}
+
+/**
+ * Arranges view members into the UI's flat sidebar-mirroring order: the
+ * area-less block first (direct to-dos, then each top-level project followed
+ * by its members), then each area by its sidebar index (direct to-dos, then
+ * its projects). Project and area order here mirrors the sidebar exactly —
+ * both read the same "index" columns.
+ */
+function groupBySidebar(db: DatabaseSync, items: ListItem[]): SidebarSection[] {
+  if (items.length === 0) return [];
+  const inList = (n: number) => Array.from({ length: n }, () => "?").join(", ");
+
+  // Headed children: resolve heading -> project.
+  const headingUuids = [
+    ...new Set(
+      items.flatMap((i) => (i.type === "to-do" && i.heading !== null ? [i.heading.uuid] : [])),
+    ),
+  ];
+  const headingProject = new Map<string, string | null>();
+  if (headingUuids.length > 0) {
+    for (const row of db
+      .prepare(`SELECT uuid, project FROM TMTask WHERE uuid IN (${inList(headingUuids.length)})`)
+      .all(...headingUuids) as Array<{ uuid: string; project: string | null }>) {
+      headingProject.set(row.uuid, row.project);
+    }
+  }
+  const effProject = (i: ListItem): string | null =>
+    i.type !== "to-do"
+      ? null
+      : (i.project?.uuid ??
+        (i.heading !== null ? (headingProject.get(i.heading.uuid) ?? null) : null));
+
+  // Sidebar rank + title for areas; index + area for every referenced project
+  // (a tag-filtered list can contain a child whose project row didn't match).
+  const areaRows = db
+    .prepare(`SELECT uuid, title, "index" FROM TMArea ORDER BY "index" ASC, uuid ASC`)
+    .all() as Array<{ uuid: string; title: string | null }>;
+  const areaRank = new Map(areaRows.map((a, rank) => [a.uuid, rank]));
+  const areaTitle = new Map(areaRows.map((a) => [a.uuid, a.title ?? ""]));
+  const projectUuids = [
+    ...new Set([
+      ...items.flatMap((i) => (i.type === "project" ? [i.uuid] : [])),
+      ...items.flatMap((i) => {
+        const p = effProject(i);
+        return p === null ? [] : [p];
+      }),
+    ]),
+  ];
+  const projectMeta = new Map<string, { index: number; area: string | null }>();
+  if (projectUuids.length > 0) {
+    for (const row of db
+      .prepare(
+        `SELECT uuid, "index", area FROM TMTask WHERE uuid IN (${inList(projectUuids.length)})`,
+      )
+      .all(...projectUuids) as Array<{ uuid: string; index: number | null; area: string | null }>) {
+      projectMeta.set(row.uuid, { index: row.index ?? 0, area: row.area });
+    }
+  }
+
+  const sortKey = (i: ListItem) => {
+    const project = i.type === "project" ? i.uuid : effProject(i);
+    const meta = project === null ? undefined : projectMeta.get(project);
+    const area = i.area?.uuid ?? meta?.area ?? null;
+    return {
+      areaRank: area === null ? -1 : (areaRank.get(area) ?? areaRows.length),
+      area: area ?? "",
+      inProject: project === null ? 0 : 1,
+      projectIndex: meta?.index ?? 0,
+      project: project ?? "",
+      headerFirst: i.type === "project" ? 0 : 1,
+      index: i.index,
+      uuid: i.uuid,
+    };
+  };
+  const keyed = items.map((item) => ({ item, k: sortKey(item) }));
+  keyed.sort(
+    (a, b) =>
+      a.k.areaRank - b.k.areaRank ||
+      a.k.area.localeCompare(b.k.area) ||
+      a.k.inProject - b.k.inProject ||
+      a.k.projectIndex - b.k.projectIndex ||
+      a.k.project.localeCompare(b.k.project) ||
+      a.k.headerFirst - b.k.headerFirst ||
+      a.k.index - b.k.index ||
+      a.k.uuid.localeCompare(b.k.uuid),
+  );
+
+  const sections: SidebarSection[] = [];
+  for (const { item, k } of keyed) {
+    const areaUuid = k.area === "" ? null : k.area;
+    const last = sections.at(-1);
+    if (last === undefined || (last.area?.uuid ?? null) !== areaUuid) {
+      sections.push({
+        area: areaUuid === null ? null : { uuid: areaUuid, title: areaTitle.get(areaUuid) ?? "" },
+        items: [],
+      });
+    }
+    sections.at(-1)?.items.push(item);
+  }
+  return sections;
 }
 
 /** The UI's star marker in Anytime: the item is also a Today member. */
@@ -256,14 +397,38 @@ export function upcomingView(db: DatabaseSync, now?: Date, filter?: UpcomingFilt
   );
 }
 
-export function somedayView(db: DatabaseSync, filter?: ViewFilter): ListItem[] {
+export interface SomedayFilter extends ViewFilter {
+  /**
+   * Also list someday to-dos that live inside ACTIVE projects — the UI's
+   * "Show items from active projects" toggle (default false, the UI's
+   * default). Children of someday projects are never listed either way: the
+   * project row stands for them.
+   */
+  activeProjectItems?: boolean;
+}
+
+export function somedayView(
+  db: DatabaseSync,
+  now?: Date,
+  filter?: SomedayFilter,
+): SidebarSection[] {
   const tf = tagFilter(db, filter);
+  const packedToday = encodePackedDate(localToday(now));
+  // Default membership excludes ALL project children (the UI shows only
+  // container-less someday to-dos, area members, and someday project rows);
+  // the toggle adds someday children of anytime-ACTIVE projects only.
+  const withActiveChildren = filter?.activeProjectItems === true;
+  const childArm = withActiveChildren
+    ? `EXISTS (SELECT 1 FROM TMTask p WHERE p.uuid = ${EFF_PROJECT}
+         AND p.trashed = 0 AND p.status = 0 AND ${ANYTIME_SELF("p")})`
+    : "0";
   const rows = fetchTaskRows(
     db,
-    `${OPEN} AND t.start = 2 AND t.startDate IS NULL${tf.sql} ORDER BY t."index" ASC`,
-    tf.binds,
+    `${OPEN} AND t.start = 2 AND t.startDate IS NULL
+     AND (${EFF_PROJECT} IS NULL OR ${childArm})${tf.sql} ORDER BY t."index" ASC`,
+    [...(withActiveChildren ? [packedToday, packedToday] : []), ...tf.binds],
   );
-  return materialize(db, rows);
+  return groupBySidebar(db, materialize(db, rows));
 }
 
 export function logbookView(

--- a/test/unit/views.test.ts
+++ b/test/unit/views.test.ts
@@ -5,6 +5,7 @@ import { inheritedTagsFor } from "../../src/read/tags.ts";
 import { fetchTaskByUuid } from "../../src/read/queries.ts";
 import {
   anytimeView,
+  type SidebarSection,
   changesView,
   inboxView,
   isTodayMember,
@@ -26,6 +27,9 @@ import {
 } from "../fixtures/seed.ts";
 
 const NOW = new Date(2026, 6, 2, 12, 0); // local 2026-07-02
+
+/** Flattens grouped anytime/someday sections back to items for membership checks. */
+const flat = (sections: SidebarSection[]) => sections.flatMap((s) => s.items);
 
 let fx: FixtureDb;
 afterEach(() => fx?.close());
@@ -178,16 +182,19 @@ describe("list views", () => {
 
     expect(inboxView(fx.db).map((i) => i.title)).toEqual(["in-inbox"]);
     // Anytime mirrors the UI: unscheduled AND Today members (starred in UI)
-    expect(anytimeView(fx.db, NOW).map((i) => i.title)).toEqual(["unscheduled", "scheduled-today"]);
+    expect(flat(anytimeView(fx.db, NOW)).map((i) => i.title)).toEqual([
+      "unscheduled",
+      "scheduled-today",
+    ]);
     expect(upcomingView(fx.db, NOW).map((i) => i.title)).toEqual(["future"]);
-    expect(somedayView(fx.db).map((i) => i.title)).toEqual(["incubating"]);
+    expect(flat(somedayView(fx.db)).map((i) => i.title)).toEqual(["incubating"]);
   });
 
   it("isTodayMember marks the UI star in Anytime", () => {
     fx = buildFixtureDb();
     seedTodo(fx.db, { title: "unscheduled", start: "active", index: 1 });
     seedTodo(fx.db, { title: "starred", start: "active", startDate: "2026-07-01", index: 2 });
-    const items = anytimeView(fx.db, NOW);
+    const items = flat(anytimeView(fx.db, NOW));
     expect(items.map((i) => [i.title, isTodayMember(i, NOW)])).toEqual([
       ["unscheduled", false],
       ["starred", true],
@@ -200,6 +207,83 @@ describe("list views", () => {
     seedTodo(fx.db, { title: "newer", status: "canceled", stopDate: 200 });
     seedTodo(fx.db, { title: "trashed-done", status: "completed", stopDate: 300, trashed: true });
     expect(logbookView(fx.db).map((i) => i.title)).toEqual(["newer", "older"]);
+  });
+});
+
+describe("anytime container cascade + sidebar grouping", () => {
+  it("excludes children of someday/future-scheduled projects (the project row represents them)", () => {
+    fx = buildFixtureDb();
+    const somedayProj = seedProject(fx.db, { title: "sd-proj", start: "someday" });
+    seedTodo(fx.db, { title: "hidden-sd-child", project: somedayProj });
+    const futureProj = seedProject(fx.db, {
+      title: "future-proj",
+      start: "someday",
+      startDate: "2026-07-10",
+    });
+    seedTodo(fx.db, { title: "hidden-future-child", project: futureProj });
+    const activeProj = seedProject(fx.db, { title: "active-proj" });
+    seedTodo(fx.db, { title: "visible-child", project: activeProj });
+
+    const titles = flat(anytimeView(fx.db, NOW)).map((i) => i.title);
+    expect(titles).toContain("active-proj");
+    expect(titles).toContain("visible-child");
+    expect(titles).not.toContain("sd-proj");
+    expect(titles).not.toContain("hidden-sd-child");
+    expect(titles).not.toContain("hidden-future-child");
+  });
+
+  it("cascades through headings (a headed child reaches its project via the heading row)", () => {
+    fx = buildFixtureDb();
+    const somedayProj = seedProject(fx.db, { title: "sd-proj", start: "someday" });
+    const h1 = seedHeading(fx.db, { title: "H1", project: somedayProj });
+    seedTodo(fx.db, { title: "headed-hidden", heading: h1 }); // project = NULL by invariant
+    const activeProj = seedProject(fx.db, { title: "active-proj" });
+    const h2 = seedHeading(fx.db, { title: "H2", project: activeProj });
+    seedTodo(fx.db, { title: "headed-visible", heading: h2 });
+
+    const titles = flat(anytimeView(fx.db, NOW)).map((i) => i.title);
+    expect(titles).toContain("headed-visible");
+    expect(titles).not.toContain("headed-hidden");
+  });
+
+  it("groups in sidebar order: top-level block first, then areas by index; direct to-dos before project blocks", () => {
+    fx = buildFixtureDb();
+    const areaB = seedArea(fx.db, "B-Area", 2);
+    const areaA = seedArea(fx.db, "A-Area", 1);
+    seedTodo(fx.db, { title: "loose", index: 50 });
+    const topProj = seedProject(fx.db, { title: "top-proj", index: 9 });
+    seedTodo(fx.db, { title: "top-proj-child", project: topProj, index: 1 });
+    seedTodo(fx.db, { title: "areaB-direct", area: areaB, index: 1 });
+    seedTodo(fx.db, { title: "areaA-direct", area: areaA, index: 7 });
+    const projA = seedProject(fx.db, { title: "proj-in-A", area: areaA, index: 3 });
+    const hA = seedHeading(fx.db, { title: "HA", project: projA });
+    seedTodo(fx.db, { title: "projA-headed-child", heading: hA, index: 1 });
+
+    const sections = anytimeView(fx.db, NOW);
+    expect(sections.map((s) => s.area?.title ?? null)).toEqual([null, "A-Area", "B-Area"]);
+    expect(sections[0]?.items.map((i) => i.title)).toEqual(["loose", "top-proj", "top-proj-child"]);
+    expect(sections[1]?.items.map((i) => i.title)).toEqual([
+      "areaA-direct",
+      "proj-in-A",
+      "projA-headed-child",
+    ]);
+    expect(sections[2]?.items.map((i) => i.title)).toEqual(["areaB-direct"]);
+  });
+
+  it("someday hides project children by default; activeProjectItems adds active-project ones only", () => {
+    fx = buildFixtureDb();
+    const activeProj = seedProject(fx.db, { title: "active-proj" });
+    seedTodo(fx.db, { title: "sd-in-active", project: activeProj, start: "someday" });
+    const somedayProj = seedProject(fx.db, { title: "sd-proj", start: "someday" });
+    seedTodo(fx.db, { title: "sd-in-sd", project: somedayProj, start: "someday" });
+    seedTodo(fx.db, { title: "sd-loose", start: "someday" });
+
+    expect(flat(somedayView(fx.db, NOW)).map((i) => i.title)).toEqual(["sd-loose", "sd-proj"]);
+    const withActive = flat(somedayView(fx.db, NOW, { activeProjectItems: true })).map(
+      (i) => i.title,
+    );
+    expect(withActive).toContain("sd-in-active");
+    expect(withActive).not.toContain("sd-in-sd");
   });
 });
 
@@ -302,10 +386,10 @@ describe("tag-filtered list views (Phase 10)", () => {
   it("filters anytime/someday/logbook the same way", () => {
     seedTagChain();
     seedTodo(fx.db, { title: "done-tagged", status: "completed", stopDate: 1_780_000_100 });
-    expect(anytimeView(fx.db, NOW, { tag: "focus" }).map((i) => i.title)).not.toContain(
+    expect(flat(anytimeView(fx.db, NOW, { tag: "focus" })).map((i) => i.title)).not.toContain(
       "unrelated",
     );
-    expect(somedayView(fx.db, { tag: "focus" })).toEqual([]);
+    expect(somedayView(fx.db, NOW, { tag: "focus" })).toEqual([]);
     expect(logbookView(fx.db, { tag: "focus" }).map((i) => i.title)).not.toContain("done-tagged");
   });
 });


### PR DESCRIPTION
Implements Mike's view-semantics findings + CLI list polish.

## View semantics (the bug)
- **Anytime container cascade**: children of projects that are not themselves anytime-visible (someday / future-scheduled / logged / trashed) are excluded — the project row represents them, matching the app (the reported case: children of a someday project leaking into `things anytime`). Heading-contained children resolve their project through the heading link.
- **Sidebar-grouped anytime/someday** (`SidebarSection[]`): area-less block first (direct to-dos, then each project block), then areas by sidebar index — the app's flat Anytime order, which also mirrors the sidebar (same `index` columns, per scf2 P6).
- **`things someday --active-project-items`** (MCP `read_view {active_project_items}`): the app's 'Show items from active projects' toggle; default now hides all project children like the app.

## CLI polish
- uuid column padded to the longest uuid in the list (21–22 char variance confirmed on live data: 629×21 vs 20,878×22).
- Uniform single-space token separation after the `-`/`P` marker (the old `padEnd(2)` made the gap depend on metadata presence).
- TTY-only ANSI colors (deadline red, date yellow, tags cyan, uuid/context dim, area headers bold, star yellow); `NO_COLOR`/`FORCE_COLOR` honored; piped output stays byte-plain.

New unit tests for cascade (incl. heading pass-through), grouping order, and the someday toggle; fixture-DB smoke verified all renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiiUK4qXABDtVKoW7S9Cft