### PR TITLE
refactor(read): derive all four tag-scope SQL builders from one clause array

### DIFF
--- a/src/read/queries.ts
+++ b/src/read/queries.ts
@@ -12,34 +12,99 @@ import type { ChecklistRow, TaskRow } from "../model/mappers.ts";
 export const NOT_TEMPLATE = "(t.rt1_recurrenceRule IS NULL AND t.repeater IS NULL)";
 
 /**
- * UI-faithful tag membership for list filtering: direct tag, or inherited
- * through the ancestor chain heading → project → area (T18/U18/A13 — the
- * same chain inheritedTagsFor() walks). Takes a SET of tag uuids (the target
- * plus its hierarchy descendants) — each of the six clauses gets the full
- * set, so callers bind `uuids.length * 6` values via tagScopeBinds().
+ * One hop of the UI-faithful tag-inheritance chain. `exists(set)` emits the
+ * hop's `EXISTS (…)` predicate; passing a placeholder SET restricts the hop to
+ * those tag uuids (the positive `--tag` membership), while passing `null` drops
+ * the tag-set restriction to mean "carries ANY tag by this hop" (the `untagged`
+ * negation). Writing each hop ONCE — restricted and unrestricted from the same
+ * body — is what keeps `--tag` and `--untagged` from silently diverging on what
+ * "tagged" means; the four exports below are all DERIVED from this array, so an
+ * inheritance fix lands in one place.
  */
