### PR TITLE
release: v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.8.0 — 2026-07-12
 
 - **`things capabilities` now shows each operation's undo classification.** Every op entry carries an `undo:` line — `reversible`, `reversible-with-loss`, `conditional`, or `irreversible` — with the note explaining what `things undo` can and cannot restore (and the acknowledgement flag its inverse needs, where one applies). The same data rides the `--json` envelope and the MCP capabilities tool as an additive `undo` field, straight from the test-locked reversibility matrix.
 - **Fixed: `--when` no longer accepts the raw URL `@time` grammar silently.** `--when 2026-07-20@09:30` used to flow straight into the URL — the app would SET the date and reminder while verification asserted the literal string as the date, reporting a false mismatch on a write that succeeded. The write layer now validates `when` strictly (`today | evening | anytime | someday | YYYY-MM-DD`), and the CLI splits a well-formed `@HH:mm` suffix into when + reminder for the commands that take both (`todo add`, `todo update`, `project update`) — giving both alongside each other, or a malformed suffix, is a clean usage error.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,6 +4,9 @@ Durable plan (survives context compaction). Written 2026-07-09. Everything shipp
 
 ## ⟹ RESUME HERE (post-compaction order)
 
+**2026-07-12: the live pick list moved to [docs/up-next.md](up-next.md)** — decisions Mike owes, VM campaigns (batchable), human-required sittings, calendar-pinned work (macOS 27 beta ~late July, iOS 27 GA ~Sept 14), small unblocked items. Everything below in this section is DONE history. v0.8.0 shipped 2026-07-12 (PRs #73–#85: Shortcuts write vector live-validated, reversible/guarded undo + checklist intents + reversibility matrix, trash-cascade fix + oddity 6½, projects sidebar mirror, upcoming window, hidden-item hints, --when validation, capabilities undo column).
+
+
 1. ~~Publish v0.6.0 to npm~~ — **DONE 2026-07-09**: tagged `v0.6.0`, published to `latest`, bin path intact, `npx things-api@0.6.0 --version` smoke green. (Publish gotcha for next time: `prepublishOnly` outlives a TOTP window — pre-run check+build, then `npm publish --ignore-scripts --otp=<code>`.)
 2. ~~§A Shortcuts onboarding~~ — **LANDED 2026-07-09** (signed-file distribution + `things setup shortcuts` + doctor availability); real-hardware import validation **DONE 2026-07-10**; ~~wiring the Shortcuts write vector~~ **DONE 2026-07-11** (§A.2).
 3. ~~§B availability layer~~ — **LANDED 2026-07-09** (see §B).

--- a/docs/up-next.md
+++ b/docs/up-next.md
@@ -1,0 +1,37 @@
+# Up-next queue (parked 2026-07-12, post-v0.8.0)
+
+The working queue for the next session(s). Everything here was triaged with Mike on 2026-07-12 after the v0.8.0 release (PRs #73–#85: Shortcuts write vector + live validation, reversible/guarded undo, checklist intent undo, reversibility matrix, trash-cascade fix, the `things projects` sidebar mirror, upcoming window, hidden-item hints, `--when` validation, capabilities undo column). Read `docs/roadmap.md` for the long-lived doctrine; THIS file is the short-horizon pick list. Remove items as they land.
+
+## 1. Decisions Mike needs to make (blocked on him, near-zero effort)
+
+- **Hide `── Repeating To-Dos ──` behind a flag in `upcoming`?** The dateless resting-template section (~15 rows in his library) always renders and survives every `--until` bound (a date bound can't apply to dateless rows — deliberate, PR #77). If maximum brevity wins, add `--repeats`/`--all`-style gating.
+- **Today/anytime showing checked-unswept items?** Closed items the log-move sweep hasn't passed stay checked in place in project/area views (GUI parity, completion≠logged model). Whether the flat `today`/`anytime` lists should also show them was flagged ~2026-07-10 and never ruled.
+- **Stateful display preferences** (roadmap §H): config-file/env defaults for the growing toggle family (`--show-later`, `--show-logged`, `--until`, `--all`). Decide the config surface + precedence; wary of plist-driven defaults confusing agents.
+- **Glyph palette doc + `⧉`**: Mike asked whether `⧉` (U+29C9) was ever considered (it wasn't — whole blocks like Misc Math Symbols-B were never mined). Open offer: a curated single-cell/color-safe candidate inventory under `docs/design/` to feed future picks and the §H cross-terminal audit. Also unanswered: did Mike have a slot in mind for `⧉`?
+- **When to send the Cultured Code report**: `docs/things-app-oddities.md` is effectively the draft (crashes §1/§6/§7, silent-failure families §2/§5, the double-trash black hole §6½). Last evidence gaps below.
+
+## 2. VM lab campaigns (autonomous; batch them — they share clone setup)
+
+- **Double-trash black hole screenshots (oddity 6½)** — VNC arm (`research-sx6.sh` template): repro Mike's GUI sequence in a clone (trash to-do, separately trash project), capture Trash-view + project-view screenshots for the CC report. Repro steps are in the oddity entry.
+- **scf2 round-3 probes** (probe-backlog §A round 2 leftovers): P4 redo (backdating value formats — completion/creation via Shortcuts set-detail, AppleScript `set completion date`, URL with token), P3a redo (Reminder Time SET formats), P2b (`set-detail` Parent on a TO-DO — re-parent between projects), **P6 sidebar-order spellings sweep** (AppleScript `move project to before project`, `set index of`, private reorder in "Anytime"/"Someday" with area uuids, full sdef `_private_` inventory) — P6 landing would unlock sidebar reorder as a write.
+- **logInterval enum verification** (probe-backlog §C): log-boundary model has only `1=daily` live-verified; probe 0/2/3/manual by flipping the GUI pref in a clone; confirm whether "log now" updates `manualLogDate`.
+- **Deadline-less fixed-repeat encoding** (probe-backlog §C): can the GUI even make one, and does its plist differ from ts=0? Our fixed⇒deadlined law depends on the answer.
+- **Repeating-template dated-reminder clear** (RC residual): Shortcuts `set-detail` clear was never re-probed ON a repeating template (bounce crashes there, R09; move-to-Inbox unprobed on templates). One clone probe settles whether repeating items truly have an in-place clear.
+- **Lab runner Shortcuts arm** (probe-backlog §C): guest input files + `shortcuts run --input-path` in the DSL so `s-suite.json` becomes a recurring suite — also unlocks recurring e2e for the shipped Shortcuts ops, and fold in **§C e2e reorder coverage** (guest smoke has NO reorder steps: inbox/someday/headings/projects-bounce) in the same lab-touching change.
+- **§E½ UI-vector feasibility probe**: VNC-drive `File → New Repeating To-Do` end-to-end in a clone, verify an `rt1_recurrenceRule` row lands. Gateway to the dedicated-Mac "ui" vector for everything conclusively UI-only (repeat rule create/edit, sidebar order, to-do↔project convert). SX6 demonstrated the click mechanics.
+
+## 3. Needs a human present (short sittings)
+
+- **P5**: Shortcuts delete of a NON-empty heading (delete-class consent re-prompts every run — no Always-Allow). Question: children re-parent, orphan, or cascade?
+- **`.ips` capture** for the heading-schedule crash (§6) — nice-to-have for the CC report.
+- **CC report submission itself** — once 6½ screenshots + (optionally) the §6 .ips land.
+
+## 4. Calendar-pinned
+
+- **macOS 27 public-beta regression VM** — ~late July 2026. Build a beta VM, run `lab:regress`, diff verdicts/tiers (the Things-update canary: rrv decode, fingerprint, doctor `repeats:`).
+- **iOS 27 GA runbook** — ~Sept 14 2026: execute `docs/lab/things-update-runbook.md` + the Apple-Intelligence memo follow-ups (`docs/design/apple-intelligence-research.md`).
+
+## 5. Smaller code items (unblocked, low effort)
+
+- **Suppress "(archived)"-titled areas?** Mike's three empty areas render `(no projects)` (correct sidebar mirroring — Things has no area-archive feature; "(archived)" is his naming). If he wants them hidden it's a deliberate divergence (config/pattern filter) — needs his call first (overlaps §1 preferences item).
+- **`things logbook --limit` default vs `--since` interplay** — no known bug; noted only that logbook predates the relative-period vocabulary added in #77/#85 and could default tighter. Optional polish.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "things-api",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "things-api",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "things-api",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Typed TypeScript library + CLI for Things 3 (Cultured Code) — verified writes, audit trail, schema-drift detection",
   "license": "MIT",
   "bin": {

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -15,7 +15,7 @@ export const API_VERSION = 1;
  * Package version, surfaced by `things --version` and the MCP serverInfo.
  * Kept in lockstep with package.json by a contract test.
  */
-export const PKG_VERSION = "0.7.0";
+export const PKG_VERSION = "0.8.0";
 
 /**
  * Stable exit-code contract for the `things` CLI (mirrored by MCP error


### PR DESCRIPTION
Version bump (package.json + PKG_VERSION lockstep), CHANGELOG dated `## 0.8.0 — 2026-07-12` (15 entries), and the post-release **up-next queue** parked at `docs/up-next.md` (roadmap RESUME section points there).

**`things-api@0.8.0` is already published to npm `latest`** and smoke-verified via `npx things-api@0.8.0 --version`. Tag `v0.8.0` pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiiUK4qXABDtVKoW7S9Cft