### PR TITLE
test: cover audit writer, H-BACKDATE-OPEN guard, and DB locator

### DIFF
--- a/test/unit/audit-log.test.ts
+++ b/test/unit/audit-log.test.ts
@@ -1,0 +1,118 @@
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { createAuditWriter } from "../../src/audit/log.ts";
+import type { AuditRecord } from "../../src/audit/schema.ts";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "things-api-audit-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** A minimal, valid AuditRecord with caller-controllable fields. */
+function makeRecord(over: Partial<AuditRecord> = {}): AuditRecord {
+  return {
+    v: 1,
+    ts: "2026-07-16T12:00:00.000Z",
+    actor: "cli",
+    host: "test-host",
+    op: "todo.update",
+    uuid: "todo-1",
+    vector: "url",
+    disruption: 0,
+    invocation: null,
+    requested: {},
+    pre: null,
+    observed: null,
+    result: "ok",
+    verify: null,
+    durationMs: 5,
+    env: { pkg: "0.0.0", dbVersion: 26, fingerprint: "ok" },
+    ...over,
+  };
+}
+
+describe("createAuditWriter — structural token redaction", () => {
+  it("emits no on-disk occurrence of the loaded auth token, redacting to REDACTED", () => {
+    const token = "auth-tok-DEADBEEF-secret";
+    const writer = createAuditWriter({ dir, secrets: [token], enabled: true });
+
+    // Embed the token in several distinct string fields, including one that
+    // carries it twice in a single value (the replacer must sweep all copies).
+    writer.append(
+      makeRecord({
+        invocation: `things:///update?auth-token=${token}&title=x`,
+        requested: {
+          note: `leading ${token} and trailing ${token}`,
+          nested: { deep: `x-${token}-y` },
+        },
+        actor: token,
+      }),
+    );
+
+    const files = readdirSync(dir);
+    expect(files).toEqual(["2026-07.jsonl"]);
+    const raw = readFileSync(join(dir, "2026-07.jsonl"), "utf8");
+
+    // The token appears NOWHERE on disk.
+    expect(raw).not.toContain(token);
+
+    // Every embedded occurrence became exactly "REDACTED".
+    const parsed = JSON.parse(raw.trimEnd()) as AuditRecord;
+    expect(parsed.invocation).toBe("things:///update?auth-token=REDACTED&title=x");
+    expect(parsed.requested["note"]).toBe("leading REDACTED and trailing REDACTED");
+    expect((parsed.requested["nested"] as { deep: string }).deep).toBe("x-REDACTED-y");
+    expect(parsed.actor).toBe("REDACTED");
+  });
+
+  it("ignores empty-string secrets (no spurious redaction) and leaves clean records intact", () => {
+    const writer = createAuditWriter({ dir, secrets: ["", "realtoken"], enabled: true });
+    writer.append(makeRecord({ invocation: "things:///update?title=hello" }));
+    const raw = readFileSync(join(dir, "2026-07.jsonl"), "utf8");
+    const parsed = JSON.parse(raw.trimEnd()) as AuditRecord;
+    expect(parsed.invocation).toBe("things:///update?title=hello");
+    expect(raw).not.toContain("REDACTED");
+  });
+});
+
+describe("createAuditWriter — enabled flag", () => {
+  it("writes nothing (no file, no directory contents) when disabled", () => {
+    const writer = createAuditWriter({ dir, secrets: ["x"], enabled: false });
+    writer.append(makeRecord());
+    writer.append(makeRecord({ ts: "2026-08-01T00:00:00.000Z" }));
+    // mkdirSync is only reached inside the enabled branch, so the dir stays empty.
+    expect(readdirSync(dir)).toEqual([]);
+    expect(existsSync(join(dir, "2026-07.jsonl"))).toBe(false);
+  });
+});
+
+describe("createAuditWriter — monthly file naming + JSONL append", () => {
+  it("names files YYYY-MM.jsonl from the record ts and appends valid JSONL", () => {
+    const writer = createAuditWriter({ dir, secrets: [], enabled: true });
+    writer.append(makeRecord({ ts: "2026-07-01T09:00:00.000Z", uuid: "a" }));
+    writer.append(makeRecord({ ts: "2026-07-31T23:59:59.000Z", uuid: "b" }));
+    writer.append(makeRecord({ ts: "2026-08-02T10:00:00.000Z", uuid: "c" }));
+
+    expect(readdirSync(dir).toSorted()).toEqual(["2026-07.jsonl", "2026-08.jsonl"]);
+
+    const july = readFileSync(join(dir, "2026-07.jsonl"), "utf8");
+    // Trailing newline on every record → final element is empty once split.
+    const lines = july.split("\n");
+    expect(lines.at(-1)).toBe("");
+    const records = lines.slice(0, -1).map((l) => JSON.parse(l) as AuditRecord);
+    expect(records.map((r) => r.uuid)).toEqual(["a", "b"]);
+
+    const august = readFileSync(join(dir, "2026-08.jsonl"), "utf8");
+    const augRecords = august
+      .split("\n")
+      .filter((l) => l.length > 0)
+      .map((l) => JSON.parse(l) as AuditRecord);
+    expect(augRecords.map((r) => r.uuid)).toEqual(["c"]);
+  });
+});