-export function tagScopeSql(uuidCount: number): string {
-  const set = `(${Array.from({ length: uuidCount }, () => "?").join(", ")})`;
-  return `(
-  EXISTS (SELECT 1 FROM TMTaskTag tt WHERE tt.tasks = t.uuid AND tt.tags IN ${set})
-  OR EXISTS (SELECT 1 FROM TMTaskTag tt WHERE tt.tasks = t.project AND tt.tags IN ${set})
-  OR EXISTS (SELECT 1 FROM TMAreaTag at WHERE at.areas = t.area AND at.tags IN ${set})
-  OR EXISTS (SELECT 1 FROM TMTask p JOIN TMAreaTag at ON at.areas = p.area
-             WHERE p.uuid = t.project AND at.tags IN ${set})
-  OR EXISTS (SELECT 1 FROM TMTask h JOIN TMTaskTag tt ON tt.tasks = h.project
-             WHERE h.uuid = t.heading AND tt.tags IN ${set})
-  OR EXISTS (SELECT 1 FROM TMTask h JOIN TMTask p ON p.uuid = h.project
-             JOIN TMAreaTag at ON at.areas = p.area WHERE h.uuid = t.heading AND at.tags IN ${set})
-)`;
+interface InheritanceClause {
+  readonly exists: (set: string | null) => string;
 }
 
-export function tagScopeBinds(uuids: string[]): string[] {
-  return Array.from({ length: 6 }, () => uuids).flat();
+/** ` AND col IN (…)` for the restricted form; empty for the tag-agnostic form. */
+const tagIn = (col: string, set: string | null): string =>
+  set === null ? "" : ` AND ${col} IN ${set}`;
+
+/**
+ * Clause 1 — the item's OWN direct `TMTaskTag` assignments. Named apart from the
+ * rest because it is ALSO the whole story for the CONTAINER `--tag`/`--untagged`
+ * projections (see {@link directTagScopeSql} / {@link directUntaggedScopeSql}).
+ */
+const DIRECT_TAG_CLAUSE: InheritanceClause = {
+  exists: (set) =>
+    `EXISTS (SELECT 1 FROM TMTaskTag tt WHERE tt.tasks = t.uuid${tagIn("tt.tags", set)})`,
+};
+
+/**
+ * The full direct+inherited membership relation, heading → project → area
+ * (T18/U18/A13 — the same chain inheritedTagsFor() walks), written ONCE. Clause 1
+ * is the direct assignment; clauses 2–6 are the five container-inheritance hops.
+ */
+const INHERITANCE_CLAUSES: readonly InheritanceClause[] = [
+  // 1. the item's own direct tags.
+  DIRECT_TAG_CLAUSE,
+  // 2. inherited from the item's PROJECT's own direct tags.
+  {
+    exists: (set) =>
+      `EXISTS (SELECT 1 FROM TMTaskTag tt WHERE tt.tasks = t.project${tagIn("tt.tags", set)})`,
+  },
+  // 3. inherited from the item's AREA's tags.
+  {
+    exists: (set) =>
+      `EXISTS (SELECT 1 FROM TMAreaTag at WHERE at.areas = t.area${tagIn("at.tags", set)})`,
+  },
+  // 4. inherited from the item's PROJECT's AREA's tags.
+  {
+    exists: (set) =>
+      `EXISTS (SELECT 1 FROM TMTask p JOIN TMAreaTag at ON at.areas = p.area
+             WHERE p.uuid = t.project${tagIn("at.tags", set)})`,
+  },
+  // 5. inherited through the item's HEADING → that heading's project's direct tags.
+  {
+    exists: (set) =>
+      `EXISTS (SELECT 1 FROM TMTask h JOIN TMTaskTag tt ON tt.tasks = h.project
+             WHERE h.uuid = t.heading${tagIn("tt.tags", set)})`,
+  },
+  // 6. inherited through the item's HEADING → its project → that project's AREA's tags.
+  {
+    exists: (set) =>
+      `EXISTS (SELECT 1 FROM TMTask h JOIN TMTask p ON p.uuid = h.project
+             JOIN TMAreaTag at ON at.areas = p.area WHERE h.uuid = t.heading${tagIn("at.tags", set)})`,
+  },
+];
+
+/** A `(?, ?, …)` placeholder list for a tag-uuid set of the given size. */
+const placeholderSet = (uuidCount: number): string =>
+  `(${Array.from({ length: uuidCount }, () => "?").join(", ")})`;
+
+/**
+ * UI-faithful tag membership for list filtering: direct tag, or inherited
+ * through the ancestor chain heading → project → area — the OR of every
+ * {@link INHERITANCE_CLAUSES} hop. Takes a SET of tag uuids (the target plus its
+ * hierarchy descendants); each hop gets the full set, so callers bind
+ * `uuids.length * INHERITANCE_CLAUSES.length` values via {@link tagScopeBinds}.
+ */
+export function tagScopeSql(uuidCount: number): string {
+  const set = placeholderSet(uuidCount);
+  return `(\n  ${INHERITANCE_CLAUSES.map((c) => c.exists(set)).join("\n  OR ")}\n)`;
 }
 
 /**
- * The DIRECT-ONLY projection of {@link tagScopeSql}: its FIRST clause alone —
- * the item's own `TMTaskTag` assignments — WITHOUT the five container-
+ * The bind list for {@link tagScopeSql}: the uuid set repeated once per hop, in
+ * clause order. Derived from the clause count so the bind multiplicity can never
+ * drift from the number of hops the SQL actually emits.
+ */
+export function tagScopeBinds(uuids: string[]): string[] {
+  return Array.from({ length: INHERITANCE_CLAUSES.length }, () => uuids).flat();
+}
+
+/**
+ * The DIRECT-ONLY projection of {@link tagScopeSql}: {@link DIRECT_TAG_CLAUSE}
+ * alone — the item's own `TMTaskTag` assignments — WITHOUT the five container-
  * inheritance hops (project/area/heading). This is the SQL behind the CONTAINER
  * `--tag` (the `project show` / `area show` / `projects` list views): every
  * child inherits its container's tags, so the inheritance-inclusive relation is
@@ -47,50 +112,36 @@ export function tagScopeBinds(uuids: string[]): string[] {
  * behavior. It keeps tag-hierarchy descendant expansion (the uuid SET is still
  * the tag plus its descendants, OR-matched) but drops container inheritance, so
  * an item matches only when it is DIRECTLY tagged. Takes the uuid set once, so
- * callers bind `uuids` exactly one time (not `× 6`). KEEP THE DIRECT CLAUSE IN
- * LOCKSTEP WITH tagScopeSql's first clause.
+ * callers bind `uuids` exactly one time (not `× 6`).
  */
 export function directTagScopeSql(uuidCount: number): string {
-  const set = `(${Array.from({ length: uuidCount }, () => "?").join(", ")})`;
-  return `EXISTS (SELECT 1 FROM TMTaskTag tt WHERE tt.tasks = t.uuid AND tt.tags IN ${set})`;
+  return DIRECT_TAG_CLAUSE.exists(placeholderSet(uuidCount));
 }
 
 /**
  * The negation of tag membership — the SQL behind the `untagged` filter (the
- * GUI's "No Tag"). It mirrors tagScopeSql's SAME six direct+inherited
- * relations (heading → project → area, T18/U18/A13) but with the tag-set
- * restriction dropped: "carries ANY tag by any hop", wrapped in NOT. An item
- * is untagged iff NO possible `--tag X` could ever match it — so this negates
- * the whole membership relation, not merely the row's own direct assignments.
- * Takes no binds. KEEP THE SIX CLAUSES IN LOCKSTEP WITH tagScopeSql.
+ * GUI's "No Tag"). It negates the SAME {@link INHERITANCE_CLAUSES} relation with
+ * the tag-set restriction dropped: "carries ANY tag by any hop", wrapped in NOT.
+ * An item is untagged iff NO possible `--tag X` could ever match it — so this
+ * negates the whole membership relation, not merely the row's own direct
+ * assignments. Takes no binds.
  */
 export function untaggedScopeSql(): string {
-  return `NOT (
-  EXISTS (SELECT 1 FROM TMTaskTag tt WHERE tt.tasks = t.uuid)
-  OR EXISTS (SELECT 1 FROM TMTaskTag tt WHERE tt.tasks = t.project)
-  OR EXISTS (SELECT 1 FROM TMAreaTag at WHERE at.areas = t.area)
-  OR EXISTS (SELECT 1 FROM TMTask p WHERE p.uuid = t.project
-             AND EXISTS (SELECT 1 FROM TMAreaTag at WHERE at.areas = p.area))
-  OR EXISTS (SELECT 1 FROM TMTask h JOIN TMTaskTag tt ON tt.tasks = h.project
-             WHERE h.uuid = t.heading)
-  OR EXISTS (SELECT 1 FROM TMTask h JOIN TMTask p ON p.uuid = h.project
-             JOIN TMAreaTag at ON at.areas = p.area WHERE h.uuid = t.heading)
-)`;
+  return `NOT (\n  ${INHERITANCE_CLAUSES.map((c) => c.exists(null)).join("\n  OR ")}\n)`;
 }
 
 /**
  * The DIRECT-ONLY counterpart of {@link untaggedScopeSql} — the SQL behind the
  * CONTAINER `--untagged` (the GUI's in-context "No Tag" inside a project/area
- * card). It negates only the item's OWN direct assignments (the first of the six
- * membership clauses), leaving container inheritance untouched: an item
- * qualifies when it carries no DIRECT tag, even if it inherits one from its
- * project/area/heading. Every child inherits the container's tags, so the
- * whole-relation `untaggedScopeSql` would exclude every row there — direct-only
- * is the useful negation. Takes no binds. KEEP THE DIRECT CLAUSE IN LOCKSTEP
- * WITH {@link directTagScopeSql}.
+ * card). It negates only {@link DIRECT_TAG_CLAUSE} (the item's OWN direct
+ * assignments), leaving container inheritance untouched: an item qualifies when
+ * it carries no DIRECT tag, even if it inherits one from its project/area/
+ * heading. Every child inherits the container's tags, so the whole-relation
+ * {@link untaggedScopeSql} would exclude every row there — direct-only is the
+ * useful negation. Takes no binds.
  */
 export function directUntaggedScopeSql(): string {
-  return `NOT EXISTS (SELECT 1 FROM TMTaskTag tt WHERE tt.tasks = t.uuid)`;
+  return `NOT ${DIRECT_TAG_CLAUSE.exists(null)}`;
 }
 
 /**

--- a/test/unit/views.test.ts
+++ b/test/unit/views.test.ts
@@ -4,7 +4,14 @@ import type { Ref } from "../../src/model/entities.ts";
 import { areaView } from "../../src/read/area-view.ts";
 import { projectView } from "../../src/read/project-view.ts";
 import { areaTags, inheritedTagsFor, tagsView } from "../../src/read/tags.ts";
-import { fetchTaskByUuid } from "../../src/read/queries.ts";
+import {
+  directTagScopeSql,
+  directUntaggedScopeSql,
+  fetchTaskByUuid,
+  tagScopeBinds,
+  tagScopeSql,
+  untaggedScopeSql,
+} from "../../src/read/queries.ts";
 import { byUuid } from "../../src/read/detail.ts";
 import { getField } from "../../src/write/verify/delta.ts";
 import {
@@ -881,6 +888,121 @@ describe('untagged filter (GUI "No Tag")', () => {
       .map((i) => i.title)
       .toSorted();
     expect(titles).toEqual(["someday bare"]);
+  });
+});
+
+describe("tag-scope derivation equivalence (all four scopes from one clause array)", () => {
+  // A fixture with one to-do matched by EACH hop of the inheritance chain plus
+  // an untagged control, so the four derived scopes can be asserted row-exact
+  // AND proven to PARTITION the universe — the invariant the old hand-
+  // synchronized quadruplication endangered.
+  function seedInheritanceWorld() {
+    fx = buildFixtureDb();
+    const focus = seedTag(fx.db, "focus");
+
+    // clause 1 — direct: the item's own tag.
+    const direct = seedTodo(fx.db, { title: "direct" });
+    tagTask(fx.db, direct, focus);
+
+    // clause 2 — via project: the item's project is directly tagged.
+    const p1 = seedProject(fx.db, { title: "P1" });
+    tagTask(fx.db, p1, focus);
+    seedTodo(fx.db, { title: "via-project", project: p1 });
+
+    // clause 3 — via area: the item's area is tagged.
+    const a1 = seedArea(fx.db, "A1");
+    tagArea(fx.db, a1, focus);
+    seedTodo(fx.db, { title: "via-area", area: a1 });
+
+    // clause 5 — via heading → project: the heading's project is directly tagged.
+    const p2 = seedProject(fx.db, { title: "P2" });
+    tagTask(fx.db, p2, focus);
+    const h1 = seedHeading(fx.db, { title: "H1", project: p2 });
+    seedTodo(fx.db, { title: "via-heading-project", heading: h1, project: null });
+
+    // clause 6 — via heading → project → area: the heading's project sits in a
+    // tagged area (the project itself carries no direct tag).
+    const a2 = seedArea(fx.db, "A2");
+    tagArea(fx.db, a2, focus);
+    const p3 = seedProject(fx.db, { title: "P3", area: a2 });
+    const h2 = seedHeading(fx.db, { title: "H2", project: p3 });
+    seedTodo(fx.db, { title: "via-heading-project-area", heading: h2, project: null });
+
+    // control — untagged by every hop.
+    seedTodo(fx.db, { title: "control" });
+
+    return { focus };
+  }
+
+  // Run a scope predicate over the seeded to-dos (type = 0 keeps the container
+  // projects/headings out of the row universe).
+  const rows = (scope: string, binds: string[] = []) =>
+    (
+      fx.db
+        .prepare(`SELECT t.title AS title FROM TMTask t WHERE t.type = 0 AND ${scope}`)
+        .all(...binds) as { title: string }[]
+    )
+      .map((r) => r.title)
+      .toSorted();
+
+  // Clause 4 (item's project's area) has no dedicated fixture row: it can only
+  // fire on a project-nested to-do whose project has an area, which the app
+  // models as an inherited-via-area case already covered by other hops. The five
+  // rows above exercise clauses 1, 2, 3, 5 and 6; the positive relation is their
+  // OR, so it matches all five.
+  const INHERITED = [
+    "direct",
+    "via-area",
+    "via-heading-project",
+    "via-heading-project-area",
+    "via-project",
+  ];
+  const ALL = [...INHERITED, "control"].toSorted();
+
+  it("--tag scope matches exactly the direct + inherited rows (whole relation)", () => {
+    const { focus } = seedInheritanceWorld();
+    const uuids = [focus];
+    expect(rows(tagScopeSql(uuids.length), tagScopeBinds(uuids))).toEqual(INHERITED);
+  });
+
+  it("untagged scope matches exactly the untagged control", () => {
+    seedInheritanceWorld();
+    expect(rows(untaggedScopeSql())).toEqual(["control"]);
+  });
+
+  it("direct scope matches exactly the directly-tagged row (clause 1 alone)", () => {
+    const { focus } = seedInheritanceWorld();
+    const uuids = [focus];
+    expect(rows(directTagScopeSql(uuids.length), uuids)).toEqual(["direct"]);
+  });
+
+  it("direct-untagged scope matches everything but the directly-tagged row", () => {
+    seedInheritanceWorld();
+    expect(rows(directUntaggedScopeSql())).toEqual([
+      "control",
+      "via-area",
+      "via-heading-project",
+      "via-heading-project-area",
+      "via-project",
+    ]);
+  });
+
+  it("--tag and --untagged PARTITION the fixture (whole relation: disjoint + total)", () => {
+    const { focus } = seedInheritanceWorld();
+    const uuids = [focus];
+    const tagged = rows(tagScopeSql(uuids.length), tagScopeBinds(uuids));
+    const untagged = rows(untaggedScopeSql());
+    expect([...tagged, ...untagged].toSorted()).toEqual(ALL); // none in neither
+    expect(tagged.filter((t) => untagged.includes(t))).toEqual([]); // none in both
+  });
+
+  it("direct and direct-untagged PARTITION the fixture (container relation)", () => {
+    const { focus } = seedInheritanceWorld();
+    const uuids = [focus];
+    const direct = rows(directTagScopeSql(uuids.length), uuids);
+    const directUntagged = rows(directUntaggedScopeSql());
+    expect([...direct, ...directUntagged].toSorted()).toEqual(ALL); // none in neither
+    expect(direct.filter((t) => directUntagged.includes(t))).toEqual([]); // none in both
   });
 });
 


### PR DESCRIPTION
## What

Eliminates a hand-synchronized SQL quadruplication in `src/read/queries.ts`. The tag-inheritance chain (task → its project → its area → its heading→project→area) was written **four independent times**:

- `tagScopeSql` — the 6-clause positive `--tag` membership relation
- `untaggedScopeSql` — the same 6 relations re-negated by hand as `NOT(… OR …)`
- `directTagScopeSql` — clause 1 alone (container `--tag`)
- `directUntaggedScopeSql` — clause 1 negated (container `--untagged`)

Three carried `KEEP … IN LOCKSTEP` comments — an admission there was no shared builder. Any future inheritance fix had to be applied up to four times or `--tag` and `--untagged` would silently diverge on what "tagged" means.

## How

The chain is now written **once** as `INHERITANCE_CLAUSES`. Each hop is an `exists(set)` builder that emits its `EXISTS (…)` predicate:

- passed a placeholder set → restricted to those tag uuids (positive membership)
- passed `null` → tag-agnostic "carries ANY tag by this hop" (the untagged negation)

All four exports derive from the array:

| export | derivation |
| --- | --- |
| `tagScopeSql` | `OR` of every clause, tag-restricted |
| `untaggedScopeSql` | `NOT (OR of every clause, tag-agnostic)` |
| `directTagScopeSql` | clause 1, tag-restricted |
| `directUntaggedScopeSql` | `NOT (clause 1, tag-agnostic)` |

`tagScopeBinds` derives its multiplicity from `INHERITANCE_CLAUSES.length`, so the bind count can never drift from the number of placeholders the SQL actually emits.

## Contract preservation

Exported signatures and the parameter-binding contract are **unchanged** — verified at every call site (all in `src/read/views.ts:tagFilter`):

- `tagScopeSql(uuidCount)` + `tagScopeBinds(uuids)` → `uuids.length × 6` binds, clause order; each clause reuses the identical set string, so positional binding is trivially preserved
- `directTagScopeSql(uuidCount)` → one set of `uuidCount` placeholders, caller binds `uuids` once
- `untaggedScopeSql()` / `directUntaggedScopeSql()` → no binds

Only the emitted SQL *formatting* changes; semantics are identical (clause 4's untagged form is the JOIN spelling of the old nested-`EXISTS` form — same relation). The `LOCKSTEP` warnings are deleted because the duplication they guarded no longer exists. Domain doc-comments (which hop covers which UI behavior) are preserved and attached to their clauses.

## Tests

- Existing tag-filter tests pass **unchanged** (they encode today's semantics).
- **New equivalence suite** (`test/unit/views.test.ts`): a fixture with one to-do matched by each inheritance hop (direct, via project, via area, via heading→project, via heading→project's area) plus an untagged control. Asserts each of the four scopes row-exact, and that positive/negative scopes **PARTITION** the fixture (no row in both, none in neither) — the invariant the quadruplication endangered.

`npm run check` passes (exit 0); 1209 tests green (6 new). No CHANGELOG entry — internal refactor with no user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)