### PR TITLE
fix(pkg): bin path without ./ prefix (npm 11 strips it, killing the CLI install)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Typed TypeScript library + CLI for Things 3 (Cultured Code) — verified writes, audit trail, schema-drift detection",
   "license": "MIT",
   "bin": {
-    "things": "./bin/things.js"
+    "things": "bin/things.js"
   },
   "files": [
     "bin",


### PR DESCRIPTION
npm 11.11 auto-removed `"things": "./bin/things.js"` at publish time ('script name … was invalid and removed') — the tarball would have installed with no `things` command. `npm pkg fix` normalization to `bin/things.js`. Re-tagging v0.5.0 onto this commit before the (not-yet-succeeded) first publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiiUK4qXABDtVKoW7S9Cft