### PR TITLE
feat: tiered name resolution + hidden internal identifiers + checklist targeting (0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+_(nothing yet)_
+
+## 0.6.0 — 2026-07-09
+
+### Reference resolution & hidden internals (mildly breaking)
+
+- **Names resolve in tiers** (areas, tags, projects): exact uuid → exact title → case-insensitive title → normalized title (whitespace/dash-insensitive, NFC) → uuid prefix. The first tier with exactly one match wins definitively; several is an ambiguity error. `--area family` finds `Family` without tripping over `Family - Jennifer`; `on-hold` finds `On Hold`. **Leading emoji/symbols are significant** — a name beginning with an emoji must be typed with it (so an archived `🗄️errand` tag is never matched by a bare `errand`). See [docs/design/reference-resolution.md](docs/design/reference-resolution.md).
+- **Area/tag references now accept a unique uuid prefix** too (≥6 chars), like task uuids.
+- **Internal sort keys are no longer surfaced.** `index` and `todayIndex` are dropped from task/heading/area/tag responses; checklist items are now `{ title, status }` only (their uuid, index, owning-task, and timestamps were unstable implementation details — a checklist item's uuid is regenerated on every rewrite and was never addressable). Ordering is conveyed by array order; `--json` still carries full task uuids. **This changes read-response shapes.**
+- **Checklist edits target by title OR 1-based index** (`--index` / MCP `index`). Duplicate titles resolve best-effort — `check` picks the first unchecked match, `uncheck` the first checked, others the first match — with `--index` as the exact override. Checklist items have `open`/`completed`/`canceled` states (canceled is read-only; the write path produces open/completed) and no trashed/logged state — they travel with their parent to-do.
+
 - **Safety: project operations now reject wrong-type targets.** `project.update`, `project.complete`, `project.set-tags`, and `project.delete` previously accepted any task uuid — passing a to-do or heading uuid resolved cleanly and compiled a project-shaped command around the wrong row (undefined app behavior; a heading in a schedule-class specifier is known to crash Things). Every `project.*` op now verifies the target is a project and points a mis-typed uuid at the right command family, matching the existing guards on `todo.*` and `heading.*`. Cross-table uuids (an area passed to a task/project op) were already caught as not-found.
 
 ### Short uuids

--- a/docs/design/reference-resolution.md
+++ b/docs/design/reference-resolution.md
@@ -1,0 +1,44 @@
+# Reference resolution — names, uuids, and checklist items
+
+How the API turns a user-supplied reference into a concrete entity. Two families, deliberately different because their stakes differ.
+
+## Area / tag / project name references (strict, tiered)
+
+A `--area` / `--tag` / project-container reference is resolved by walking tiers in order; **the first tier with exactly one match wins and is definitive** (lower tiers are never consulted). A tier with two-or-more matches is an ambiguity error listing the candidates. Falling off the end is not-found.
+
+| Tier | Rule | Example that resolves here |
+|---|---|---|
+| 0. UUID | ref equals a row's full uuid | `7Ck4hAXU…` |
+| 1. Exact | byte-for-byte, case-sensitive `title = ref` | `Family` when `Family` and `FaMiLy` both exist — exact casing disambiguates |
+| 2. Case-insensitive | `title = ref COLLATE NOCASE` | `family` → `Family` (when no other case-variant exists) |
+| 3. Normalized | NFC + case-fold + strip all whitespace and dashes/hyphens; **nothing else removed** | `on-hold` → `On Hold`; `familyjennifer` → `Family - Jennifer` |
+| 4. UUID prefix | ref is ≥6 base-62 chars and a unique uuid prefix | `7Ck4hA` |
+
+Worked examples (Mike's cases):
+
+- Areas `Family` and `Family - Jennifer`, ref `family`: tier 2 matches **only** `Family` (the other is a different string, not a case-variant) → resolves to `Family`. It does **not** fail, because `Family - Jennifer` never enters the running.
+- Areas `Family` and `FaMiLy`, ref `family`: tier 0/1 miss; tier 2 matches **both** → ambiguity error.
+- Same areas, ref `Family`: tier 1 (exact) matches only `Family` → resolves, definitively, ignoring `FaMiLy`. "Get the casing exactly right and it always wins."
+
+### Leading emoji / symbols are significant (by design, unopinionated)
+
+Normalization folds only **case, whitespace, and dashes** — it never strips emoji, symbols, or other punctuation. Consequence: a name that begins with an emoji must be typed *with* that emoji to match. This is not an opinion about what a leading emoji *means*; it is simply "we fold equivalent spellings, we do not delete characters."
+
+It happens to serve a common convention cleanly: a retired tag prefixed with an emoji (e.g. `🗄️errand`) is automatically excluded from a bare `errand` reference — `errand` resolves to an active `errand` tag, or to nothing, but never to the archived one. (An opt-in `resolve.stripLeadingSymbols` config for users who *want* emoji-insensitive matching is a possible future addition; it is intentionally not the default.)
+
+## Checklist-item references (best-effort, low-stakes)
+
+Checklist items are addressed within a single to-do's list, where duplicate titles are common and the stakes are low (checking a sub-item). Unlike area/tag resolution, this is **best-effort, not strict**:
+
+- **By 1-based index** (`index`): exact and unambiguous — `index: 2` is the second item. 1-based because both humans and agents count list positions from 1 ("the 2nd item"), and it matches the existing `add --at` / `move --to` positions.
+- **By title** (`item`): if one item has the title, use it. If several do, target the **first item on which the action is meaningful** — `check` → the first *unchecked* match, `uncheck` → the first *checked* match, `rename`/`remove` → the first match. If every match is already in the target state, the first match. Precise disambiguation is the caller's job, via `index`.
+
+An `index` always overrides a title. This trades the project's usual loud-on-ambiguity stance for ergonomics *only here*, because "check off get milk" almost always means the obvious one, and the cost of a wrong guess is a re-check.
+
+### Checklist item states
+
+Checklist items have `status` ∈ `open` | `completed` | `canceled` (canceled exists in real data, with a `stopDate`). They have **no** trashed/logged state — they live and move with their parent to-do. The write surface only produces `open`/`completed` (check/uncheck); `canceled` is read-only (the app offers no create/set path we can drive, and the json rewrite carries a boolean). A checklist rewrite therefore cannot preserve a pre-existing `canceled` item's state — documented in [things-app-oddities.md](../things-app-oddities.md).
+
+## Hidden internal identifiers
+
+These columns are Things-internal implementation details and are **not** surfaced in API responses (they are unstable, non-addressable, or meaningless to a consumer): `index` and `todayIndex` on tasks; `uuid`, `index`, `task`, `created`, `modified`, `stopped` on checklist items (a checklist item's uuid is regenerated on every rewrite and is never a valid mutation target). Ordering is conveyed by array order; reorder operations take uuid sequences; the audit log captures ranks directly from SQL. `--json` still carries full task uuids (the one stable, addressable identifier).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "things-api",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "things-api",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "UNLICENSED",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "things-api",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Typed TypeScript library + CLI for Things 3 (Cultured Code) — verified writes, audit trail, schema-drift detection",
   "license": "MIT",
   "bin": {

--- a/src/cli/commands/todo.ts
+++ b/src/cli/commands/todo.ts
@@ -10,10 +10,7 @@ import { withClient } from "./reads.ts";
 function renderDetail(item: AnyTask | null): string[] {
   if (!item) return ["(not found)"];
   if (item.type === "heading") {
-    return [
-      `${item.uuid}  [heading] ${item.title}`,
-      `  project: ${item.project?.title ?? "—"}  index: ${item.index}`,
-    ];
+    return [`${item.uuid}  [heading] ${item.title}`, `  project: ${item.project?.title ?? "—"}`];
   }
   const lines = [
     `${item.uuid}  [${item.type}] ${item.title}`,

--- a/src/cli/commands/writes.ts
+++ b/src/cli/commands/writes.ts
@@ -478,18 +478,26 @@ export function registerWriteCommands(program: Command): void {
           "--acknowledge-checklist-reset when items exist. GRANULAR (one per call): " +
           "--add/--remove/--check/--uncheck/--rename+--to/--move-item+--to-position change " +
           "a single item with every other item's checked state PRESERVED (no reset flag " +
-          "needed). Items are matched by exact title — ambiguous titles are rejected; item " +
-          "uuids are not stable across any edit.",
+          "needed). Target an item by title or by --index (1-based); duplicate titles are " +
+          "resolved best-effort (check → first unchecked, etc.). Checklist item uuids are " +
+          "internal and never exposed.",
       )
       .option("--item <text>", "wholesale: checklist item in order (repeatable)", collect, [])
       .option("--acknowledge-checklist-reset", "accept wholesale replacement of existing items")
       .option("--add <title>", "granular: append an item")
       .option("--at <n>", "with --add: 1-based insert position")
-      .option("--remove <title>", "granular: delete an item")
-      .option("--check <title>", "granular: mark an item completed")
-      .option("--uncheck <title>", "granular: mark an item open")
-      .option("--rename <title>", "granular: rename an item (requires --to)")
-      .option("--move-item <title>", "granular: reposition an item (requires --to-position)")
+      .option("--remove [title]", "granular: delete an item (by title or --index)")
+      .option("--check [title]", "granular: mark an item completed (by title or --index)")
+      .option("--uncheck [title]", "granular: mark an item open (by title or --index)")
+      .option(
+        "--rename [title]",
+        "granular: rename an item (target by title or --index; requires --to)",
+      )
+      .option("--move-item [title]", "granular: reposition an item (requires --to-position)")
+      .option(
+        "--index <n>",
+        "granular: target the item at this 1-based position instead of a title",
+      )
       .option("--to <title>", "new title for --rename")
       .option("--to-position <n>", "1-based position for --move-item"),
   ).action(async (uuid: string, opts: WriteFlagOpts & Record<string, unknown>) => {
@@ -518,6 +526,18 @@ export function registerWriteCommands(program: Command): void {
         process.exitCode = ExitCode.Usage;
         return;
       }
+      // Target: --index (1-based) OR the action flag's title value. When a
+      // targeting flag is present without a value commander yields `true`.
+      const flagVal = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
+      const target: { index?: number; item?: string } =
+        opts["index"] !== undefined
+          ? { index: Number(opts["index"]) }
+          : { item: flagVal(opts[action]) ?? "" };
+      if (action !== "add" && opts["index"] === undefined && target.item === "") {
+        process.stderr.write(`error: --${action} needs a title, or use --index <n>\n`);
+        process.exitCode = ExitCode.Usage;
+        return;
+      }
       const edit =
         action === "add"
           ? {
@@ -526,22 +546,14 @@ export function registerWriteCommands(program: Command): void {
               ...(opts["at"] !== undefined && { at: Number(opts["at"]) }),
             }
           : action === "remove"
-            ? { action: "remove" as const, item: opts["remove"] as string }
+            ? { action: "remove" as const, ...target }
             : action === "check"
-              ? { action: "check" as const, item: opts["check"] as string }
+              ? { action: "check" as const, ...target }
               : action === "uncheck"
-                ? { action: "uncheck" as const, item: opts["uncheck"] as string }
+                ? { action: "uncheck" as const, ...target }
                 : action === "rename"
-                  ? {
-                      action: "rename" as const,
-                      item: opts["rename"] as string,
-                      title: opts["to"] as string,
-                    }
-                  : {
-                      action: "move" as const,
-                      item: opts["moveItem"] as string,
-                      to: Number(opts["toPosition"]),
-                    };
+                  ? { action: "rename" as const, ...target, title: opts["to"] as string }
+                  : { action: "move" as const, ...target, to: Number(opts["toPosition"]) };
       await runWrite(opts, (c) => c.write.editChecklist(uuid, edit, writeOptionsFrom(opts)));
       return;
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -286,23 +286,55 @@ export interface ThingsClient {
 }
 
 /** One granular checklist edit; every other item's checked state is preserved. */
+/**
+ * Target for an existing checklist item: by `item` (title) or `index`
+ * (1-based). Provide exactly one. Title matching is best-effort on duplicates
+ * (docs/design/reference-resolution.md); index is exact.
+ */
+export interface ChecklistTarget {
+  item?: string;
+  /** 1-based position; overrides `item` when both are given. */
+  index?: number;
+}
+
 export type ChecklistEdit =
   | { action: "add"; title: string; /** 1-based insert position (default: append). */ at?: number }
-  | { action: "remove"; item: string }
-  | { action: "check"; item: string }
-  | { action: "uncheck"; item: string }
-  | { action: "rename"; item: string; title: string }
-  | { action: "move"; item: string; /** 1-based target position. */ to: number };
+  | ({ action: "remove" } & ChecklistTarget)
+  | ({ action: "check" } & ChecklistTarget)
+  | ({ action: "uncheck" } & ChecklistTarget)
+  | ({ action: "rename"; title: string } & ChecklistTarget)
+  | ({ action: "move"; /** 1-based target position. */ to: number } & ChecklistTarget);
 
-/** Resolve an item by exact title — loud on missing/ambiguous (never guess). */
-function checklistIndex(items: ChecklistItemSpec[], ref: string): number {
+/**
+ * Resolve a checklist target to an array index. `index` (1-based) is exact.
+ * A title resolves best-effort: unique → that item; duplicates → the first on
+ * which the action is meaningful (check → first unchecked, uncheck → first
+ * checked, others → first match). Loud only when nothing matches / index is
+ * out of range.
+ */
+function checklistTarget(
+  items: ChecklistItemSpec[],
+  edit: ChecklistEdit & ChecklistTarget,
+): number {
+  if (edit.index !== undefined) {
+    const i = edit.index - 1;
+    if (i < 0 || i >= items.length) {
+      throw new RangeError(`checklist index ${edit.index} is out of range (1..${items.length})`);
+    }
+    return i;
+  }
+  const ref = edit.item;
+  if (ref === undefined) throw new RangeError("give a checklist item title or 1-based index");
   const matches = items.map((c, i) => ({ c, i })).filter(({ c }) => c.title === ref);
+  if (matches.length === 0) throw new RangeError(`no checklist item titled "${ref}"`);
   if (matches.length === 1) return (matches[0] as { i: number }).i;
-  throw new RangeError(
-    matches.length === 0
-      ? `no checklist item titled "${ref}"`
-      : `checklist item title "${ref}" is ambiguous (${matches.length} matches) — rename first`,
-  );
+  const meaningful =
+    edit.action === "check"
+      ? matches.find(({ c }) => !c.completed)
+      : edit.action === "uncheck"
+        ? matches.find(({ c }) => c.completed)
+        : undefined;
+  return (meaningful ?? matches[0] ?? { i: 0 }).i;
 }
 
 export function applyChecklistEdit(
@@ -318,21 +350,21 @@ export function applyChecklistEdit(
       return next;
     }
     case "remove":
-      next.splice(checklistIndex(next, edit.item), 1);
+      next.splice(checklistTarget(next, edit), 1);
       return next;
     case "check":
     case "uncheck": {
-      const target = next[checklistIndex(next, edit.item)] as ChecklistItemSpec;
+      const target = next[checklistTarget(next, edit)] as ChecklistItemSpec;
       target.completed = edit.action === "check";
       return next;
     }
     case "rename": {
-      const target = next[checklistIndex(next, edit.item)] as ChecklistItemSpec;
+      const target = next[checklistTarget(next, edit)] as ChecklistItemSpec;
       target.title = edit.title;
       return next;
     }
     case "move": {
-      const from = checklistIndex(next, edit.item);
+      const from = checklistTarget(next, edit);
       const [moved] = next.splice(from, 1);
       next.splice(Math.max(0, Math.min(next.length, edit.to - 1)), 0, moved as ChecklistItemSpec);
       return next;

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -15,7 +15,7 @@ export const API_VERSION = 1;
  * Package version, surfaced by `things --version` and the MCP serverInfo.
  * Kept in lockstep with package.json by a contract test.
  */
-export const PKG_VERSION = "0.5.0";
+export const PKG_VERSION = "0.6.0";
 
 /**
  * Stable exit-code contract for the `things` CLI (mirrored by MCP error

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -160,6 +160,14 @@ function buildInstructions(getClient: () => ThingsClient): string {
   return lines.join("\n");
 }
 
+/** Build a checklist edit target from MCP args (index wins over title). */
+function checklistTarget(args: { item?: string | undefined; index?: number | undefined }): {
+  item?: string;
+  index?: number;
+} {
+  return args.index !== undefined ? { index: args.index } : { item: args.item ?? "" };
+}
+
 export function createThingsMcpServer(options: McpServerOptions = {}): McpServer {
   // One lazily-opened client for the server's lifetime; SQLite read
   // snapshots are per-statement, so fresh reads see external commits.
@@ -654,8 +662,9 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
     {
       description:
         "Edit a to-do's checklist. The single-item actions add / remove / check / uncheck " +
-        "/ rename / move change one item — matched by exact title — and leave every other " +
-        "item and its checked state untouched. The replace action swaps in a whole new " +
+        "/ rename / move change one item — targeted by title or 1-based index — and leave " +
+        "every other item and its checked state untouched (duplicate titles resolve " +
+        "best-effort). The replace action swaps in a whole new " +
         "list (items), discarding the existing items and their checked states — pass " +
         "acknowledge_checklist_reset to confirm when items already exist; entries may be " +
         "strings or {title, completed} objects to create items pre-checked. Positions are " +
@@ -667,7 +676,15 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
         item: z
           .string()
           .optional()
-          .describe("remove/check/uncheck/rename/move: the existing item's exact title"),
+          .describe("remove/check/uncheck/rename/move: the existing item's title"),
+        index: z
+          .number()
+          .int()
+          .min(1)
+          .optional()
+          .describe(
+            "remove/check/uncheck/rename/move: target by 1-based position instead of title",
+          ),
         at: z
           .number()
           .int()
@@ -723,20 +740,22 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
           case "remove":
           case "check":
           case "uncheck":
-            if (args.item === undefined) return usage(`action "${args.action}" requires item`);
-            edit = { action: args.action, item: args.item };
+            if (args.item === undefined && args.index === undefined) {
+              return usage(`action "${args.action}" requires item or index`);
+            }
+            edit = { action: args.action, ...checklistTarget(args) };
             break;
           case "rename":
-            if (args.item === undefined || args.title === undefined) {
-              return usage('action "rename" requires item and title');
+            if (args.title === undefined || (args.item === undefined && args.index === undefined)) {
+              return usage('action "rename" requires title and (item or index)');
             }
-            edit = { action: "rename", item: args.item, title: args.title };
+            edit = { action: "rename", ...checklistTarget(args), title: args.title };
             break;
           case "move":
-            if (args.item === undefined || args.to === undefined) {
-              return usage('action "move" requires item and to');
+            if (args.to === undefined || (args.item === undefined && args.index === undefined)) {
+              return usage('action "move" requires to and (item or index)');
             }
-            edit = { action: "move", item: args.item, to: args.to };
+            edit = { action: "move", ...checklistTarget(args), to: args.to };
             break;
         }
         return mutationResult(await c.write.editChecklist(args.uuid, edit, writeOptions(args)));

--- a/src/model/entities.ts
+++ b/src/model/entities.ts
@@ -54,9 +54,6 @@ interface TaskCommon {
   /** Opt-in: tags inherited from ancestor area/project (native UI filtering includes these). */
   inheritedTags?: Ref[];
   repeating: RepeatingInfo;
-  /** Sparse sortable rank keys — expose raw, never renumber. */
-  index: number;
-  todayIndex: number;
   created: Date;
   modified: Date;
   stopped: Date | null;
@@ -84,14 +81,12 @@ export interface Heading {
   title: string;
   /** The owning project. */
   project: Ref | null;
-  index: number;
 }
 
 export interface Area {
   uuid: string;
   title: string;
   visible: boolean;
-  index: number;
   tags: Ref[];
 }
 
@@ -100,19 +95,19 @@ export interface Tag {
   title: string;
   shortcut: string | null;
   parent: Ref | null;
-  index: number;
 }
 
+/**
+ * A checklist item as the API surfaces it: title + status only. The DB uuid
+ * is deliberately omitted — it is regenerated on every checklist rewrite and
+ * is never a valid mutation target (address items by title or 1-based
+ * position; see docs/design/reference-resolution.md). `status` is open |
+ * completed | canceled (canceled exists in real data); items have no
+ * trashed/logged state — they live and move with their parent to-do.
+ */
 export interface ChecklistItem {
-  uuid: string;
   title: string;
   status: TaskStatus;
-  index: number;
-  /** Owning to-do uuid. */
-  task: string;
-  created: Date;
-  modified: Date;
-  stopped: Date | null;
 }
 
 export type AnyTask = Todo | Project | Heading;

--- a/src/model/mappers.ts
+++ b/src/model/mappers.ts
@@ -119,8 +119,6 @@ function commonFields(row: TaskRow, refs: RefResolver, tags: Ref[]) {
     area: refs(row.area),
     tags,
     repeating: mapRepeating(row),
-    index: row.index ?? 0,
-    todayIndex: row.todayIndex ?? 0,
     created: decodeEpochReal(row.creationDate) ?? new Date(0),
     modified: decodeEpochReal(row.userModificationDate) ?? new Date(0),
     stopped: decodeEpochReal(row.stopDate),
@@ -153,19 +151,12 @@ export function mapHeading(row: TaskRow, refs: RefResolver): Heading {
     type: "heading",
     title: row.title ?? "",
     project: refs(row.project),
-    index: row.index ?? 0,
   };
 }
 
 export function mapChecklistItem(row: ChecklistRow): ChecklistItem {
   return {
-    uuid: row.uuid,
     title: row.title ?? "",
     status: mapStatus(row),
-    index: row.index ?? 0,
-    task: row.task,
-    created: decodeEpochReal(row.creationDate) ?? new Date(0),
-    modified: decodeEpochReal(row.userModificationDate) ?? new Date(0),
-    stopped: decodeEpochReal(row.stopDate),
   };
 }

--- a/src/read/area-view.ts
+++ b/src/read/area-view.ts
@@ -42,7 +42,6 @@ export function areaView(db: DatabaseSync, ref: string, now?: Date): AreaView {
     uuid: row.uuid,
     title: row.title ?? "",
     visible: row.visible !== 0,
-    index: row.index ?? 0,
     tags: areaTags(db, uuid),
   };
 

--- a/src/read/queries.ts
+++ b/src/read/queries.ts
@@ -84,54 +84,107 @@ export function resolveTaskUuidPrefix(db: DatabaseSync, ref: string): string {
   return rows[0]?.uuid ?? ref;
 }
 
+/**
+ * Fold a name to its match key: NFC + case-fold + strip all whitespace and
+ * dashes/hyphens (ASCII hyphen, the U+2010–2015 dash block, U+2212 minus).
+ * Nothing else is removed, so emoji/symbols stay significant — see
+ * docs/design/reference-resolution.md.
+ */
+export function normalizeNameKey(s: string): string {
+  return s
+    .normalize("NFC")
+    .toLowerCase()
+    .replace(/[\s‐-―−-]+/gu, "");
+}
+
+const BASE62 = /^[0-9A-Za-z]+$/;
+
+export interface NamedResolution {
+  resolved: { uuid: string; title: string } | null;
+  /** 0 = not found, 1 = ok, >1 = ambiguous at the deciding tier. */
+  matches: number;
+}
+
+/**
+ * Tiered reference resolution (docs/design/reference-resolution.md): exact
+ * uuid → exact title → case-insensitive title → normalized title → uuid
+ * prefix. The FIRST tier with exactly one match wins; a tier with several is
+ * ambiguous; no tier is not-found. Shared by the read-side `resolve*Uuid`
+ * throwers and the write-side `resolve*` (ContainerResolution) helpers.
+ */
+export function resolveNamedRef(
+  db: DatabaseSync,
+  table: string,
+  extraWhere: string,
+  extraBinds: (string | number)[],
+  ref: string,
+): NamedResolution {
+  type Row = { uuid: string; title: string };
+  const sel = (cond: string, extra: (string | number)[] = []): Row[] =>
+    db
+      .prepare(`SELECT uuid, title FROM ${table} WHERE ${extraWhere} AND ${cond}`)
+      .all(...extraBinds, ...extra) as unknown as Row[];
+
+  const byId = sel("uuid = ?", [ref]);
+  if (byId.length === 1) return { resolved: byId[0] ?? null, matches: 1 };
+
+  for (const cond of ["title = ?", "title = ? COLLATE NOCASE"]) {
+    const rows = sel(cond, [ref]);
+    if (rows.length === 1) return { resolved: rows[0] ?? null, matches: 1 };
+    if (rows.length > 1) return { resolved: null, matches: rows.length };
+  }
+
+  const key = normalizeNameKey(ref);
+  if (key !== "") {
+    const hits = sel("title IS NOT NULL").filter((r) => normalizeNameKey(r.title) === key);
+    if (hits.length === 1) return { resolved: hits[0] ?? null, matches: 1 };
+    if (hits.length > 1) return { resolved: null, matches: hits.length };
+  }
+
+  if (ref.length >= 6 && BASE62.test(ref)) {
+    const upper = ref.slice(0, -1) + String.fromCharCode(ref.charCodeAt(ref.length - 1) + 1);
+    const rows = sel("uuid >= ? AND uuid < ?", [ref, upper]);
+    if (rows.length === 1) return { resolved: rows[0] ?? null, matches: 1 };
+    if (rows.length > 1) return { resolved: null, matches: rows.length };
+  }
+
+  return { resolved: null, matches: 0 };
+}
+
+function resolveUuidOrThrow(
+  db: DatabaseSync,
+  table: string,
+  extraWhere: string,
+  ref: string,
+  kind: string,
+  listCmd: string,
+): string {
+  const r = resolveNamedRef(db, table, extraWhere, [], ref);
+  if (r.resolved !== null) return r.resolved.uuid;
+  throw new RangeError(
+    r.matches === 0
+      ? `${kind} not found: ${ref} (list ${kind}s with \`${listCmd}\`)`
+      : `${kind} reference is ambiguous: ${ref} (${r.matches} matches — use the exact name or uuid)`,
+  );
+}
+
 export function resolveTagUuid(db: DatabaseSync, ref: string): string {
-  const byId = db.prepare("SELECT uuid FROM TMTag WHERE uuid = ?").get(ref) as
-    | { uuid: string }
-    | undefined;
-  if (byId !== undefined) return byId.uuid;
-  const rows = db.prepare("SELECT uuid FROM TMTag WHERE title = ? COLLATE NOCASE").all(ref) as {
-    uuid: string;
-  }[];
-  if (rows.length === 1 && rows[0] !== undefined) return rows[0].uuid;
-  throw new RangeError(
-    rows.length === 0
-      ? `tag not found: ${ref} (list tags with \`things tags\`)`
-      : `tag reference is ambiguous: ${ref} (${rows.length} matches — use the uuid)`,
-  );
+  return resolveUuidOrThrow(db, "TMTag", "1=1", ref, "tag", "things tags");
 }
 
-/** Resolve a project reference (uuid or unique case-insensitive title) — loud on miss. */
 export function resolveProjectUuid(db: DatabaseSync, ref: string): string {
-  const byId = db
-    .prepare("SELECT uuid FROM TMTask WHERE uuid = ? AND type = 1 AND trashed = 0")
-    .get(ref) as { uuid: string } | undefined;
-  if (byId !== undefined) return byId.uuid;
-  const rows = db
-    .prepare("SELECT uuid FROM TMTask WHERE title = ? COLLATE NOCASE AND type = 1 AND trashed = 0")
-    .all(ref) as { uuid: string }[];
-  if (rows.length === 1 && rows[0] !== undefined) return rows[0].uuid;
-  throw new RangeError(
-    rows.length === 0
-      ? `project not found: ${ref} (list projects with \`things projects\`)`
-      : `project reference is ambiguous: ${ref} (${rows.length} matches — use the uuid)`,
+  return resolveUuidOrThrow(
+    db,
+    "TMTask",
+    "type = 1 AND trashed = 0",
+    ref,
+    "project",
+    "things projects",
   );
 }
 
-/** Resolve an area reference (uuid or unique case-insensitive title) — loud on miss. */
 export function resolveAreaUuid(db: DatabaseSync, ref: string): string {
-  const byId = db.prepare("SELECT uuid FROM TMArea WHERE uuid = ?").get(ref) as
-    | { uuid: string }
-    | undefined;
-  if (byId !== undefined) return byId.uuid;
-  const rows = db.prepare("SELECT uuid FROM TMArea WHERE title = ? COLLATE NOCASE").all(ref) as {
-    uuid: string;
-  }[];
-  if (rows.length === 1 && rows[0] !== undefined) return rows[0].uuid;
-  throw new RangeError(
-    rows.length === 0
-      ? `area not found: ${ref} (list areas with \`things areas\`)`
-      : `area reference is ambiguous: ${ref} (${rows.length} matches — use the uuid)`,
-  );
+  return resolveUuidOrThrow(db, "TMArea", "1=1", ref, "area", "things areas");
 }
 
 export function fetchTaskRows(db: DatabaseSync, where: string, params: unknown[] = []): TaskRow[] {

--- a/src/read/tags.ts
+++ b/src/read/tags.ts
@@ -35,7 +35,6 @@ export function tagsView(db: DatabaseSync): Tag[] {
       title: row.title ?? "",
       shortcut: row.shortcut,
       parent: parentRow ? { uuid: parentRow.uuid, title: parentRow.title ?? "" } : null,
-      index: row.index ?? 0,
     };
   });
 }
@@ -55,7 +54,6 @@ export function areasView(db: DatabaseSync): Area[] {
     uuid: row.uuid,
     title: row.title ?? "",
     visible: row.visible !== 0,
-    index: row.index ?? 0,
     tags: areaTags(db, row.uuid),
   }));
 }

--- a/src/read/views.ts
+++ b/src/read/views.ts
@@ -271,7 +271,9 @@ function groupBySidebar(db: DatabaseSync, items: ListItem[]): SidebarSection[] {
     }
   }
 
-  const sortKey = (i: ListItem) => {
+  // items arrive in SQL "index" order, so array position IS the per-container
+  // rank (the internal index is no longer exposed on the entity).
+  const sortKey = (i: ListItem, pos: number) => {
     const project = i.type === "project" ? i.uuid : effProject(i);
     const meta = project === null ? undefined : projectMeta.get(project);
     const area = i.area?.uuid ?? meta?.area ?? null;
@@ -282,11 +284,11 @@ function groupBySidebar(db: DatabaseSync, items: ListItem[]): SidebarSection[] {
       projectIndex: meta?.index ?? 0,
       project: project ?? "",
       headerFirst: i.type === "project" ? 0 : 1,
-      index: i.index,
+      pos,
       uuid: i.uuid,
     };
   };
-  const keyed = items.map((item) => ({ item, k: sortKey(item) }));
+  const keyed = items.map((item, pos) => ({ item, k: sortKey(item, pos) }));
   keyed.sort(
     (a, b) =>
       a.k.areaRank - b.k.areaRank ||
@@ -295,7 +297,7 @@ function groupBySidebar(db: DatabaseSync, items: ListItem[]): SidebarSection[] {
       a.k.projectIndex - b.k.projectIndex ||
       a.k.project.localeCompare(b.k.project) ||
       a.k.headerFirst - b.k.headerFirst ||
-      a.k.index - b.k.index ||
+      a.k.pos - b.k.pos ||
       a.k.uuid.localeCompare(b.k.uuid),
   );
 
@@ -389,12 +391,15 @@ export function upcomingView(db: DatabaseSync, now?: Date, filter?: UpcomingFilt
     }));
   });
 
-  return [...items, ...occurrences].toSorted(
-    (a, b) =>
-      (a.startDate ?? "").localeCompare(b.startDate ?? "") ||
-      a.index - b.index ||
-      a.uuid.localeCompare(b.uuid),
-  );
+  return [...items, ...occurrences]
+    .map((item, pos) => ({ item, pos }))
+    .toSorted(
+      (a, b) =>
+        (a.item.startDate ?? "").localeCompare(b.item.startDate ?? "") ||
+        a.pos - b.pos ||
+        a.item.uuid.localeCompare(b.item.uuid),
+    )
+    .map((x) => x.item);
 }
 
 export interface SomedayFilter extends ViewFilter {

--- a/src/write/pre-state.ts
+++ b/src/write/pre-state.ts
@@ -8,6 +8,7 @@ import { encodePackedDate, localToday } from "../model/dates.ts";
 import type { AnyTask, Project, TaskStatus, Todo } from "../model/entities.ts";
 import { TASK_STATUS_FROM_DB } from "../model/entities.ts";
 import { byUuid } from "../read/detail.ts";
+import { resolveNamedRef } from "../read/queries.ts";
 import type { ContainerRef, ReorderParams } from "./operations.ts";
 
 export interface ResolvedContainer {
@@ -106,45 +107,12 @@ export function emptyPreState(): PreState {
   };
 }
 
-function resolveByTitleOrUuid(
-  db: DatabaseSync,
-  table: "TMArea" | "TMTag",
-  ref: string,
-): ContainerResolution {
-  const byId = db.prepare(`SELECT uuid, title FROM ${table} WHERE uuid = ?`).get(ref) as
-    | ResolvedContainer
-    | undefined;
-  if (byId !== undefined) return { resolved: byId, matches: 1 };
-  const rows = db
-    .prepare(`SELECT uuid, title FROM ${table} WHERE title = ? COLLATE NOCASE`)
-    .all(ref) as unknown as ResolvedContainer[];
-  const first = rows[0];
-  return {
-    resolved: rows.length === 1 && first !== undefined ? first : null,
-    matches: rows.length,
-  };
-}
-
 export function resolveArea(db: DatabaseSync, ref: ContainerRef): ContainerResolution {
-  return resolveByTitleOrUuid(db, "TMArea", ref.uuid ?? ref.title ?? "");
+  return resolveNamedRef(db, "TMArea", "1=1", [], ref.uuid ?? ref.title ?? "");
 }
 
 export function resolveProject(db: DatabaseSync, ref: ContainerRef): ContainerResolution {
-  const key = ref.uuid ?? ref.title ?? "";
-  const byId = db
-    .prepare("SELECT uuid, title FROM TMTask WHERE uuid = ? AND type = 1 AND trashed = 0")
-    .get(key) as ResolvedContainer | undefined;
-  if (byId !== undefined) return { resolved: byId, matches: 1 };
-  const rows = db
-    .prepare(
-      "SELECT uuid, title FROM TMTask WHERE title = ? COLLATE NOCASE AND type = 1 AND trashed = 0",
-    )
-    .all(key) as unknown as ResolvedContainer[];
-  const first = rows[0];
-  return {
-    resolved: rows.length === 1 && first !== undefined ? first : null,
-    matches: rows.length,
-  };
+  return resolveNamedRef(db, "TMTask", "type = 1 AND trashed = 0", [], ref.uuid ?? ref.title ?? "");
 }
 
 export function resolveHeading(
@@ -179,7 +147,7 @@ export function missingTagTitles(db: DatabaseSync, titles: string[]): string[] {
 }
 
 export function resolveTag(db: DatabaseSync, ref: string): ContainerResolution {
-  return resolveByTitleOrUuid(db, "TMTag", ref);
+  return resolveNamedRef(db, "TMTag", "1=1", [], ref);
 }
 
 export function loadTarget(db: DatabaseSync, uuid: string): AnyTask | null {

--- a/test/unit/mappers.test.ts
+++ b/test/unit/mappers.test.ts
@@ -55,7 +55,6 @@ describe("mapTodo", () => {
     expect(todo.startDate).toBe("2026-06-25");
     expect(todo.todaySection).toBe("evening");
     expect(todo.area).toEqual(AREA);
-    expect(todo.todayIndex).toBe(6000626); // sparse rank exposed raw
     expect(todo.repeating).toEqual({ isTemplate: false, isInstance: false, templateUuid: null });
   });
 
@@ -99,7 +98,6 @@ describe("mapProject / mapHeading", () => {
       type: "heading",
       title: "Phase 1",
       project: null,
-      index: -1731,
     });
   });
 });

--- a/test/unit/reference-resolution.test.ts
+++ b/test/unit/reference-resolution.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { normalizeNameKey, resolveAreaUuid, resolveNamedRef } from "../../src/read/queries.ts";
+import { applyChecklistEdit } from "../../src/client.ts";
+import type { ChecklistItemSpec } from "../../src/write/operations.ts";
+import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
+import { seedArea, seedTag } from "../fixtures/seed.ts";
+
+let fx: FixtureDb;
+beforeEach(() => (fx = buildFixtureDb()));
+afterEach(() => fx?.close());
+
+const resolveArea = (ref: string) => resolveNamedRef(fx.db, "TMArea", "1=1", [], ref);
+
+describe("normalizeNameKey", () => {
+  it("folds case, whitespace, and dashes but keeps emoji/symbols", () => {
+    expect(normalizeNameKey("On Hold")).toBe("onhold");
+    expect(normalizeNameKey("on-hold")).toBe("onhold");
+    expect(normalizeNameKey("Family - Jennifer")).toBe("familyjennifer");
+    expect(normalizeNameKey("🗄️errand")).toBe("🗄️errand");
+    expect(normalizeNameKey("HEALTH")).toBe("health");
+  });
+});
+
+describe("tiered name resolution (areas/tags)", () => {
+  it("Mike's case: `family` matches `Family` and NOT `Family - Jennifer`", () => {
+    seedArea(fx.db, "Family");
+    seedArea(fx.db, "Family - Jennifer");
+    const r = resolveArea("family");
+    expect(r.resolved?.title).toBe("Family");
+    expect(r.matches).toBe(1);
+  });
+
+  it("case-variant collision is ambiguous — unless the exact casing is given", () => {
+    seedArea(fx.db, "Family");
+    seedArea(fx.db, "FaMiLy");
+    // lowercase matches both at the case-insensitive tier → ambiguous
+    expect(resolveArea("family").matches).toBe(2);
+    expect(resolveArea("family").resolved).toBeNull();
+    // exact casing wins definitively at tier 1, ignoring the other
+    expect(resolveArea("Family").resolved?.title).toBe("Family");
+    expect(resolveArea("FaMiLy").resolved?.title).toBe("FaMiLy");
+  });
+
+  it("normalized tier: space/dash-insensitive when higher tiers miss", () => {
+    seedArea(fx.db, "On Hold");
+    expect(resolveArea("on-hold").resolved?.title).toBe("On Hold");
+    expect(resolveArea("ONHOLD").resolved?.title).toBe("On Hold");
+  });
+
+  it("leading emoji is significant: `errand` never matches `🗄️errand`", () => {
+    seedTag(fx.db, "🗄️errand");
+    const r = resolveNamedRef(fx.db, "TMTag", "1=1", [], "errand");
+    expect(r.resolved).toBeNull();
+    expect(r.matches).toBe(0);
+    // but the full emoji name resolves
+    expect(resolveNamedRef(fx.db, "TMTag", "1=1", [], "🗄️errand").resolved?.title).toBe("🗄️errand");
+  });
+
+  it("an active tag wins over an archived emoji-prefixed one at the same key", () => {
+    seedTag(fx.db, "errand");
+    seedTag(fx.db, "🗄️errand");
+    expect(resolveNamedRef(fx.db, "TMTag", "1=1", [], "errand").resolved?.title).toBe("errand");
+  });
+
+  it("exact uuid resolves; a unique uuid prefix resolves as a last resort", () => {
+    // Real Things uuids are base-62 (the fixture generator uses hyphens, which
+    // are not valid uuid-prefix input), so insert a realistic one directly.
+    const uuid = "Ab3xK9mNpQ2rSt4uVw6yZ0";
+    fx.db
+      .prepare('INSERT INTO TMArea (uuid, title, visible, "index") VALUES (?, ?, 1, 0)')
+      .run(uuid, "Work");
+    expect(resolveArea(uuid).resolved?.uuid).toBe(uuid);
+    expect(resolveArea(uuid.slice(0, 8)).resolved?.uuid).toBe(uuid);
+  });
+
+  it("the throwing wrapper reports not-found vs ambiguous", () => {
+    seedArea(fx.db, "Dup");
+    seedArea(fx.db, "Dup");
+    expect(() => resolveAreaUuid(fx.db, "Nope")).toThrow(/not found/);
+    expect(() => resolveAreaUuid(fx.db, "Dup")).toThrow(/ambiguous/);
+  });
+});
+
+describe("checklist targeting (best-effort title + 1-based index)", () => {
+  const list = (): ChecklistItemSpec[] => [
+    { title: "get milk", completed: true },
+    { title: "get eggs", completed: false },
+    { title: "get milk", completed: false },
+  ];
+
+  it("check by title targets the first UNCHECKED match (best-effort on duplicates)", () => {
+    const out = applyChecklistEdit(list(), { action: "check", item: "get milk" });
+    // the second 'get milk' (index 2) was unchecked → it gets checked; the first stays
+    expect(out.map((c) => c.completed)).toEqual([true, false, true]);
+  });
+
+  it("uncheck by title targets the first CHECKED match", () => {
+    const out = applyChecklistEdit(list(), { action: "uncheck", item: "get milk" });
+    expect(out.map((c) => c.completed)).toEqual([false, false, false]);
+  });
+
+  it("1-based index targets exactly and overrides title", () => {
+    const out = applyChecklistEdit(list(), { action: "rename", index: 2, title: "get bread" });
+    expect(out.map((c) => c.title)).toEqual(["get milk", "get bread", "get milk"]);
+  });
+
+  it("out-of-range index and unknown title are loud", () => {
+    expect(() => applyChecklistEdit(list(), { action: "remove", index: 9 })).toThrow(
+      /out of range/,
+    );
+    expect(() => applyChecklistEdit(list(), { action: "check", item: "ghost" })).toThrow(
+      /no checklist item/,
+    );
+  });
+});


### PR DESCRIPTION
Implements the reference-resolution and internal-hiding design we nailed down. 425 tests green; rules documented in [docs/design/reference-resolution.md](docs/design/reference-resolution.md).

## Tiered name resolution (areas/tags/projects)
First tier with exactly one match wins **definitively**:
1. exact uuid → 2. exact title (case-sensitive) → 3. case-insensitive title → 4. normalized (NFC + whitespace/dash-folded) → 5. uuid prefix.

Your worked cases, unit-tested:
- `family` → `Family`, **not** ambiguous with `Family - Jennifer` (a different string, never in the running).
- `Family` + `FaMiLy`: lowercase `family` → ambiguous; exact `Family` wins definitively.
- `on-hold` → `On Hold` (normalized tier).
- **Leading emoji is significant**: a bare `errand` never matches an archived `🗄️errand` — your convention, with zero opinion encoded (we fold equivalent spellings, we don't delete characters). Areas/tags also take a unique uuid prefix now.

## Hidden internal identifiers (mildly breaking read shapes)
- `index`/`todayIndex` dropped from task/heading/area/tag responses (view sorters use array position — already SQL index-ordered).
- `ChecklistItem` → `{ title, status }`. The uuid/index/owning-task/timestamps were unstable, non-addressable internals (a checklist uuid is regenerated on every rewrite).
- `--json` still carries full task uuids; the audit log is unaffected.

## Checklist targeting
By title **or** `--index` (1-based, MCP `index`). Duplicate titles resolve best-effort — check → first unchecked, uncheck → first checked, else first match — with `--index` the exact override. Documented that checklist items are open/completed/**canceled** (canceled is read-only; 6 exist in your real data) and have no trashed/logged state.

Version bump to 0.6.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiiUK4qXABDtVKoW7S9Cft