--- a/test/unit/locate-db.test.ts
+++ b/test/unit/locate-db.test.ts
@@ -1,0 +1,92 @@
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { locateThingsDb, ThingsDbNotFoundError } from "../../src/db/locate.ts";
+
+const CONTAINER = "Library/Group Containers/JLMPQHK86H.com.culturedcode.ThingsMac";
+
+let home: string;
+let savedEnv: string | undefined;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "things-api-home-"));
+  savedEnv = process.env["THINGS_DB"];
+  delete process.env["THINGS_DB"];
+});
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+  if (savedEnv === undefined) delete process.env["THINGS_DB"];
+  else process.env["THINGS_DB"] = savedEnv;
+});
+
+/**
+ * Create a glob-matching candidate under `home` and return its absolute path.
+ * `mtimeSec` sets the mtime explicitly so recency ordering is deterministic.
+ */
+function seedCandidate(tag: string, mtimeSec: number): string {
+  const path = join(
+    home,
+    CONTAINER,
+    `ThingsData-${tag}`,
+    "Things Database.thingsdatabase",
+    "main.sqlite",
+  );
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, "");
+  utimesSync(path, mtimeSec, mtimeSec);
+  return path;
+}
+
+describe("locateThingsDb — precedence", () => {
+  it("explicit dbPath option beats env beats glob", () => {
+    process.env["THINGS_DB"] = "/env/path/main.sqlite";
+    seedCandidate("A", 1_000);
+    const result = locateThingsDb({ dbPath: "/explicit/main.sqlite", home });
+    expect(result).toEqual({
+      path: "/explicit/main.sqlite",
+      source: "option",
+      otherCandidates: [],
+    });
+  });
+
+  it("env var beats glob when no dbPath given", () => {
+    process.env["THINGS_DB"] = "/env/path/main.sqlite";
+    seedCandidate("A", 1_000);
+    const result = locateThingsDb({ home });
+    expect(result).toEqual({ path: "/env/path/main.sqlite", source: "env", otherCandidates: [] });
+  });
+});
+
+describe("locateThingsDb — glob discovery", () => {
+  it("picks the most-recently-modified candidate and lists the rest as otherCandidates", () => {
+    const old1 = seedCandidate("OLD1", 1_000);
+    const newest = seedCandidate("NEW", 3_000);
+    const old2 = seedCandidate("OLD2", 2_000);
+
+    const result = locateThingsDb({ home });
+    expect(result.source).toBe("container");
+    expect(result.path).toBe(newest);
+    // otherCandidates holds the remaining matches, still ordered newest-first.
+    expect(result.otherCandidates).toEqual([old2, old1]);
+  });
+
+  it("otherCandidates is empty when exactly one candidate matches", () => {
+    const only = seedCandidate("ONLY", 1_000);
+    const result = locateThingsDb({ home });
+    expect(result).toEqual({ path: only, source: "container", otherCandidates: [] });
+  });
+
+  it("throws ThingsDbNotFoundError naming the searched glob when nothing matches", () => {
+    let caught: unknown;
+    try {
+      locateThingsDb({ home });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ThingsDbNotFoundError);
+    expect((caught as Error).message).toContain(join(home, CONTAINER));
+    expect((caught as Error).message).toContain("Things database not found");
+  });
+});

