### PR TITLE
chore(release): 0.5.0 — first npm publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+_(nothing yet)_
+
+## 0.5.0 — 2026-07-09
+
 ### Backdating, logged import, and three new reorder scopes
 
 - **`things todo backdate <uuid> --completed-on/--created-on`** (op `todo.backdate`, MCP `backdate_todo`): rewrites a to-do's completion and/or creation timestamp to local noon on the given date — AppleScript property writes, the only surface that can (lab scf2 P4b). Completion backdating requires an already-completed/canceled to-do; undo restores the previous dates at day precision.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "things-api",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "things-api",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "things-api",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Typed TypeScript library + CLI for Things 3 (Cultured Code) — verified writes, audit trail, schema-drift detection",
   "license": "MIT",
   "bin": {

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -15,7 +15,7 @@ export const API_VERSION = 1;
  * Package version, surfaced by `things --version` and the MCP serverInfo.
  * Kept in lockstep with package.json by a contract test.
  */
-export const PKG_VERSION = "0.4.0";
+export const PKG_VERSION = "0.5.0";
 
 /**
  * Stable exit-code contract for the `things` CLI (mirrored by MCP error


### PR DESCRIPTION
Version lockstep to 0.5.0; CHANGELOG rolled with today's view semantics, CLI polish, and the new write surfaces (backdate, add-logged, reorder scopes headings/someday/projects). Publishing to npm as unscoped `things-api` after merge + tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiiUK4qXABDtVKoW7S9Cft