### PR TITLE
docs(cli): name the app's "No Tag" filter in the --untagged help copy

### DIFF
--- a/src/cli/commands/reads.ts
+++ b/src/cli/commands/reads.ts
@@ -73,7 +73,7 @@ export function openInThings(uuid: string): string {
 }
 
 /** Help copy for the `--untagged` content scope (the GUI's "No Tag"). */
-const UNTAGGED_DESC = "only items with no tag (direct or inherited)";
+const UNTAGGED_DESC = 'only items with no tag, direct or inherited — the app\'s "No Tag" filter';
 
 /**
  * Shared usage guard: `--untagged` is a content scope that inverts `--tag`, so


### PR DESCRIPTION
Discoverability bridge: keep the CLI-idiomatic `--untagged` spelling (a `--no-tag` flag would collide with commander's boolean-negation prefix and misread as "disable tag filtering"), but name the app's "No Tag" feature in the help copy so it's findable by its GUI name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nGHpVG78bpg39jQY3qdcP