### PR TITLE
feat: accept Things share links as refs + durable roadmap + headings doctrine decided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ _(nothing yet)_
 
 ### Reference resolution & hidden internals (mildly breaking)
 
+- **Things share links are accepted wherever a uuid or name is expected.** Right-click → Share → Copy Link in the app yields `things:///show?id=<uuid>`; paste it directly into any `--uuid`/`--area`/`--project`/`--tag` argument and it is stripped to the id automatically — no intermediate step.
+
 - **Names resolve in tiers** (areas, tags, projects): exact uuid → exact title → case-insensitive title → normalized title (whitespace/dash-insensitive, NFC) → uuid prefix. The first tier with exactly one match wins definitively; several is an ambiguity error. `--area family` finds `Family` without tripping over `Family - Jennifer`; `on-hold` finds `On Hold`. **Leading emoji/symbols are significant** — a name beginning with an emoji must be typed with it (so an archived `🗄️errand` tag is never matched by a bare `errand`). See [docs/design/reference-resolution.md](docs/design/reference-resolution.md).
 - **Area/tag references now accept a unique uuid prefix** too (≥6 chars), like task uuids.
 - **Internal sort keys are no longer surfaced.** `index` and `todayIndex` are dropped from task/heading/area/tag responses; checklist items are now `{ title, status }` only (their uuid, index, owning-task, and timestamps were unstable implementation details — a checklist item's uuid is regenerated on every rewrite and was never addressable). Ordering is conveyed by array order; `--json` still carries full task uuids. **This changes read-response shapes.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@
 - **[docs/capability-matrix.md](docs/capability-matrix.md)** — the CRUD × vector wish-list/checklist. Update it in the SAME change as: any operation-catalog edit (`src/write/operations.ts`), any vector-matrix edit, any new probe verdict, or any gap opened/closed.
 - **[docs/things-app-oddities.md](docs/things-app-oddities.md)** — the future Cultured Code bug report. Record every newly discovered app bug/quirk THE MOMENT it is found, with probe evidence.
 - **[docs/gaps.md](docs/gaps.md)** — roadmap: one entry per phase, updated when a phase lands.
+- **[docs/roadmap.md](docs/roadmap.md)** — durable parked-work plan (survives compaction): decided-but-unbuilt items, distribution/onboarding, doctrine decisions. Update when a parked item lands or a new one is deferred.
 - **CHANGELOG.md** — every user-visible change goes under `## Unreleased`.
 
 ## Safety rails (non-negotiable)

--- a/docs/gaps.md
+++ b/docs/gaps.md
@@ -6,9 +6,9 @@ Living register of Things-app capabilities that are missing, thin, or janky in t
 
 ## Headline gaps
 
-### 0. Headings doctrine (DECIDED 2026-07-06; dual-mode now UNBLOCKED 2026-07-09)
+### 0. Headings doctrine — DECIDED 2026-07-09: FIRST-CLASS, no flatten mode
 
-The flatten-by-default plan: project reads return one FLAT to-do list in UI order with heading rows spliced out (walk project rows by `index`; replace each heading row with its children in their own container-scoped order); project reorder accepts ALL children and silently strips heading associations (O06's "rips headed children out" becomes the intended flattening, not a hazard); the `--heading` placement params get removed. Only `byUuid` keeps reporting the raw heading link. **The candidate second mode — headings first-class when a Shortcuts vector is configured — is now a LIVE path: the L5 sitting proved create/rename/delete all work via Shortcuts (§1).** Which mode ships (flatten-only vs dual-mode) is Mike's call; still implementation-deferred.
+**Final decision (see [docs/roadmap.md](roadmap.md) §E): headings are always first-class; there is NO flatten or dual mode.** The flatten plan was motivated by "headings barely work without Shortcuts" and "their index makes flat reads incoherent" — both premises are now false. AppleScript unblocked heading rename/archive/delete/reorder + placement (P10/P11, docs/lab/heading-research.md), leaving ONLY `heading.create`-in-an-existing-project Shortcuts-gated; and v0.6.0 HID `index`/`todayIndex`, removing the incoherence entirely. Reads stay heading-aware (free, SQLite); writes are capability-gated — `heading.create` reports `unsupported` + a `things setup shortcuts` remediation when Shortcuts is unconfigured (the `allow-experimental` pattern). No silent clobbering (O06 stays a guard). The prior flatten-by-default text is retired.
 
 ### 1. Headings in existing projects — SOLVED via Shortcuts (L5 sitting, 2026-07-09)
 - **Create / rename / delete a heading in an existing project all WORK via Shortcuts** (S02/S03/S04, [s-campaign-results.md](lab/s-campaign-results.md)) — `things-proxy-create-heading` / `-edit-title` / `-delete-items`. The sole capability Shortcuts uniquely provides, now proven.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,78 @@
+# things-api roadmap & parked work
+
+Durable plan (survives context compaction). Written 2026-07-09. Everything shipped through v0.6.0 lives in CHANGELOG / the living docs; this file tracks what is DECIDED-BUT-UNBUILT, PARKED, or awaiting Mike. Update as items land.
+
+## ⟹ RESUME HERE (post-compaction order)
+
+1. **Publish v0.6.0 to npm.** Prepared (package.json/lock + `PKG_VERSION` at 0.6.0, CHANGELOG 0.6.0 section dated 2026-07-09) but NOT tagged/published — needs Mike's `npm login` + OTP. Steps: confirm `npm run check` green → `npm pack --dry-run` (watch for the npm-11 bin warning, see memory `npm11-bin-path-quirk`) → `git tag v0.6.0` → `npm publish --access public --otp=<code>`.
+2. **§A Shortcuts onboarding** — the biggest gap; Mike wants the setup/share plan (below) actioned.
+3. **§B availability layer** (greenlit, straightforward).
+4. **§C e2e reorder coverage** + **§D project-schedule vector** (small).
+5. **§F comprehensive reference compendium** (Mike's "reference book" goal).
+
+Headings doctrine (§E) is DECIDED below — no flatten mode. Tag/area emoji-archival first-class support is SHELVED indefinitely (Mike, item 4).
+
+---
+
+## §A. Shortcuts onboarding & distribution
+
+### What is truly Shortcuts-only (the reason onboarding matters)
+Three capabilities exist on NO other surface (everything else — heading rename/archive/delete/reorder, placement under existing headings, etc. — now works via AppleScript/URL, see docs/lab/heading-research.md):
+1. **Create a heading in an EXISTING project** (S02) — the marquee gap. AppleScript has no `make heading` (A31); URL `heading=` never creates (T09). Headless once consented (output-class).
+2. **Clear a reminder from a DATE-scheduled item** (P3b) — AppleScript has no reminder property (⛔); URL can't clear dated reminders (oddity 2e). Headless.
+3. **Permanently delete ONE item** (S-delperm) — interactive-only (delete-class consent has no Always-Allow); AppleScript's only hard-delete is all-or-nothing `trash.empty`.
+
+So onboarding unlocks (1) and (2) headlessly; (3) stays user-present regardless.
+
+### The six proxy shortcuts (golden-resident; rebuild on a networked Mac)
+Build cards: docs/lab/l5-build-cards.md. Names/contracts: docs/lab/s-campaign-results.md. They are:
+`things-proxy-find-items`, `-create-heading`, `-edit-title`, `-set-detail`, `-delete-items`, `-delete-items-permanently`. All use Find Items (ID filter) → act; one item per run.
+
+### iCloud share-link durability (answers to Mike's questions)
+How Apple's `https://www.icloud.com/shortcuts/<id>` sharing works:
+- **Durability**: the link points to a SNAPSHOT stored on Apple's iCloud servers, tied to the sharer's Apple ID. It stays live as long as the sharer keeps it shared and the Apple ID is active — effectively indefinite, but Apple-hosted (not under our control).
+- **Editing after sharing**: sharing is **immutable per link**. Editing your local copy does NOT update the shared snapshot; re-sharing mints a NEW link. So a README link pins one version — update = new link + README bump.
+- **Removing from your system**: deleting your local shortcut does NOT immediately kill the link (the snapshot lives on iCloud), but if you **stop sharing** (Shortcut → Share sheet → Copy iCloud Link is per-share; there's a "Stop Sharing" in the shortcut's details) the link dies for everyone. So: don't revoke the shared links once published.
+- **Signing**: shared shortcuts are signed by the sharer's Apple ID; on import the recipient sees "Untrusted Shortcut" unless they've allowed untrusted shortcuts, OR the shortcut came through the signed iCloud share (which is trusted). Sharing via iCloud is the trusted path.
+
+### Recommended distribution plan
+1. On a networked Mac signed into Mike's Apple ID, build the six proxies from the build cards (or export from the golden — but the golden is airgapped/Apple-ID-less, so it can only make unsigned copies; rebuild is cleaner).
+2. For each, Share → Copy iCloud Link. Collect six `https://www.icloud.com/shortcuts/...` links.
+3. Put them in the README under a "Shortcuts setup (optional)" section + a one-time consent note (grant "Always Allow" on first run of each output-class proxy).
+4. Build `things setup shortcuts`: prints the six links + install/consent instructions, and verifies presence via `shortcuts list`.
+5. Emit the same link + instructions from otherwise-blocked actions (heading create, dated-reminder clear) as the remediation string.
+
+### Bulk edits (Mike's question)
+All proxies are single-item by design (Find Items → one → act), which is CORRECT for us: per-item verification is the whole point of the pipeline. A bulk case ("tag 500 items matching 'drive'") is served by `things batch` iterating single mutations, each guarded+verified — we do NOT want a bulk Shortcuts action (loses verification, and triggers the scary "allow large edits" consent). Conclusion: the "allow Shortcuts to edit large amounts of data" setting is MOOT for our design; doctor need not flag it. (uriSchemeEnabled still gets surfaced — §B.)
+
+---
+
+## §B. Availability / environment layer (greenlit)
+
+- Advisory `availability(env)` per write vector: does this surface work in the current environment? (URL scheme needs `uriSchemeEnabled`; Shortcuts needs the proxies present + consented.)
+- `things doctor` reads `uriSchemeEnabled` (int-bool in the group-container plist, via `plutil -p` — see docs/lab/phase21b-research.md) and reports Enable-Things-URLs state.
+- Correct the `feature-disabled` failure classifier to key on `uriSchemeEnabled` rather than a null token (the token persists even when disabled — Phase 21b).
+- Do NOT flag the "allow large edits" Shortcuts setting (moot, §A bulk note).
+
+## §C. e2e reorder coverage (small)
+The guest e2e smoke (lab/scripts/e2e-write-smoke.sh) has NO reorder steps. Add smoke steps for the shipped scopes: inbox, someday (to-dos + area-less projects), headings, projects (bounce). One VM run; wire into `lab:regress`.
+
+## §D. AppleScript project-schedule vector (small — "what did you mean")
+P14-A3 found `schedule to do id <PROJECT>` SUCCEEDS via AppleScript (projects inherit the `to do` class), setting the project's startDate with no error/crash. Today `project.update` schedules a project only via the URL vector (`update-project?when=`). This means AppleScript is an ALTERNATIVE, un-wired vector for project scheduling. Action: add an `applescript` matrix entry + compile branch for project schedule (evidence P14-A3), OR just document it and leave URL as the sole vector (it already works). Low priority; decide during §F.
+
+## §E. Headings doctrine — DECIDED 2026-07-09: no flatten mode
+
+**Decision: headings are ALWAYS first-class. There is NO flatten/dual-mode.** Rationale (supersedes gaps.md §0's flatten-by-default plan):
+- The original case for flattening was "headings barely work without Shortcuts + their index makes flat reads incoherent." Both premises are now FALSE: AppleScript unblocked rename/archive/delete/reorder + placement (P10/P11), leaving only heading CREATE-in-existing-project Shortcuts-gated; and we HID `index`/`todayIndex` (v0.6.0), so the incoherence argument is gone entirely.
+- **Reads**: always heading-aware — free (SQLite; project-view already groups by heading). No second flat shape to build or maintain.
+- **Writes**: naturally capability-gated. Placement/rename/archive/delete/reorder work now. Only `heading.create` (in an existing project) reports `unsupported` with a "run `things setup shortcuts`" remediation when Shortcuts isn't configured — exactly the `allow-experimental` pattern.
+- **No silent clobbering**: the O06 "reorder rips headed children out" stays a guard, never a silent flatten. Silence is what created that hazard class.
+- **Maintenance burden avoided**: a flatten/dual-mode would mean two read shapes, index-reconciliation, mode config, and a whole class of "which mode am I in" bugs — for the sake of one create op. Not worth it.
+
+Only remaining heading work: wire `heading.create` behind the Shortcuts vector (§A). Update gaps.md §0 to record this decision when §A lands.
+
+## §F. Comprehensive reference compendium (Mike's "reference book")
+Goal: by project end, EVERYTHING probed is documented in one navigable place. Consolidate the per-campaign lab docs (a/o/p/r/e/u/x/s-suite results, phase21b, scf/scf2, P7–P14, heading-research) into a `docs/reference/` compendium: the full op×vector×verdict matrix with evidence ids, the crash/erratic catalog (oddities §7), and the "novel working paths" list. Leave no stone: any op we hand-waved as "probably dead" without a probe gets one. Track open probe candidates here as they arise.
+
+## Shelved indefinitely (Mike, item 4)
+First-class support for "ignored"/archived tags, emoji-stripping opt-in, pseudo-archived areas. Revisit only if real usage surfaces a need. (The leading-symbol-significant rule already protects emoji-prefixed archival tags for free — v0.6.0.)

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -24,6 +24,8 @@ AGENT NOTES:
   - Uuid parameters accept unique PREFIXES (>= 6 chars); list output shows
     8+-char prefixes, --json always carries full uuids. Ambiguous prefixes
     fail with the candidates listed.
+  - A Things share link (Share > Copy Link, "things:///show?id=<uuid>") is
+    accepted anywhere a uuid or name is expected — it is stripped to the id.
   - Exit codes are stable: 0 ok, 2 usage, 3 verify-failed, 4 blocked,
     5 drift-blocked, 6 unsupported, 7 environment.
   - No command ever prompts interactively; operations with cascading or

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -121,7 +121,8 @@ function buildInstructions(getClient: () => ThingsClient): string {
     "Conventions:",
     "- Items are identified by uuid (returned by every read tool); uuid parameters accept " +
       "unique prefixes of at least 6 characters (ambiguity returns an error listing the " +
-      "candidates). Where a parameter says " +
+      "candidates); a Things share link (things:///show?id=<uuid>) is also accepted and " +
+      "stripped to its id. Where a parameter says " +
       `"${REF_FORMAT}", projects, areas, and tags may also be referenced by exact name.`,
     "- References must name existing items; unknown or ambiguous references return an error " +
       "rather than being guessed at. Create missing tags/areas/projects first (add_tag, " +

--- a/src/read/queries.ts
+++ b/src/read/queries.ts
@@ -64,7 +64,28 @@ export function tagWithDescendants(db: DatabaseSync, uuid: string): string[] {
  * not-found, several throw with the candidates listed. Uuid params across
  * the CLI/MCP/library accept prefixes through this.
  */
-export function resolveTaskUuidPrefix(db: DatabaseSync, ref: string): string {
+/**
+ * Accept a Things share link wherever a uuid/ref is expected: the app's
+ * right-click → Share → Copy Link yields `things:///show?id=<uuid>`. Strip
+ * the URI to its `id` (or `query`) parameter so it pastes directly; non-URI
+ * input passes through untouched (after trimming).
+ */
+export function stripThingsUri(ref: string): string {
+  const s = ref.trim();
+  if (!/^things:/i.test(s)) return s;
+  const m = /[?&](?:id|query)=([^&]+)/i.exec(s);
+  if (m?.[1] !== undefined) {
+    try {
+      return decodeURIComponent(m[1]);
+    } catch {
+      return m[1];
+    }
+  }
+  return s;
+}
+
+export function resolveTaskUuidPrefix(db: DatabaseSync, refRaw: string): string {
+  const ref = stripThingsUri(refRaw);
   const exact = db.prepare("SELECT uuid FROM TMTask WHERE uuid = ?").get(ref) as
     | { uuid: string }
     | undefined;
@@ -117,8 +138,9 @@ export function resolveNamedRef(
   table: string,
   extraWhere: string,
   extraBinds: (string | number)[],
-  ref: string,
+  refRaw: string,
 ): NamedResolution {
+  const ref = stripThingsUri(refRaw);
   type Row = { uuid: string; title: string };
   const sel = (cond: string, extra: (string | number)[] = []): Row[] =>
     db

--- a/test/unit/reference-resolution.test.ts
+++ b/test/unit/reference-resolution.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { normalizeNameKey, resolveAreaUuid, resolveNamedRef } from "../../src/read/queries.ts";
+import {
+  normalizeNameKey,
+  resolveAreaUuid,
+  resolveNamedRef,
+  stripThingsUri,
+} from "../../src/read/queries.ts";
 import { applyChecklistEdit } from "../../src/client.ts";
 import type { ChecklistItemSpec } from "../../src/write/operations.ts";
 import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
@@ -22,7 +27,27 @@ describe("normalizeNameKey", () => {
   });
 });
 
+describe("stripThingsUri", () => {
+  it("extracts the id from a Share > Copy Link uri; passes plain refs through", () => {
+    expect(stripThingsUri("things:///show?id=ArVfyjWdyQHKVRLxNKaQYA")).toBe(
+      "ArVfyjWdyQHKVRLxNKaQYA",
+    );
+    expect(stripThingsUri("  things:///show?id=ABC123&reveal=1 ")).toBe("ABC123");
+    expect(stripThingsUri("things:///show?query=Errands")).toBe("Errands");
+    expect(stripThingsUri("ArVfyjWdyQHKVRLxNKaQYA")).toBe("ArVfyjWdyQHKVRLxNKaQYA");
+    expect(stripThingsUri("Family")).toBe("Family");
+  });
+});
+
 describe("tiered name resolution (areas/tags)", () => {
+  it("a Share link resolves like the bare uuid it wraps", () => {
+    const uuid = "Zx9qWaBc2dEf4gHi6jKl8m";
+    fx.db
+      .prepare('INSERT INTO TMArea (uuid, title, visible, "index") VALUES (?, ?, 1, 0)')
+      .run(uuid, "Linked");
+    expect(resolveArea(`things:///show?id=${uuid}`).resolved?.uuid).toBe(uuid);
+  });
+
   it("Mike's case: `family` matches `Family` and NOT `Family - Jennifer`", () => {
     seedArea(fx.db, "Family");
     seedArea(fx.db, "Family - Jennifer");


### PR DESCRIPTION
## Share links as references (folded into unpublished 0.6.0)
Right-click → Share → Copy Link in the app gives `things:///show?id=<uuid>`. That now pastes directly into any `--uuid`/`--area`/`--project`/`--tag` argument — `stripThingsUri` extracts the id at both resolver chokepoints (`resolveTaskUuidPrefix` + `resolveNamedRef`), so it covers task uuids and every named ref. Tested; documented in AGENT NOTES + MCP instructions.

## docs/roadmap.md — durable parked-work plan
Survives compaction. Captures: Shortcuts onboarding + distribution plan (with answers on iCloud-share durability), the availability-layer spec, e2e reorder coverage, the project-schedule vector, the reference-compendium goal, and shelved items.

## Headings doctrine — DECIDED: first-class, no flatten mode
Both premises for flattening are now false — AppleScript unblocked the heading lifecycle (P10/P11) and 0.6.0 hid `index`/`todayIndex`. Reads stay heading-aware; only `heading.create` is Shortcuts-gated (reports unsupported + a setup remediation). gaps.md §0 rewritten; roadmap §E has the full rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiiUK4qXABDtVKoW7S9Cft