### PR TITLE
fix(exit-code): batch unsupported ops exit 6; centralize error-code construction

### DIFF
--- a/src/cli/commands/writes.ts
+++ b/src/cli/commands/writes.ts
@@ -27,7 +27,15 @@ import { BOUNCE_MAX_ITEMS, type ReorderResult } from "../../write/reorder.ts";
 import type { UndoItemResult } from "../../write/undo.ts";
 import type { VectorId } from "../../write/vectors/types.ts";
 
-import { errorEnvelope, ExitCode, okEnvelope, type EnvelopeMeta } from "../../contracts.ts";
+import {
+  aggregateExitCode,
+  blockedCode,
+  errorEnvelope,
+  ExitCode,
+  okEnvelope,
+  verifyFailedCode,
+  type EnvelopeMeta,
+} from "../../contracts.ts";
 import { ReferenceResolutionError } from "../../read/queries.ts";
 import { usageError } from "../read-driver.ts";
 
@@ -277,7 +285,7 @@ function emitResult(result: ReorderResult, opts: WriteFlagOpts, meta: EnvelopeMe
           `${JSON.stringify(
             errorEnvelope(
               {
-                code: `verify-failed:${result.reason}`,
+                code: verifyFailedCode(result),
                 message: result.detail,
                 ...(result.likelyCause !== undefined && { likelyCause: result.likelyCause }),
                 ...(result.hint !== undefined && { remediation: result.hint }),
@@ -305,7 +313,7 @@ function emitResult(result: ReorderResult, opts: WriteFlagOpts, meta: EnvelopeMe
           `${JSON.stringify(
             errorEnvelope(
               {
-                code: `blocked:${result.hazard ?? result.reason}`,
+                code: blockedCode(result),
                 message: result.detail,
                 ...(result.likelyCause !== undefined && { likelyCause: result.likelyCause }),
                 remediation: result.remediation,
@@ -1566,8 +1574,8 @@ export function registerWriteCommands(program: Command): void {
         "options carry the confirmation flags (acknowledgeChecklistReset, " +
         "acknowledgeProjectReopen, dangerouslyPermanent, acknowledgeTagSubtree). " +
         "--dry-run plans everything without executing; --fail-fast skips the rest after " +
-        "the first failure. Exit: 0 all ok · 3 any verify-failed/invalid · 4 any blocked " +
-        "· 5 any drift-blocked.",
+        "the first failure. Exit (worst failure wins): 0 all ok · 3 any verify-failed/invalid " +
+        "· 4 any blocked · 5 any drift-blocked · 6 any unsupported.",
     )
     .option("--dry-run", "plan every op; execute nothing")
     .option("--fail-fast", "skip remaining ops after the first failure")
@@ -1629,17 +1637,9 @@ export function registerWriteCommands(program: Command): void {
           },
         };
         process.stdout.write(`${JSON.stringify(summary)}\n`);
-        const kinds = new Set(failed.map((r) => r.outcome.kind));
-        const reasons = new Set(
-          failed.map((r) => (r.outcome.kind === "blocked" ? r.outcome.reason : "")),
-        );
-        process.exitCode = reasons.has("drift")
-          ? ExitCode.DriftBlocked
-          : kinds.has("blocked")
-            ? ExitCode.Blocked
-            : failed.length > 0
-              ? ExitCode.VerifyFailed
-              : ExitCode.Ok;
+        // Worst failure decides the exit code, by the stable precedence
+        // drift > blocked > unsupported > verify-failed (see aggregateExitCode).
+        process.exitCode = aggregateExitCode(failed.map((r) => r.outcome));
       } finally {
         client?.close();
       }

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -159,3 +159,48 @@ export function okEnvelope<T>(kind: string, data: T, meta: EnvelopeMeta): OkEnve
 export function errorEnvelope(error: ErrorEnvelope["error"], meta: EnvelopeMeta): ErrorEnvelope {
   return { apiVersion: API_VERSION, ok: false, kind: "error", error, meta };
 }
+
+/**
+ * Canonical machine-readable error CODE for a refused ("blocked") mutation: the
+ * specific hazard id when one is named, else the block reason. Every surface —
+ * the CLI `--json` envelope, the MCP tool error, and the audit trail — builds
+ * the `blocked:*` string HERE so the format lives in exactly one place. The
+ * input is a structural subset of the blocked mutation outcome (`hazard`,
+ * `reason`), kept as plain strings so the core never depends on the write layer.
+ */
+export function blockedCode(outcome: { hazard?: string; reason: string }): `blocked:${string}` {
+  return `blocked:${outcome.hazard ?? outcome.reason}`;
+}
+
+/**
+ * Canonical error CODE for a mutation that executed but failed read-after-write
+ * verification (`verify-failed:<reason>`). Companion to {@link blockedCode}; see
+ * it for why this lives in the core and takes a plain-string shape.
+ */
+export function verifyFailedCode<R extends string>(outcome: { reason: R }): `verify-failed:${R}` {
+  return `verify-failed:${outcome.reason}`;
+}
+
+/**
+ * Aggregate exit code for a multi-op run (`things batch`): the single WORST
+ * failure decides, by the documented precedence
+ *
+ *   drift-blocked > blocked > unsupported > verify-failed
+ *
+ * mirroring the per-outcome mapping the single-op path applies (drift→5,
+ * blocked→4, unsupported→6, everything else that failed→3). `failures` is the
+ * failed ops' outcomes: each carries its `kind`, plus the block `reason` so a
+ * drift block can be told apart from a policy block. An empty list is success.
+ */
+export function aggregateExitCode(
+  failures: readonly { kind: string; reason?: string }[],
+): ExitCode {
+  if (failures.length === 0) return ExitCode.Ok;
+  const kinds = new Set(failures.map((f) => f.kind));
+  if (failures.some((f) => f.kind === "blocked" && f.reason === "drift")) {
+    return ExitCode.DriftBlocked;
+  }
+  if (kinds.has("blocked")) return ExitCode.Blocked;
+  if (kinds.has("unsupported")) return ExitCode.Unsupported;
+  return ExitCode.VerifyFailed;
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -16,7 +16,13 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { openThings, type ChecklistEdit, type OpenOptions, type ThingsClient } from "../client.ts";
 import { omitEmpty } from "../model/serialize.ts";
-import { PKG_VERSION, type GroupedPagination, type Pagination } from "../contracts.ts";
+import {
+  blockedCode,
+  PKG_VERSION,
+  verifyFailedCode,
+  type GroupedPagination,
+  type Pagination,
+} from "../contracts.ts";
 import { diagnose } from "../diagnose.ts";
 import {
   AREA_PREVIEW_LIMIT,
@@ -152,14 +158,14 @@ function mutationResult(result: MutationResult | ReorderResult): ToolResult {
       return jsonResult(result);
     case "blocked":
       return errorResult({
-        code: `blocked:${result.hazard ?? result.reason}`,
+        code: blockedCode(result),
         message: result.detail,
         ...(result.likelyCause !== undefined && { likelyCause: result.likelyCause }),
         remediation: result.remediation,
       });
     case "verify-failed":
       return errorResult({
-        code: `verify-failed:${result.reason}`,
+        code: verifyFailedCode(result),
         message: result.detail,
         ...(result.likelyCause !== undefined && { likelyCause: result.likelyCause }),
         ...(result.hint !== undefined && { remediation: result.hint }),

--- a/src/write/edit-checklist.ts
+++ b/src/write/edit-checklist.ts
@@ -22,6 +22,7 @@
  * carries only a `completed` boolean) — matching the prior granular behavior.
  */
 import type { AuditRecord } from "../audit/schema.ts";
+import { blockedCode, verifyFailedCode } from "../contracts.ts";
 import type { Todo } from "../model/entities.ts";
 import { resolveTaskUuidPrefix } from "../read/queries.ts";
 import { applyChecklistEdit, checklistTarget, type ChecklistEdit } from "./checklist.ts";
@@ -128,7 +129,7 @@ export async function runEditChecklist(
       uuid,
       startedAt,
       requested: { action: edit.action },
-      result: "blocked:H-UNKNOWN-DESTINATION",
+      result: blockedCode({ hazard: "H-UNKNOWN-DESTINATION", reason: "hazard" }),
     });
     return {
       kind: "blocked",
@@ -186,8 +187,7 @@ export async function runEditChecklist(
       uuid,
       startedAt,
       requested: capture.requested,
-      result:
-        leg.kind === "blocked" ? `blocked:${leg.hazard ?? leg.reason}` : "verify-failed:mismatch",
+      result: leg.kind === "blocked" ? blockedCode(leg) : verifyFailedCode({ reason: "mismatch" }),
     });
     return { ...leg, op: "todo.edit-checklist-item" };
   }

--- a/src/write/pipeline.ts
+++ b/src/write/pipeline.ts
@@ -8,6 +8,7 @@ import type { DatabaseSync } from "node:sqlite";
 
 import type { AuditWriter } from "../audit/log.ts";
 import { undoToken, type AuditRecord } from "../audit/schema.ts";
+import { blockedCode, verifyFailedCode } from "../contracts.ts";
 import type { DisruptionTier, ThingsApiConfig } from "../config.ts";
 import type { FingerprintStatus } from "../db/fingerprint.ts";
 import { localToday } from "../model/dates.ts";
@@ -314,7 +315,7 @@ export async function runMutation<K extends OperationKind>(
       fp.kind === "unknown-version"
         ? `unknown database version ${fp.observation.databaseVersion ?? "?"} (newer Things?)`
         : "schema fingerprint deviates from the shipped baseline";
-    audit({ result: "blocked:drift" });
+    audit({ result: blockedCode({ reason: "drift" }) });
     return {
       kind: "blocked",
       op,
@@ -333,7 +334,7 @@ export async function runMutation<K extends OperationKind>(
     lock = await acquireMutationLock(deps.lockPath);
   } catch (err) {
     if (err instanceof MutationLockError) {
-      audit({ result: "blocked:lock" });
+      audit({ result: blockedCode({ reason: "lock" }) });
       return {
         kind: "blocked",
         op,
@@ -372,7 +373,7 @@ export async function runMutation<K extends OperationKind>(
       acks,
     });
     if (block !== null) {
-      audit({ result: `blocked:${block.hazard}` });
+      audit({ result: blockedCode({ hazard: block.hazard, reason: "hazard" }) });
       return {
         kind: "blocked",
         op,
@@ -396,7 +397,7 @@ export async function runMutation<K extends OperationKind>(
       return { kind: "unsupported", op, considered: plan.considered };
     }
     if (plan.kind === "tier-blocked") {
-      audit({ result: "blocked:disruption-tier" });
+      audit({ result: blockedCode({ reason: "disruption-tier" }) });
       return {
         kind: "blocked",
         op,
@@ -415,7 +416,7 @@ export async function runMutation<K extends OperationKind>(
     if (plan.candidate.support.experimental === true) {
       const declared = (deps.sdefProbe ?? sdefDeclaresPrivateReorder)();
       if (!declared) {
-        audit({ result: "blocked:environment" });
+        audit({ result: blockedCode({ reason: "environment" }) });
         return {
           kind: "blocked",
           op,
@@ -461,7 +462,7 @@ export async function runMutation<K extends OperationKind>(
       const proxies = (deps.shortcutProxies ?? (() => readShortcutProxies()))();
       if (!proxies.present.includes(invocation.shortcut)) {
         audit({
-          result: "blocked:environment",
+          result: blockedCode({ reason: "environment" }),
           vector: vector.id,
           disruption: effectiveTier,
           invocation: invocation.redactedPayload,
@@ -482,7 +483,7 @@ export async function runMutation<K extends OperationKind>(
     // plain opens and AppleEvents to a closed Things steal focus (A40/A41).
     const running = await (deps.ensureRunning ?? defaultEnsureRunning)(appRunning);
     if (!running) {
-      audit({ result: "blocked:environment" });
+      audit({ result: blockedCode({ reason: "environment" }) });
       return {
         kind: "blocked",
         op,
@@ -504,7 +505,7 @@ export async function runMutation<K extends OperationKind>(
     const executeResult = await vector.execute(invocation);
     if (executeResult.exitCode !== 0 || executeResult.timedOut === true) {
       audit({
-        result: "verify-failed:silent-noop",
+        result: verifyFailedCode({ reason: "silent-noop" }),
         vector: vector.id,
         disruption: effectiveTier,
         invocation: invocation.redactedPayload,
@@ -608,7 +609,7 @@ export async function runMutation<K extends OperationKind>(
       };
     }
 
-    audit({ ...auditCommon, result: `verify-failed:${outcome.kind}` });
+    audit({ ...auditCommon, result: verifyFailedCode({ reason: outcome.kind }) });
     return withHint(
       {
         kind: "verify-failed" as const,

--- a/test/cli/write-cli.test.ts
+++ b/test/cli/write-cli.test.ts
@@ -308,6 +308,93 @@ describe("batch (Phase 13)", () => {
     expect(process.exitCode).toBe(4); // blocked outranks invalid
   });
 
+  it("a batch of only unsupported ops exits 6 (Unsupported), not 3", async () => {
+    // url-scheme cannot delete a to-do (matrix support "no"); forcing that
+    // vector makes the op unsupported at planning time — nothing executes.
+    const a = seedTodo(fixture.db, { title: "u1" });
+    const b = seedTodo(fixture.db, { title: "u2" });
+    const batchFile = join(stateDir, "unsupported.jsonl");
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(
+      batchFile,
+      [
+        JSON.stringify({
+          op: "todo.delete",
+          params: { uuid: a },
+          options: { vector: "url-scheme" },
+        }),
+        JSON.stringify({
+          op: "todo.delete",
+          params: { uuid: b },
+          options: { vector: "url-scheme" },
+        }),
+      ].join("\n"),
+    );
+    await run(["batch", batchFile, "--dry-run"]);
+    const lines = stdout
+      .join("")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    expect(lines[0].outcome.kind).toBe("unsupported");
+    expect(lines[1].outcome.kind).toBe("unsupported");
+    expect(lines[2].summary).toEqual({ total: 2, ok: 0, failed: 2, skipped: 0 });
+    expect(process.exitCode).toBe(6);
+  });
+
+  it("mixed batch: blocked outranks unsupported (exit 4)", async () => {
+    const a = seedTodo(fixture.db, { title: "u1" });
+    const batchFile = join(stateDir, "mixed-blocked.jsonl");
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(
+      batchFile,
+      [
+        JSON.stringify({
+          op: "todo.delete",
+          params: { uuid: a },
+          options: { vector: "url-scheme" },
+        }), // unsupported
+        JSON.stringify({ op: "trash.empty", params: {} }), // H-PERMANENT-DELETE -> blocked
+      ].join("\n"),
+    );
+    await run(["batch", batchFile, "--dry-run"]);
+    const lines = stdout
+      .join("")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    expect(new Set([lines[0].outcome.kind, lines[1].outcome.kind])).toEqual(
+      new Set(["unsupported", "blocked"]),
+    );
+    expect(process.exitCode).toBe(4);
+  });
+
+  it("mixed batch: unsupported outranks verify-failed/invalid (exit 6)", async () => {
+    const a = seedTodo(fixture.db, { title: "u1" });
+    const batchFile = join(stateDir, "mixed-unsupported.jsonl");
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(
+      batchFile,
+      [
+        JSON.stringify({
+          op: "todo.delete",
+          params: { uuid: a },
+          options: { vector: "url-scheme" },
+        }), // unsupported
+        "not json {", // invalid -> feeds the verify-failed catch-all
+      ].join("\n"),
+    );
+    await run(["batch", batchFile, "--dry-run"]);
+    const lines = stdout
+      .join("")
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l));
+    expect(lines[0].outcome.kind).toBe("unsupported");
+    expect(lines[1].outcome.kind).toBe("invalid");
+    expect(process.exitCode).toBe(6);
+  });
+
   it("--fail-fast skips after the first failure", async () => {
     const uuid = seedTodo(fixture.db, { title: "ff" });
     const batchFile = join(stateDir, "ff.jsonl");

--- a/test/unit/contracts.test.ts
+++ b/test/unit/contracts.test.ts
@@ -3,11 +3,14 @@ import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 
 import {
+  aggregateExitCode,
   API_VERSION,
+  blockedCode,
   errorEnvelope,
   ExitCode,
   okEnvelope,
   PKG_VERSION,
+  verifyFailedCode,
 } from "../../src/contracts.ts";
 
 describe("exit-code contract", () => {
@@ -51,6 +54,62 @@ describe("json envelope contract", () => {
     expect(env.ok).toBe(false);
     expect(env.kind).toBe("error");
     expect(env.error.code).toBe("drift-blocked");
+  });
+});
+
+describe("error-code builders", () => {
+  it("blockedCode prefers the hazard id, falling back to the block reason", () => {
+    expect(blockedCode({ hazard: "H-PERMANENT-DELETE", reason: "hazard" })).toBe(
+      "blocked:H-PERMANENT-DELETE",
+    );
+    expect(blockedCode({ reason: "drift" })).toBe("blocked:drift");
+    expect(blockedCode({ reason: "disruption-tier" })).toBe("blocked:disruption-tier");
+    expect(blockedCode({ reason: "environment" })).toBe("blocked:environment");
+  });
+
+  it("verifyFailedCode namespaces the reason", () => {
+    expect(verifyFailedCode({ reason: "timeout" })).toBe("verify-failed:timeout");
+    expect(verifyFailedCode({ reason: "mismatch" })).toBe("verify-failed:mismatch");
+    expect(verifyFailedCode({ reason: "silent-noop" })).toBe("verify-failed:silent-noop");
+  });
+});
+
+describe("aggregate exit code", () => {
+  it("is Ok for no failures", () => {
+    expect(aggregateExitCode([])).toBe(ExitCode.Ok);
+  });
+
+  it("maps a lone failure kind to its exit code", () => {
+    expect(aggregateExitCode([{ kind: "verify-failed", reason: "timeout" }])).toBe(
+      ExitCode.VerifyFailed,
+    );
+    expect(aggregateExitCode([{ kind: "invalid" }])).toBe(ExitCode.VerifyFailed);
+    expect(aggregateExitCode([{ kind: "unsupported" }])).toBe(ExitCode.Unsupported);
+    expect(aggregateExitCode([{ kind: "blocked", reason: "hazard" }])).toBe(ExitCode.Blocked);
+    expect(aggregateExitCode([{ kind: "blocked", reason: "drift" }])).toBe(ExitCode.DriftBlocked);
+  });
+
+  it("applies precedence drift > blocked > unsupported > verify-failed", () => {
+    // The regression this guards: unsupported must outrank a plain
+    // verify-failed/invalid (the batch path used to exit 3 here, not 6).
+    expect(
+      aggregateExitCode([{ kind: "verify-failed", reason: "mismatch" }, { kind: "unsupported" }]),
+    ).toBe(ExitCode.Unsupported);
+    expect(aggregateExitCode([{ kind: "invalid" }, { kind: "unsupported" }])).toBe(
+      ExitCode.Unsupported,
+    );
+    // blocked outranks unsupported...
+    expect(
+      aggregateExitCode([{ kind: "unsupported" }, { kind: "blocked", reason: "hazard" }]),
+    ).toBe(ExitCode.Blocked);
+    // ...and a drift block outranks everything.
+    expect(
+      aggregateExitCode([
+        { kind: "unsupported" },
+        { kind: "blocked", reason: "hazard" },
+        { kind: "blocked", reason: "drift" },
+      ]),
+    ).toBe(ExitCode.DriftBlocked);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes an exit-code contract bug and centralizes error-code string construction.

**The bug:** the `things batch` aggregate exit-code derivation never inspected `unsupported` outcomes. A batch whose only failures were `unsupported` ops exited **3 (VerifyFailed)** instead of **6 (Unsupported)** — the single-op path maps `unsupported → 6` correctly, so the two paths disagreed and the documented stable-exit-code contract was violated.

**The refactor:** the `blocked:*` / `verify-failed:*` code strings and the batch's exit-code precedence were hand-rolled across five files. They now live in one place — `src/contracts.ts` (the core both surfaces import):

- `blockedCode(outcome)` / `verifyFailedCode(outcome)` build the code strings from a structural, plain-string shape (`{ hazard?, reason }` / `{ reason }`) — no write-layer import, so the `core → surfaces` dependency direction is preserved. Replaces the templates in the CLI `--json` envelope, the MCP tool error, the pipeline audit records, and the edit-checklist audit records.
- `aggregateExitCode(failures)` collapses a batch's failed outcomes to one exit code by the precedence **drift > blocked > unsupported > verify-failed**, mirroring the single-op mapping. Replaces the hand-rolled batch derivation and fixes the bug.

Emitted strings are byte-for-byte unchanged (pure refactor); the only user-visible copy change is the `batch --help` exit legend, which now documents `6 any unsupported`.

## Placement rationale

The builders accept plain-string structural shapes rather than the `MutationResult` union, so `contracts.ts` never imports from `write/` (that would invert the DAG). The blocked/verify-failed `MutationResult` variants are structurally assignable to those shapes, so call sites pass the narrowed outcome directly. Return types are precise template-literal types (`` `blocked:${string}` ``, `` `verify-failed:${R}` ``) so they satisfy the strict `AuditRecord.result` field without casts.

`undo`'s exit derivation (writes.ts) was **intentionally left as-is**: it aggregates a different taxonomy (`ok`/`irreversible`/`failed`/`partial`/`dry-run`) with an empty-set → Usage(2) rule that has no blocked/unsupported/drift concept, so it does not belong to the mutation-outcome precedence `aggregateExitCode` encodes. Folding it in would have been a false unification. The single `aggregate` helper covers the batch case, which is where the bug lived.

## Tests

- `test/unit/contracts.test.ts` — unit coverage for `blockedCode`, `verifyFailedCode`, and `aggregateExitCode` (including the full precedence ladder).
- `test/cli/write-cli.test.ts` — CLI batch cases driven through a fixture DB: all-unsupported → 6, blocked outranks unsupported → 4, unsupported outranks verify-failed/invalid → 6. Unsupported is produced deterministically and without executing by forcing `todo.delete` onto the `url-scheme` vector (matrix support `"no"`) under `--dry-run`.

`npm run check` passes (exit 0): 1211 tests, typecheck, lint, format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
