### PR TITLE
fix(write): make stale mutation-lock steal atomic

### DIFF
--- a/src/write/lock.ts
+++ b/src/write/lock.ts
@@ -2,8 +2,16 @@
  * Advisory mutation lockfile: serializes mutations across concurrent CLI
  * invocations so create-probe verification is never ambiguous (design §4).
  * Stale locks (dead pid) are stolen; live locks are awaited with backoff.
+ *
+ * The steal is atomic: a stealer `rename`s the stale lockfile to a private
+ * temp name (rename succeeds for exactly one racer; every other racer gets
+ * ENOENT and falls back to the wait/retry loop), then re-reads the renamed
+ * file to confirm the holder is still dead before discarding it. This closes
+ * the TOCTOU window an unconditional unlink+recreate would leave open, where
+ * two processes could both observe a dead holder and both end up believing
+ * they hold the lock.
  */
-import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 
 export class MutationLockError extends Error {
@@ -31,42 +39,92 @@ export interface MutationLock {
   release(): void;
 }
 
+/**
+ * Injectable filesystem + environment seam. Production uses the real node:fs
+ * calls; unit tests substitute this to drive the concurrent steal paths
+ * deterministically. Not part of the public contract — callers pass only the
+ * documented options below.
+ * @internal
+ */
+export interface LockDeps {
+  mkdirSync: typeof mkdirSync;
+  readFileSync: typeof readFileSync;
+  writeFileSync: typeof writeFileSync;
+  renameSync: typeof renameSync;
+  unlinkSync: typeof unlinkSync;
+  pidAlive: (pid: number) => boolean;
+  pid: number;
+  now: () => string;
+  uniqueSuffix: () => string;
+  /** Test-only barrier, awaited after a dead holder is observed and before
+   * the steal `rename`. Inert (absent) in production. */
+  onBeforeSteal?: () => Promise<void> | void;
+}
+
+let stealCounter = 0;
+
+function realDeps(): LockDeps {
+  return {
+    mkdirSync,
+    readFileSync,
+    writeFileSync,
+    renameSync,
+    unlinkSync,
+    pidAlive,
+    pid: process.pid,
+    now: () => new Date().toISOString(),
+    uniqueSuffix: () =>
+      `${Date.now().toString(36)}-${(stealCounter++).toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+  };
+}
+
+function errCode(err: unknown): string | undefined {
+  return (err as NodeJS.ErrnoException).code;
+}
+
+export interface AcquireMutationLockOptions {
+  waitMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+  /** @internal test seam — see {@link LockDeps}. */
+  deps?: LockDeps;
+}
+
 export async function acquireMutationLock(
   path: string,
-  options: { waitMs?: number; sleep?: (ms: number) => Promise<void> } = {},
+  options: AcquireMutationLockOptions = {},
 ): Promise<MutationLock> {
   const waitMs = options.waitMs ?? 30_000;
   const sleep = options.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+  const deps = options.deps ?? realDeps();
   const deadline = Date.now() + waitMs;
-  mkdirSync(dirname(path), { recursive: true });
+  deps.mkdirSync(dirname(path), { recursive: true });
 
   for (;;) {
     try {
-      const payload: LockPayload = { pid: process.pid, ts: new Date().toISOString() };
-      writeFileSync(path, JSON.stringify(payload), { flag: "wx" });
+      const payload: LockPayload = { pid: deps.pid, ts: deps.now() };
+      deps.writeFileSync(path, JSON.stringify(payload), { flag: "wx" });
       return {
         release() {
           try {
-            unlinkSync(path);
+            deps.unlinkSync(path);
           } catch {
             // already gone — fine
           }
         },
       };
     } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+      if (errCode(err) !== "EEXIST") throw err;
       let holder: LockPayload | null = null;
       try {
-        holder = JSON.parse(readFileSync(path, "utf8")) as LockPayload;
+        holder = JSON.parse(deps.readFileSync(path, "utf8") as string) as LockPayload;
       } catch {
         holder = null; // torn write — treat as stale
       }
-      if (holder === null || !pidAlive(holder.pid)) {
-        try {
-          unlinkSync(path); // stale: holder is dead
-        } catch {
-          // raced another steal — loop and retry
-        }
+      if (holder === null || !deps.pidAlive(holder.pid)) {
+        await stealStale(path, deps);
+        // Whatever the steal outcome, re-loop: an empty slot lets us create a
+        // fresh lock via `wx`; a slot re-taken by another process sends us
+        // back through the holder check (and, for a live holder, the wait).
         continue;
       }
       if (Date.now() >= deadline) {
@@ -78,5 +136,53 @@ export async function acquireMutationLock(
       // lock-acquisition retries are inherently sequential polling against the same lockfile
       await sleep(150);
     }
+  }
+}
+
+/**
+ * Atomically claim and discard a lockfile whose holder appears dead. Exactly
+ * one concurrent stealer wins the `rename`; the rest get ENOENT and return to
+ * retry. After winning, the renamed file is re-read: if a live lock had been
+ * installed at `path` in the meantime (so the file we just moved is actually
+ * live), it is restored to `path` — via `wx`, so a lock re-created by a third
+ * process is never clobbered — and we back off instead of stealing it.
+ */
+async function stealStale(path: string, deps: LockDeps): Promise<void> {
+  const temp = `${path}.steal-${deps.pid}-${deps.uniqueSuffix()}`;
+  if (deps.onBeforeSteal) await deps.onBeforeSteal();
+  try {
+    deps.renameSync(path, temp);
+  } catch (err) {
+    if (errCode(err) === "ENOENT") return; // lost the rename race — retry
+    throw err;
+  }
+  // We won the rename and now own `temp`. Confirm the holder is still dead.
+  let stolen: LockPayload | null = null;
+  try {
+    stolen = JSON.parse(deps.readFileSync(temp, "utf8") as string) as LockPayload;
+  } catch {
+    stolen = null; // torn write — genuinely stale
+  }
+  if (stolen !== null && deps.pidAlive(stolen.pid)) {
+    // A live lock slipped in between our read and our rename: this file is not
+    // stale after all. Put it back for its holder (only if the slot is free)
+    // and back off.
+    try {
+      deps.writeFileSync(path, JSON.stringify(stolen), { flag: "wx" });
+    } catch {
+      // slot already re-taken — leave the newcomer's lock intact
+    }
+    tryUnlink(deps, temp);
+    return;
+  }
+  // Confirmed stale — drop it so the next loop turn can create a fresh lock.
+  tryUnlink(deps, temp);
+}
+
+function tryUnlink(deps: LockDeps, path: string): void {
+  try {
+    deps.unlinkSync(path);
+  } catch {
+    // already gone — fine
   }
 }

--- a/test/unit/mutation-lock.test.ts
+++ b/test/unit/mutation-lock.test.ts
@@ -1,0 +1,213 @@
+/**
+ * The advisory mutation lockfile (src/write/lock.ts). Guards the atomic steal
+ * of a stale (dead-holder) lock: a normal steal succeeds; a live holder is
+ * never stolen; the loser of the steal `rename` falls back to waiting; the
+ * post-rename re-read restores a lock that turned out to be live; and two
+ * concurrent stealers resolve to a single winner with the other backing off
+ * (the TOCTOU race an unconditional unlink+recreate would leave open).
+ */
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { acquireMutationLock, type LockDeps, MutationLockError } from "../../src/write/lock.ts";
+
+const ME = 424242; // this-process pid stand-in (treated as alive)
+const OTHER = 525252; // a second live process
+const DEAD = 999001; // a holder pid that is not alive
+
+let dir: string;
+let lockPath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "things-api-lock-test-"));
+  lockPath = join(dir, "mutate.lock");
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** Real-fs deps with a controllable pid identity + liveness table. */
+function deps(pid: number, alive: Set<number>, overrides: Partial<LockDeps> = {}): LockDeps {
+  let n = 0;
+  return {
+    mkdirSync,
+    readFileSync,
+    writeFileSync,
+    renameSync,
+    unlinkSync,
+    pidAlive: (p) => alive.has(p),
+    pid,
+    now: () => "2026-07-16T00:00:00.000Z",
+    uniqueSuffix: () => `t${(n++).toString(36)}`,
+    ...overrides,
+  };
+}
+
+function writeHolder(path: string, pid: number): void {
+  writeFileSync(path, JSON.stringify({ pid, ts: "2026-07-16T00:00:00.000Z" }), { flag: "w" });
+}
+
+function holderPid(path: string): number {
+  return (JSON.parse(readFileSync(path, "utf8")) as { pid: number }).pid;
+}
+
+/** Any leftover `<lock>.steal-*` temp files in the lock directory. */
+function stealTemps(): string[] {
+  const base = basename(lockPath);
+  return readdirSync(dirname(lockPath)).filter((f) => f.startsWith(`${base}.steal-`));
+}
+
+const noSleep = () => Promise.resolve();
+
+describe("acquireMutationLock — stale steal", () => {
+  it("steals a lock whose holder is dead and installs its own", async () => {
+    writeHolder(lockPath, DEAD);
+
+    const lock = await acquireMutationLock(lockPath, {
+      waitMs: 1000,
+      sleep: noSleep,
+      deps: deps(ME, new Set([ME])), // DEAD absent => dead
+    });
+
+    expect(holderPid(lockPath)).toBe(ME);
+    expect(stealTemps()).toEqual([]);
+
+    lock.release();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it("creates the lock outright when no file exists", async () => {
+    const lock = await acquireMutationLock(lockPath, {
+      waitMs: 1000,
+      sleep: noSleep,
+      deps: deps(ME, new Set([ME])),
+    });
+    expect(holderPid(lockPath)).toBe(ME);
+    lock.release();
+  });
+
+  it("never steals a live holder's lock — waits then errors", async () => {
+    writeHolder(lockPath, OTHER);
+
+    await expect(
+      acquireMutationLock(lockPath, {
+        waitMs: 0, // deadline already passed on first EEXIST
+        sleep: noSleep,
+        deps: deps(ME, new Set([ME, OTHER])),
+      }),
+    ).rejects.toBeInstanceOf(MutationLockError);
+
+    // Untouched: the live holder still owns the file, no temp litter.
+    expect(holderPid(lockPath)).toBe(OTHER);
+    expect(stealTemps()).toEqual([]);
+  });
+
+  it("loser of the steal rename falls back to waiting", async () => {
+    writeHolder(lockPath, DEAD);
+
+    // Simulate a competing stealer that won the rename first and installed its
+    // own live lock: our rename gets ENOENT, and the slot now holds OTHER.
+    let firstRename = true;
+    const renameLosing: typeof renameSync = (from, to) => {
+      if (firstRename) {
+        firstRename = false;
+        try {
+          unlinkSync(from as string);
+        } catch {
+          // already gone
+        }
+        writeHolder(lockPath, OTHER); // the winner's fresh live lock
+        const err = new Error("ENOENT") as NodeJS.ErrnoException;
+        err.code = "ENOENT";
+        throw err;
+      }
+      return renameSync(from, to);
+    };
+
+    await expect(
+      acquireMutationLock(lockPath, {
+        waitMs: 0,
+        sleep: noSleep,
+        deps: deps(ME, new Set([ME, OTHER]), { renameSync: renameLosing }),
+      }),
+    ).rejects.toBeInstanceOf(MutationLockError);
+
+    expect(holderPid(lockPath)).toBe(OTHER); // winner's lock intact
+    expect(stealTemps()).toEqual([]);
+  });
+
+  it("restores a lock that turns out live after the rename (post-rename re-check)", async () => {
+    writeHolder(lockPath, DEAD);
+
+    // Between the holder read (DEAD) and the rename, a live lock appears in the
+    // slot, so the file we move is actually OTHER's live lock.
+    let armed = true;
+    const onBeforeSteal = () => {
+      if (!armed) return;
+      armed = false;
+      unlinkSync(lockPath);
+      writeHolder(lockPath, OTHER);
+    };
+
+    await expect(
+      acquireMutationLock(lockPath, {
+        waitMs: 0,
+        sleep: noSleep,
+        deps: deps(ME, new Set([ME, OTHER]), { onBeforeSteal }),
+      }),
+    ).rejects.toBeInstanceOf(MutationLockError);
+
+    // The live lock was put back, not stolen; no temp litter.
+    expect(holderPid(lockPath)).toBe(OTHER);
+    expect(stealTemps()).toEqual([]);
+  });
+
+  it("two concurrent stealers: exactly one wins, the other backs off", async () => {
+    writeHolder(lockPath, DEAD);
+
+    const alive = new Set([ME, OTHER]);
+    let p2Result: Promise<{ release(): void }> | null = null;
+
+    // P1 pauses just before its steal rename to let P2 run to completion. P2
+    // (no barrier) wins the rename, finds DEAD, and installs its own lock. P1
+    // then renames P2's *live* lock, detects it via the re-check, restores it,
+    // and backs off — the race resolves to a single holder.
+    const onBeforeSteal = async (): Promise<void> => {
+      if (p2Result) return;
+      p2Result = acquireMutationLock(lockPath, {
+        waitMs: 1000,
+        sleep: noSleep,
+        deps: deps(OTHER, alive),
+      });
+      await p2Result; // P2 fully acquires before P1 resumes its steal
+    };
+
+    const p1 = acquireMutationLock(lockPath, {
+      waitMs: 0,
+      sleep: noSleep,
+      deps: deps(ME, alive, { onBeforeSteal }),
+    });
+
+    await expect(p1).rejects.toBeInstanceOf(MutationLockError);
+
+    const p2Lock = await p2Result!;
+    expect(holderPid(lockPath)).toBe(OTHER); // P2 is the sole holder
+    expect(stealTemps()).toEqual([]);
+
+    p2Lock.release();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+});


### PR DESCRIPTION
## The race

`acquireMutationLock` steals a lockfile whose holder pid is dead. The old steal path did an unconditional `unlinkSync(path)` then looped to recreate the lock with `wx` — a TOCTOU window:

1. P1 and P2 both `writeFileSync(wx)` → both get `EEXIST`.
2. Both read `holder = deadPid`; both compute `pidAlive(deadPid) === false`.
3. P1 `unlink`s the stale file and recreates it with `wx` → **P1 now holds a live lock**.
4. P2 (already past its own liveness check) `unlink`s **P1's live lock** and recreates it with `wx` → **P2 also believes it holds the lock**.

Two processes now both hold the "exclusive" mutation lock, breaking the invariant that create-probe verification never races (`pipeline.ts` doctrine: "create-probe verification must never race").

## The fix

Make the steal atomic with `rename`:

- A stealer `rename`s the stale file to a private temp name. On POSIX, `rename` of a given source path succeeds for **exactly one** racer; every other racer gets `ENOENT` and falls back to the normal wait/retry loop. That single-winner property is what closes the window.
- After winning the rename, the stealer **re-reads the renamed file** and confirms the holder is still dead. If a live lock slipped into the slot between the original read and the rename (so the file it just moved is actually live), it **restores** that lock to `path` — via `wx`, so a lock a third process may have re-created is never clobbered — and backs off instead of stealing it.
- `ENOENT`/`EEXIST` everywhere are treated as "lost a benign race → retry", never as errors.

Public API, wait-loop backoff, and `MutationLockError` semantics are unchanged. An internal, `@internal` test-only deps seam (fs + pid identity + a pre-rename barrier) makes the concurrent steal paths drivable deterministically without changing the public signature.

## Tests

`test/unit/mutation-lock.test.ts` covers: creating a lock outright; normal steal of a dead-holder lock; live-holder lock is never stolen; loser-of-rename falls back to waiting; post-rename re-check restores a lock that turned out live; and the two-stealer interleaving (P1 pauses at the pre-rename barrier while P2 completes its steal, then P1 detects P2's live lock via the re-check and backs off — exactly one holder survives). All assert no `.steal-*` temp litter is left behind.

`npm run check` passes (exit 0): 1209 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)