### PR TITLE
feat(read): non-blocking schema-change warning on the read path

### DIFF
--- a/src/cli/read-driver.ts
+++ b/src/cli/read-driver.ts
@@ -24,6 +24,7 @@ import {
 import { resolveCap } from "../read/caps.ts";
 import { DEFAULT_LIST_LIMIT } from "../read/pagination.ts";
 import { omitEmpty } from "../model/serialize.ts";
+import { schemaWarnings } from "../surface-copy.ts";
 
 export interface GlobalReadOpts {
   json?: boolean;
@@ -97,6 +98,9 @@ export function runRead<T>(
   try {
     client = openThings(opts.db ? { dbPath: opts.db } : {});
     const fp = client.fingerprint();
+    // Reads never block on a schema change — they warn (design decision). The
+    // note reuses the same cached fingerprint the write path gates on.
+    const warnings = schemaWarnings(client.schemaStatus());
     const { data, pagination, grouped, lines: precomputed } = fn(client);
     // The canonical command a sugar invocation normalized to — known now that
     // `fn` has resolved any reference. Present only for the routing sugars
@@ -109,11 +113,12 @@ export function runRead<T>(
       ...(pagination !== undefined && { pagination }),
       ...(grouped !== undefined && { grouped }),
       ...(resolvedCommand !== null && { resolvedCommand }),
+      ...(warnings.length > 0 && { warnings }),
     };
-    if (fp.kind !== "ok") {
-      process.stderr.write(
-        `warning: schema fingerprint ${meta.fingerprint} — reads best-effort, writes disabled (run \`things doctor\`)\n`,
-      );
+    // Human output gets the note once on STDERR (never mixed into the piped
+    // stdout rows); the --json envelope carries it in meta.warnings instead.
+    if (!opts.json) {
+      for (const warning of warnings) process.stderr.write(`warning: ${warning}\n`);
     }
     if (opts.json) {
       // Omit-empty applies to the entity/data payload only (contracts.md); the

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,7 +8,13 @@ import { loadConfig, type ThingsApiConfig } from "./config.ts";
 import { PKG_VERSION } from "./contracts.ts";
 import { BASELINES } from "./db/baselines/index.ts";
 import { openConnection, type ThingsConnection } from "./db/connection.ts";
-import { compareToBaseline, observeSchema, type FingerprintStatus } from "./db/fingerprint.ts";
+import {
+  compareToBaseline,
+  observeSchema,
+  toSchemaStatus,
+  type FingerprintStatus,
+  type SchemaStatus,
+} from "./db/fingerprint.ts";
 import { locateThingsDb } from "./db/locate.ts";
 import type { AnyTask, Area, Project, Tag } from "./model/entities.ts";
 import { auditDir, mutationLockPath } from "./paths.ts";
@@ -126,6 +132,13 @@ export interface ThingsClient {
   dbPath: string;
   config: ThingsApiConfig;
   fingerprint(): FingerprintStatus;
+  /**
+   * The read-path schema check: the cached fingerprint comparison reduced to a
+   * warn-or-not verdict (ok / drift / unknown-version) with detail. Reuses the
+   * SAME lazily-built fingerprint the write path gates on — computed at most
+   * once per client, so it costs nothing after the first read.
+   */
+  schemaStatus(): SchemaStatus;
   read: {
     today(filter?: TodayFilter): TodayView;
     inbox(filter?: InboxFilter): ListItem[];
@@ -465,6 +478,7 @@ export function openThings(options: OpenOptions = {}): ThingsClient {
     dbPath: located.path,
     config,
     fingerprint,
+    schemaStatus: () => toSchemaStatus(fingerprint()),
     read: {
       today: (f) => todayView(conn.db, now(), f),
       inbox: (f) => inboxView(conn.db, now(), f),

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -109,6 +109,13 @@ export interface EnvelopeMeta {
    * reads reached via a sugar form; absent for canonical invocations.
    */
   resolvedCommand?: string;
+  /**
+   * Non-blocking advisories about this read (ADDITIVE). Present only when there
+   * is something to flag — currently a one-line note when the Things database
+   * schema no longer matches the version this build was validated against
+   * (reads stay best-effort; run `things doctor`). Absent means none.
+   */
+  warnings?: string[];
 }
 
 export interface OkEnvelope<T> {

--- a/src/db/fingerprint.ts
+++ b/src/db/fingerprint.ts
@@ -123,3 +123,29 @@ export function compareToBaseline(
   });
   return { kind: "drift", observation, expected: baseline.fingerprint, detail };
 }
+
+/**
+ * The read-path view of {@link FingerprintStatus}: the comparison outcome
+ * reduced to the discriminant a consumer surface acts on, plus the human
+ * detail lines (for drift, the missing tables/columns). Reads consult this to
+ * WARN — never to block; the write path keeps using the full FingerprintStatus.
+ */
+export interface SchemaStatus {
+  status: "ok" | "drift" | "unknown-version";
+  detail: string[];
+}
+
+/** Reduce a cached {@link FingerprintStatus} to the read-path {@link SchemaStatus}. */
+export function toSchemaStatus(fp: FingerprintStatus): SchemaStatus {
+  switch (fp.kind) {
+    case "ok":
+      return { status: "ok", detail: [] };
+    case "drift":
+      return { status: "drift", detail: fp.detail };
+    case "unknown-version":
+      return {
+        status: "unknown-version",
+        detail: [`unrecognized databaseVersion: ${fp.observation.databaseVersion ?? "unknown"}`],
+      };
+  }
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -40,6 +40,7 @@ import {
   PROJECT_LIMIT_DESC,
   REF_FORMAT,
   REMINDER_FORMAT,
+  schemaWarnings,
   WHEN_VALUES,
 } from "../surface-copy.ts";
 import { capabilitiesTable } from "../write/capabilities.ts";
@@ -403,6 +404,29 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
     }
   };
 
+  /**
+   * A read handler wrapper: run through {@link guard}, then — on a successful
+   * result — append a meta block carrying any non-blocking schema warning (the
+   * same note the CLI prints), so a consumer sees when the Things database no
+   * longer matches the validated schema and its data may be incomplete. No
+   * block is added when the schema checks out or the read itself errored.
+   */
+  const readGuard = async (fn: () => Promise<ToolResult> | ToolResult): Promise<ToolResult> => {
+    const result = await guard(fn);
+    if (result.isError === true) return result;
+    let warnings: string[] = [];
+    try {
+      warnings = schemaWarnings(getClient().schemaStatus());
+    } catch {
+      warnings = [];
+    }
+    if (warnings.length === 0) return result;
+    return {
+      ...result,
+      content: [...result.content, { type: "text", text: JSON.stringify({ meta: { warnings } }) }],
+    };
+  };
+
   /** Resolve a uuid to to-do/project for the type-generic item tools. */
   const itemType = (uuid: string): "to-do" | "project" => {
     const item = getClient().read.byUuid(uuid);
@@ -482,7 +506,7 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
       annotations: READ_ONLY,
     },
     async (args) =>
-      guard(() => {
+      readGuard(() => {
         const tagConflict = tagFlagConflict(args);
         if (tagConflict !== null) return usage(tagConflict);
         // show_active_project_items is the preferred name; active_project_items
@@ -627,7 +651,7 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
       annotations: READ_ONLY,
     },
     async (args) =>
-      guard(() => {
+      readGuard(() => {
         const tagConflict = tagFlagConflict(args);
         if (tagConflict !== null) return usage(tagConflict);
         if (
@@ -671,7 +695,7 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
       annotations: READ_ONLY,
     },
     async (args) =>
-      guard(() => {
+      readGuard(() => {
         const limit = resolveLimit(args);
         if (limit === "conflict") return usage("pass at most one of limit / all");
         const since = new Date(args.since);
@@ -698,7 +722,7 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
       annotations: READ_ONLY,
     },
     async (args) =>
-      guard(() => {
+      readGuard(() => {
         const item = getClient().read.byUuid(args.uuid);
         return item === null
           ? errorResult({ code: "not-found", message: noUuidMatch("item", args.uuid) })
@@ -727,7 +751,7 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
       annotations: READ_ONLY,
     },
     async (args) =>
-      guard(() => {
+      readGuard(() => {
         const tagConflict = tagFlagConflict(args);
         if (tagConflict !== null) return usage(tagConflict);
         return readResult(
@@ -775,7 +799,7 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
       annotations: READ_ONLY,
     },
     async (args) =>
-      guard(() => {
+      readGuard(() => {
         const tagConflict = tagFlagConflict(args);
         if (tagConflict !== null) return usage(tagConflict);
         const areaLimit = resolveCap(args.area_limit, args.all, AREA_PREVIEW_LIMIT);
@@ -816,7 +840,7 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
       annotations: READ_ONLY,
     },
     async (args) =>
-      guard(() => {
+      readGuard(() => {
         const c = getClient();
         // areas/tags are not dated entities and have no per-row tag list to
         // filter — overdue and the tag filters are vacuous there, rejected

--- a/src/surface-copy.ts
+++ b/src/surface-copy.ts
@@ -58,3 +58,29 @@ export const GROUPED_ALL_DESC = "show every item in every group (no per-block ca
  */
 export const OMIT_EMPTY_NOTE =
   "Optional fields are omitted from the result when empty; a missing field means unset, empty, or default (read it the same as a null or empty value).";
+
+/**
+ * The read-path schema advisory, surfaced on the envelope `meta.warnings` (and
+ * to STDERR in human CLI output): a one-line, actionable note when the Things
+ * database no longer matches the schema this build was validated against, so a
+ * read stays best-effort rather than silently serving possibly-incomplete data.
+ * Returns an empty array when the schema checks out — an absent warnings key
+ * means no concern. Consumer-voiced (docs/design/surface-copy.md): behavior and
+ * next step only.
+ */
+export function schemaWarnings(status: { status: "ok" | "drift" | "unknown-version" }): string[] {
+  switch (status.status) {
+    case "ok":
+      return [];
+    case "drift":
+      return [
+        "Things database schema has changed since this version was validated — " +
+          "data may be incomplete; run `things doctor`.",
+      ];
+    case "unknown-version":
+      return [
+        "This version has not been validated against your Things database version — " +
+          "data may be incomplete; run `things doctor`.",
+      ];
+  }
+}

--- a/test/cli/read-drift-warning.test.ts
+++ b/test/cli/read-drift-warning.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Reads never block on a schema change — they warn (non-blocking, one line).
+ * When the Things database no longer matches the schema this build was
+ * validated against (a depended column dropped, or an unrecognized
+ * databaseVersion), a read still serves best-effort data and flags it: on
+ * STDERR in human mode, and in `meta.warnings` under --json. A healthy schema
+ * carries no warnings key at all (omit-empty semantics).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { buildProgram } from "../../src/cli/main.ts";
+import { resolveInvocation } from "../../src/cli/resolve-invocation.ts";
+import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
+import { seedArea } from "../fixtures/seed.ts";
+
+let fx: FixtureDb | null = null;
+afterEach(() => {
+  fx?.close();
+  fx = null;
+});
+
+/** A `write`-shaped sink that appends every chunk (decoded) to `sink`. */
+const capture =
+  (sink: string[]) =>
+  (chunk: string | Uint8Array): boolean => {
+    sink.push(typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk));
+    return true;
+  };
+
+/** Run the CLI in-process, capturing stdout AND stderr and the exit code. */
+function runCli(argv: string[]): { stdout: string; stderr: string; exitCode: number } {
+  const out: string[] = [];
+  const err: string[] = [];
+  const originalOut = process.stdout.write.bind(process.stdout);
+  const originalErr = process.stderr.write.bind(process.stderr);
+  process.stdout.write = capture(out) as typeof process.stdout.write;
+  process.stderr.write = capture(err) as typeof process.stderr.write;
+  const originalExitCode = process.exitCode;
+  try {
+    const program = buildProgram();
+    program.exitOverride();
+    program.parse(resolveInvocation(program, argv).argv, { from: "user" });
+    return { stdout: out.join(""), stderr: err.join(""), exitCode: Number(process.exitCode ?? 0) };
+  } finally {
+    process.stdout.write = originalOut;
+    process.stderr.write = originalErr;
+    process.exitCode = originalExitCode;
+  }
+}
+
+describe("read schema warning (non-blocking)", () => {
+  it("--json: a dropped depended column adds meta.warnings, read still succeeds", () => {
+    fx = buildFixtureDb();
+    seedArea(fx.db, "Work");
+    // areas read touches only TMArea, so the read survives a dropped TMTask column.
+    fx.db.exec("ALTER TABLE TMTask DROP COLUMN startBucket;");
+
+    const { stdout, exitCode } = runCli(["areas", "--json", "--db", fx.path]);
+    expect(exitCode).toBe(0);
+    const envelope = JSON.parse(stdout);
+    expect(envelope.ok).toBe(true);
+    expect(envelope.meta.warnings).toBeDefined();
+    expect(envelope.meta.warnings[0]).toContain("schema has changed");
+    expect(envelope.meta.warnings[0]).toContain("things doctor");
+  });
+
+  it("human mode: the warning goes to STDERR, never into the stdout rows", () => {
+    fx = buildFixtureDb();
+    seedArea(fx.db, "Work");
+    fx.db.exec("ALTER TABLE TMTask DROP COLUMN startBucket;");
+
+    const { stdout, stderr, exitCode } = runCli(["areas", "--db", fx.path]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain("warning:");
+    expect(stderr).toContain("schema has changed");
+    expect(stdout).not.toContain("schema has changed");
+  });
+
+  it("--json: an unrecognized databaseVersion adds meta.warnings", () => {
+    fx = buildFixtureDb();
+    seedArea(fx.db, "Work");
+    fx.db.exec("UPDATE Meta SET value = replace(value, '26', '27') WHERE key = 'databaseVersion'");
+
+    const { stdout, exitCode } = runCli(["areas", "--json", "--db", fx.path]);
+    expect(exitCode).toBe(0);
+    const envelope = JSON.parse(stdout);
+    expect(envelope.meta.warnings).toBeDefined();
+    expect(envelope.meta.warnings[0]).toContain("database version");
+    expect(envelope.meta.warnings[0]).toContain("things doctor");
+  });
+
+  it("healthy schema: no warnings key at all, and STDERR stays clean", () => {
+    fx = buildFixtureDb();
+    seedArea(fx.db, "Work");
+
+    const { stdout, stderr, exitCode } = runCli(["areas", "--json", "--db", fx.path]);
+    expect(exitCode).toBe(0);
+    const envelope = JSON.parse(stdout);
+    expect(envelope.meta.fingerprint).toBe("ok");
+    expect("warnings" in envelope.meta).toBe(false);
+    expect(stderr).toBe("");
+  });
+});

--- a/test/mcp/server.test.ts
+++ b/test/mcp/server.test.ts
@@ -90,6 +90,20 @@ function textOf(result: unknown): unknown {
   return JSON.parse(content[0]?.text ?? "null");
 }
 
+/** The warnings array from whichever result block carries meta.warnings. */
+function warningsOf(result: unknown): string[] | undefined {
+  const content = (result as { content: { text: string }[] }).content;
+  for (const block of content) {
+    try {
+      const parsed = JSON.parse(block.text) as { meta?: { warnings?: string[] } };
+      if (parsed.meta?.warnings !== undefined) return parsed.meta.warnings;
+    } catch {
+      // non-JSON block: skip
+    }
+  }
+  return undefined;
+}
+
 beforeEach(() => {
   fixture = buildFixtureDb();
   stateDir = mkdtempSync(join(tmpdir(), "things-api-mcp-test-"));
@@ -1143,6 +1157,47 @@ describe("things MCP server", () => {
           expect(match, `"${name}" leaks "${match?.[0] ?? ""}" (${pattern})`).toBeNull();
         }
       }
+    });
+  });
+
+  describe("schema warning (non-blocking, read meta)", () => {
+    it("a dropped depended column surfaces a warning in a read tool's meta", async () => {
+      // Drop a depended column before the server opens its connection; the read
+      // itself (areas only touch TMArea) still succeeds — reads warn, never block.
+      fixture.db.exec("ALTER TABLE TMTask DROP COLUMN startBucket;");
+      await connect([fakeVector(null).vector]);
+      const result = await client.callTool({
+        name: "list_collections",
+        arguments: { kind: "areas" },
+      });
+      expect(result.isError).toBeFalsy();
+      const warnings = warningsOf(result);
+      expect(warnings).toBeDefined();
+      expect(warnings?.[0]).toContain("schema has changed");
+      expect(warnings?.[0]).toContain("things doctor");
+    });
+
+    it("an unrecognized databaseVersion surfaces a warning in a read tool's meta", async () => {
+      fixture.db.exec(
+        "UPDATE Meta SET value = replace(value, '26', '27') WHERE key = 'databaseVersion'",
+      );
+      await connect([fakeVector(null).vector]);
+      const result = await client.callTool({ name: "read_view", arguments: { view: "today" } });
+      expect(result.isError).toBeFalsy();
+      const warnings = warningsOf(result);
+      expect(warnings).toBeDefined();
+      expect(warnings?.[0]).toContain("database version");
+      expect(warnings?.[0]).toContain("things doctor");
+    });
+
+    it("a healthy schema adds no warnings block", async () => {
+      await connect([fakeVector(null).vector]);
+      const result = await client.callTool({
+        name: "list_collections",
+        arguments: { kind: "areas" },
+      });
+      expect(result.isError).toBeFalsy();
+      expect(warningsOf(result)).toBeUndefined();
     });
   });
 });

--- a/test/unit/fingerprint.test.ts
+++ b/test/unit/fingerprint.test.ts
@@ -2,7 +2,12 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { BASELINES } from "../../src/db/baselines/index.ts";
 import { DB_V26 } from "../../src/db/baselines/db-v26.ts";
-import { compareToBaseline, observeSchema, readDatabaseVersion } from "../../src/db/fingerprint.ts";
+import {
+  compareToBaseline,
+  observeSchema,
+  readDatabaseVersion,
+  toSchemaStatus,
+} from "../../src/db/fingerprint.ts";
 import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
 
 let fixture: FixtureDb | null = null;
@@ -59,5 +64,31 @@ describe("schema fingerprint", () => {
     );
     const status = compareToBaseline(observeSchema(fixture.db), BASELINES);
     expect(status.kind).toBe("unknown-version");
+  });
+});
+
+describe("toSchemaStatus (read-path verdict)", () => {
+  it("maps ok to a clean status with no detail", () => {
+    fixture = buildFixtureDb();
+    const status = toSchemaStatus(compareToBaseline(observeSchema(fixture.db), BASELINES));
+    expect(status).toEqual({ status: "ok", detail: [] });
+  });
+
+  it("carries the drift detail lines through", () => {
+    fixture = buildFixtureDb();
+    fixture.db.exec("ALTER TABLE TMTask DROP COLUMN startBucket;");
+    const status = toSchemaStatus(compareToBaseline(observeSchema(fixture.db), BASELINES));
+    expect(status.status).toBe("drift");
+    expect(status.detail).toContain("column missing: TMTask.startBucket");
+  });
+
+  it("names the unrecognized databaseVersion", () => {
+    fixture = buildFixtureDb();
+    fixture.db.exec(
+      "UPDATE Meta SET value = replace(value, '26', '27') WHERE key = 'databaseVersion'",
+    );
+    const status = toSchemaStatus(compareToBaseline(observeSchema(fixture.db), BASELINES));
+    expect(status.status).toBe("unknown-version");
+    expect(status.detail[0]).toContain("27");
   });
 });


### PR DESCRIPTION
## What

Reads never surfaced a schema change: after a Things update, `things today` silently served data computed against a possibly-changed schema, and an unknown (newer) `databaseVersion` never showed up on reads. Writes hard-block on this; **reads must not — they warn** (design decision).

## Changes

**Library**
- `ThingsClient.schemaStatus()` returns the read-path verdict `{ status: "ok" | "drift" | "unknown-version", detail }`, reducing the **same lazily-built fingerprint the write path gates on** (`toSchemaStatus(fingerprint())`). Computed at most once per client — free after the first read.
- Envelope `meta.warnings?: string[]` — optional, additive. No existing field changed.
- `schemaWarnings()` — the shared, consumer-voiced copy both surfaces emit.

**Surfaces**
- CLI read driver: not-ok schema prints a one-line note to **STDERR in human mode** (once per invocation) and carries it in **`meta.warnings` under `--json`**.
- MCP read tools (`read_view`, `search`, `changes_since`, `get_item`, `get_project`, `get_area`, `list_collections`): append the same warning string to result **meta** via a `readGuard` wrapper. `doctor`/`capabilities` are untouched.
- A healthy schema adds **no `warnings` key at all** (omit-empty semantics).

## Copy

Consumer-voiced and actionable, e.g. _"Things database schema has changed since this version was validated — data may be incomplete; run `things doctor`."_ No banned vocabulary in descriptions or runtime text.

## Tests

- `test/unit/fingerprint.test.ts` — `toSchemaStatus` mapping (ok / drift detail / unknown-version).
- `test/cli/read-drift-warning.test.ts` — dropped column → `meta.warnings` (json) + STDERR line (human, not in stdout); unknown `databaseVersion` → warning; healthy → no `warnings` key, clean STDERR.
- `test/mcp/server.test.ts` — dropped column and unknown version each surface the warning in read-tool meta; healthy adds no block.

`npm run check` passes (exit 0); 1213 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)