--- a/test/unit/write-guards.test.ts
+++ b/test/unit/write-guards.test.ts
@@ -310,3 +310,26 @@ describe("H-HEADING-CHILDREN", () => {
     expect(check("project.delete", { uuid: area })?.hazard).toBe("H-UNKNOWN-DESTINATION");
   });
 });
+
+describe("H-BACKDATE-OPEN", () => {
+  it("blocks rewriting completionDate on an OPEN to-do (with the exact remediation)", () => {
+    const uuid = seedTodo(fixture.db, { title: "still open", status: "open" });
+    const block = check("todo.backdate", { uuid, completionDate: "2024-01-01" });
+    expect(block?.hazard).toBe("H-BACKDATE-OPEN");
+    expect(block?.detail).toContain("completionDate can only be rewritten");
+    expect(block?.detail).toContain("open");
+    expect(block?.remediation).toBe("complete it first (todo.complete), then backdate");
+  });
+
+  it("passes completionDate backdate on a completed or a canceled to-do", () => {
+    const completed = seedTodo(fixture.db, { title: "done", status: "completed" });
+    const canceled = seedTodo(fixture.db, { title: "gone", status: "canceled" });
+    expect(check("todo.backdate", { uuid: completed, completionDate: "2024-01-01" })).toBeNull();
+    expect(check("todo.backdate", { uuid: canceled, completionDate: "2024-01-01" })).toBeNull();
+  });
+
+  it("does not fire when only creationDate is backdated (no completionDate rewrite)", () => {
+    const uuid = seedTodo(fixture.db, { title: "still open", status: "open" });
+    expect(check("todo.backdate", { uuid, creationDate: "2024-01-01" })).toBeNull();
+  });
+});


### PR DESCRIPTION
Test-only change (no `src/` edits) filling three coverage gaps. One commit per area.

## Commits

- **test(audit)** — `createAuditWriter` (`src/audit/log.ts`) had zero coverage; every pipeline test injects an in-memory array instead. New tests drive the real writer against a temp dir: structural token redaction (the configured auth token appears **nowhere** on disk; every embedded copy — including two-in-one-value and nested — becomes `REDACTED`), empty-string secrets are ignored, `enabled:false` suppresses all writes (no dir contents, no file), and `YYYY-MM.jsonl` monthly naming with valid appended JSONL parsed line-by-line.
- **test(write)** — `H-BACKDATE-OPEN` (`src/write/guards.ts`) was the only hazard of 16 with zero test references. Added to `write-guards.test.ts` matching its patterns: `todo.backdate` of `completionDate` on an OPEN to-do is blocked with the exact hazard id + remediation; passes on completed and canceled to-dos; does not fire when only `creationDate` is rewritten.
- **test(db)** — `locateThingsDb` (`src/db/locate.ts`) was untested despite an injectable `options.home` seam. Uses a temp home shaped like the Things group-container layout with explicit mtimes: option > env > glob precedence, most-recently-modified glob winner with `otherCandidates` populated (newest-first), single-candidate empty `otherCandidates`, and the `ThingsDbNotFoundError` no-match path naming the searched glob.

All tests are hermetic (temp dirs + fixture DBs / temp home). `npm run check` passes by exit code; no CHANGELOG edit (test-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)