### PR TITLE
chore(release): 0.4.0 — first npm publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+_(nothing yet)_
+
+## 0.4.0 — 2026-07-09
+
 ### Anytime/Someday view semantics + CLI list polish
 
 - **Anytime container cascade (fix)**: children of projects that are not themselves anytime-visible (someday, future-scheduled, logged, or trashed) no longer appear in `anytime` — the project row represents them, matching the app. Heading-contained children resolve their project through the heading link.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "things-api",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "things-api",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "things-api",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Typed TypeScript library + CLI for Things 3 (Cultured Code) — verified writes, audit trail, schema-drift detection",
   "license": "MIT",
   "bin": {

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -15,7 +15,7 @@ export const API_VERSION = 1;
  * Package version, surfaced by `things --version` and the MCP serverInfo.
  * Kept in lockstep with package.json by a contract test.
  */
-export const PKG_VERSION = "0.3.0";
+export const PKG_VERSION = "0.4.0";
 
 /**
  * Stable exit-code contract for the `things` CLI (mirrored by MCP error


### PR DESCRIPTION
Version lockstep to 0.4.0 (package.json, package-lock, `PKG_VERSION`), CHANGELOG rolled with today's anytime/someday semantics + CLI polish + Phase 21b ops. Publishing to npm as unscoped `things-api` (name confirmed available) after merge + tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiiUK4qXABDtVKoW7S9Cft