### PR TITLE
fix(guards): every project.* op rejects non-project targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Safety: project operations now reject wrong-type targets.** `project.update`, `project.complete`, `project.set-tags`, and `project.delete` previously accepted any task uuid — passing a to-do or heading uuid resolved cleanly and compiled a project-shaped command around the wrong row (undefined app behavior; a heading in a schedule-class specifier is known to crash Things). Every `project.*` op now verifies the target is a project and points a mis-typed uuid at the right command family, matching the existing guards on `todo.*` and `heading.*`. Cross-table uuids (an area passed to a task/project op) were already caught as not-found.
+
 ### Short uuids
 
 - **Every uuid parameter accepts a unique PREFIX (minimum 6 characters)** — CLI, MCP, and library alike (`things todo complete Vwn2yoRP` instead of the full 22-character id). Resolution is an indexed range scan; an exact full uuid always wins (a 21-char uuid can prefix a 22-char one), unknown prefixes report not-found, and ambiguous prefixes fail with every candidate listed. `things undo` and audit records always carry full uuids.

--- a/src/write/guards.ts
+++ b/src/write/guards.ts
@@ -156,25 +156,33 @@ const GUARDS: Record<HazardId, GuardFn> = {
               : " — use the project commands"),
         );
       }
-      // Type/state preconditions for the Tier-2 ops: the probed commands
-      // address `project id` / trashed `to do id` specifically (E14/E15/E17).
-      if ((op === "project.move" || op === "project.duplicate") && pre.target.type !== "project") {
-        problems.push(`target ${String(params["uuid"])} is a ${pre.target.type}, not a project`);
+      // Every project.* op (except project.add) must target a PROJECT. A
+      // wrong-type uuid resolves cleanly (it is a real TMTask row) and would
+      // otherwise compile a `project id` / update-project specifier around a
+      // to-do or heading — undefined app behavior, and a heading in a
+      // schedule-class specifier CRASHES Things (P11e). Guarded, not probed.
+      if (op.startsWith("project.") && op !== "project.add" && pre.target.type !== "project") {
+        problems.push(
+          `target ${String(params["uuid"])} is a ${pre.target.type}, not a project` +
+            (pre.target.type === "to-do"
+              ? " — use the `things todo` commands"
+              : pre.target.type === "heading"
+                ? " — use the `things heading` commands"
+                : ""),
+        );
       }
+      // State preconditions once the target IS a project (E14/E15/E17, P01–P07).
       if (
-        (op === "project.cancel" || op === "project.reopen" || op === "project.restore") &&
-        pre.target.type !== "project"
+        op === "project.cancel" &&
+        pre.target.type === "project" &&
+        pre.target.status !== "open"
       ) {
-        problems.push(`target ${String(params["uuid"])} is a ${pre.target.type}, not a project`);
-      } else if (op === "project.cancel" && pre.target.type === "project") {
-        // Only open->canceled is probed (P01); re-canceling resolved
-        // projects is unvalidated.
-        if (pre.target.status !== "open") {
-          problems.push(
-            `target project is already ${pre.target.status} — cancel needs an open project`,
-          );
-        }
-      } else if (op === "project.reopen" && pre.target.type === "project") {
+        // Only open->canceled is probed (P01); re-canceling resolved projects is unvalidated.
+        problems.push(
+          `target project is already ${pre.target.status} — cancel needs an open project`,
+        );
+      }
+      if (op === "project.reopen" && pre.target.type === "project") {
         if (pre.target.status === "open") {
           problems.push("target project is already open — nothing to reopen");
         }
@@ -183,7 +191,8 @@ const GUARDS: Record<HazardId, GuardFn> = {
             "target project is in the Trash — restore it first (things project restore)",
           );
         }
-      } else if (op === "project.restore" && pre.target.type === "project" && !pre.target.trashed) {
+      }
+      if (op === "project.restore" && pre.target.type === "project" && !pre.target.trashed) {
         problems.push(
           `target ${String(params["uuid"])} is not in the Trash — restore only applies to ` +
             "trashed projects",

--- a/test/unit/write-guards.test.ts
+++ b/test/unit/write-guards.test.ts
@@ -7,7 +7,7 @@ import type {
   OperationParamsMap,
 } from "../../src/write/operations.ts";
 import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
-import { seedHeading, seedProject, seedTag, seedTodo } from "../fixtures/seed.ts";
+import { seedArea, seedHeading, seedProject, seedTag, seedTodo } from "../fixtures/seed.ts";
 
 let fixture: FixtureDb;
 
@@ -200,5 +200,40 @@ describe("H-HEADING-CHILDREN", () => {
     expect(check("heading.rename", { uuid: todo, title: "x" })?.hazard).toBe(
       "H-UNKNOWN-DESTINATION",
     );
+  });
+
+  it("EVERY project op rejects a to-do or heading uuid (wrong-specifier crash guard)", () => {
+    const proj = seedProject(fixture.db, { title: "P" });
+    const heading = seedHeading(fixture.db, { title: "H", project: proj });
+    const todo = seedTodo(fixture.db, { title: "t", project: proj });
+    // The four ops that previously had NO type check.
+    for (const op of ["project.update", "project.complete", "project.delete"] as const) {
+      const params =
+        op === "project.complete"
+          ? { uuid: todo, children: "require-resolved" as const }
+          : { uuid: todo };
+      const block = check(op, params as never);
+      expect(block?.hazard).toBe("H-UNKNOWN-DESTINATION");
+      expect(block?.detail).toContain("not a project");
+      expect(block?.detail).toContain("things todo");
+    }
+    expect(check("project.set-tags", { uuid: todo, tags: [] })?.detail).toContain("not a project");
+    // A heading points at the heading commands.
+    expect(check("project.update", { uuid: heading, title: "x" })?.detail).toContain(
+      "things heading",
+    );
+    // The already-covered ops still reject too.
+    expect(check("project.move", { uuid: todo, area: { uuid: "A" } })?.hazard).toBe(
+      "H-UNKNOWN-DESTINATION",
+    );
+    // ...and a real project passes the type gate (may still hit other problems).
+    expect(check("project.update", { uuid: proj, title: "renamed" })).toBeNull();
+  });
+
+  it("a cross-table uuid (area) in a task/project op is caught as not-found", () => {
+    const area = seedArea(fixture.db, "Home");
+    // Areas live in TMArea, not TMTask, so loadTarget returns null.
+    expect(check("todo.update", { uuid: area, title: "x" })?.hazard).toBe("H-UNKNOWN-DESTINATION");
+    expect(check("project.delete", { uuid: area })?.hazard).toBe("H-UNKNOWN-DESTINATION");
   });
 });


### PR DESCRIPTION
You flagged the exact gap. Audit result: `todo.*` and `heading.*` were fully type-guarded (#53/#54), but **`project.update`, `project.complete`, `project.set-tags`, `project.delete` never checked their target's type**.

A to-do or heading uuid passed to those resolves cleanly (real `TMTask` row), clears every guard, and compiles a `project id`/`update-project` specifier wrapped around the wrong row → undefined app behavior. One member of that family is a **confirmed crash** (a heading in a schedule specifier, P11e). The short-uuid resolver widened the exposure since it resolves any `TMTask` prefix regardless of type.

**Fix**: one general rule — `project.*` (except `project.add`) must target a project — replacing the piecemeal move/duplicate/cancel/reopen/restore checks, and pointing a mis-typed uuid at the right command family. Cross-table uuids (an area handed to a task/project op) were already caught as not-found (different table → resolves to null). Tests cover all four newly-guarded ops and both cross-table directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiiUK4qXABDtVKoW7S9Cft