### PR TITLE
chore: exclude .claude/ agent worktrees from git and lint/fmt scans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,9 @@ vendor/*
 # Lab artifacts (evidence records, screenshots, guest DB copies)
 lab/artifacts/
 
+# Claude Code session-local state (agent worktrees live under here — must never
+# be committed or scanned by tooling)
+.claude/
+
 # Build artifacts (source + build.sh are the record)
 lab/guest/disruption-monitor/disruption-monitor

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,4 +1,4 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
-  "ignorePatterns": ["**/*.md", "dist", "coverage", "lab/artifacts", "vendor"]
+  "ignorePatterns": ["**/*.md", "dist", "coverage", "lab/artifacts", "vendor", ".claude"]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -8,5 +8,5 @@
   "env": {
     "builtin": true
   },
-  "ignorePatterns": ["dist", "coverage", "lab/artifacts"]
+  "ignorePatterns": ["dist", "coverage", "lab/artifacts", ".claude"]
 }


### PR DESCRIPTION
Concurrent Claude agent worktrees live under `.claude/worktrees/`. `npm run check` in one checkout was failing on *another* checkout's in-progress code because oxlint walked into them. Adds `.claude` to oxlint/oxfmt ignorePatterns and `.claude/` to .gitignore. `npm run check` exit 0 with a live worktree present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nGHpVG78bpg39jQY3qdcP