### PR TITLE
fix(write): exclude pre-existing rows from create-probe discovery + delta unit suite

### DIFF
--- a/src/write/commands.ts
+++ b/src/write/commands.ts
@@ -35,6 +35,7 @@ import {
   resolveHeading,
   resolveProject,
   resolveTag,
+  sameTitleTaskUuids,
   trashedCount,
   type PreState,
 } from "./pre-state.ts";
@@ -226,6 +227,18 @@ function containerGiven(ref: ContainerRef | undefined): boolean {
   return ref !== undefined && (ref.uuid !== undefined || ref.title !== undefined);
 }
 
+/**
+ * The create-probe title for the duplicate / identity-replacement ops, whose
+ * new row inherits the pre-read target's title. Non-heading targets only (the
+ * heading-convert op uses the raw title, headings included); "" when the target
+ * did not resolve. Shared by the pre-read same-title capture and the delta so
+ * the excluded set and the probe title cannot drift apart.
+ */
+function nonHeadingTitle(pre: PreState): string {
+  const target = pre.target;
+  return target !== null && target.type !== "heading" ? target.title : "";
+}
+
 // ----------------------------------------------------------------- commands
 
 const todoAdd: CommandSpec<"todo.add"> = {
@@ -250,6 +263,7 @@ const todoAdd: CommandSpec<"todo.add"> = {
     }
     if (containerGiven(params.area)) pre.destArea = resolveArea(db, params.area as ContainerRef);
     if (params.tags !== undefined) applyTagRefs(db, pre, params.tags);
+    pre.sameTitleUuids = sameTitleTaskUuids(db, params.title, "to-do");
     return pre;
   },
   expectedDelta(pre, params, ctx) {
@@ -277,7 +291,12 @@ const todoAdd: CommandSpec<"todo.add"> = {
     if (area !== undefined && area !== null) assert.push({ field: "area.uuid", equals: area.uuid });
     return {
       mode: "create",
-      probe: { title: params.title, type: "to-do", sinceEpoch: ctx.nowEpoch - 2 },
+      probe: {
+        title: params.title,
+        type: "to-do",
+        sinceEpoch: ctx.nowEpoch - 2,
+        excludeUuids: pre.sameTitleUuids,
+      },
       assert,
     };
   },
@@ -667,6 +686,7 @@ const projectAdd: CommandSpec<"project.add"> = {
   preRead(db, params) {
     const pre = emptyPreState();
     if (containerGiven(params.area)) pre.destArea = resolveArea(db, params.area as ContainerRef);
+    pre.sameTitleUuids = sameTitleTaskUuids(db, params.title, "project");
     return pre;
   },
   expectedDelta(pre, params, ctx) {
@@ -678,7 +698,12 @@ const projectAdd: CommandSpec<"project.add"> = {
     if (area !== undefined && area !== null) assert.push({ field: "area.uuid", equals: area.uuid });
     return {
       mode: "create",
-      probe: { title: params.title, type: "project", sinceEpoch: ctx.nowEpoch - 2 },
+      probe: {
+        title: params.title,
+        type: "project",
+        sinceEpoch: ctx.nowEpoch - 2,
+        excludeUuids: pre.sameTitleUuids,
+      },
       assert,
     };
   },
@@ -854,17 +879,24 @@ const projectDuplicate: CommandSpec<"project.duplicate"> = {
   preRead(db, params) {
     const pre = emptyPreState();
     pre.target = loadTarget(db, params.uuid);
+    pre.sameTitleUuids = sameTitleTaskUuids(db, nonHeadingTitle(pre), "project");
     return pre;
   },
   expectedDelta(pre, _params, ctx) {
     // E17: the copy carries the title, notes AND children; discover it with
-    // the create probe (fresh creationDate, same as the to-do path E07).
+    // the create probe (fresh creationDate, same as the to-do path E07). The
+    // ORIGINAL shares the copy's title, so it is among the excluded pre-existing
+    // rows — discovery lands on the copy, never the source.
     const target = pre.target;
-    const title = target !== null && target.type !== "heading" ? target.title : "";
     const notes = target !== null && target.type !== "heading" ? target.notes : "";
     return {
       mode: "create",
-      probe: { title, type: "project", sinceEpoch: ctx.nowEpoch - 2 },
+      probe: {
+        title: nonHeadingTitle(pre),
+        type: "project",
+        sinceEpoch: ctx.nowEpoch - 2,
+        excludeUuids: pre.sameTitleUuids,
+      },
       assert: [{ field: "notes", equals: notes }],
     };
   },
@@ -1140,17 +1172,23 @@ const todoDuplicate: CommandSpec<"todo.duplicate"> = {
   preRead(db, params) {
     const pre = emptyPreState();
     pre.target = loadTarget(db, params.uuid);
+    pre.sameTitleUuids = sameTitleTaskUuids(db, nonHeadingTitle(pre), "to-do");
     return pre;
   },
   expectedDelta(pre, _params, ctx) {
     // The copy carries the same title/notes with a fresh uuid + creationDate
-    // (E07) — discover it with the create probe, assert copy fidelity.
+    // (E07) — discover it with the create probe, assert copy fidelity. The
+    // ORIGINAL shares the title, so it is excluded as a pre-existing row.
     const target = pre.target;
-    const title = target !== null && target.type !== "heading" ? target.title : "";
     const notes = target !== null && target.type !== "heading" ? target.notes : "";
     return {
       mode: "create",
-      probe: { title, type: "to-do", sinceEpoch: ctx.nowEpoch - 2 },
+      probe: {
+        title: nonHeadingTitle(pre),
+        type: "to-do",
+        sinceEpoch: ctx.nowEpoch - 2,
+        excludeUuids: pre.sameTitleUuids,
+      },
       assert: [{ field: "notes", equals: notes }],
     };
   },
@@ -1418,11 +1456,7 @@ const todoAddLogged: CommandSpec<"todo.add-logged"> = {
       throw new RangeError("creationDate must not be after completionDate");
     }
     const pre = emptyPreState();
-    pre.sameTitleUuids = (
-      db.prepare("SELECT uuid FROM TMTask WHERE title = ? AND type = 0").all(params.title) as {
-        uuid: string;
-      }[]
-    ).map((r) => r.uuid);
+    pre.sameTitleUuids = sameTitleTaskUuids(db, params.title, "to-do");
     return pre;
   },
   expectedDelta(pre, params) {
@@ -1581,15 +1615,21 @@ const headingCreate: CommandSpec<"heading.create"> = {
   preRead(db, params) {
     const pre = emptyPreState();
     pre.destProject = resolveProject(db, params.project);
+    pre.sameTitleUuids = sameTitleTaskUuids(db, params.title, "heading");
     return pre;
   },
   expectedDelta(pre, params, ctx) {
     const project = pre.destProject?.resolved;
-    // A new type=2 row with this title under the project; disambiguate
-    // duplicate titles by newest creationDate (findCreated orders DESC).
+    // A new type=2 row with this title under the project; a pre-existing
+    // same-title heading is excluded so discovery cannot bind to it.
     return {
       mode: "create",
-      probe: { title: params.title, type: "heading", sinceEpoch: ctx.nowEpoch - 2 },
+      probe: {
+        title: params.title,
+        type: "heading",
+        sinceEpoch: ctx.nowEpoch - 2,
+        excludeUuids: pre.sameTitleUuids,
+      },
       assert:
         project !== undefined && project !== null
           ? [{ field: "project.uuid", equals: project.uuid }]
@@ -1685,18 +1725,23 @@ const todoMakeRepeating: CommandSpec<"todo.make-repeating"> = {
     assertRepeatRule(params);
     const pre = emptyPreState();
     pre.target = loadTarget(db, params.uuid);
+    pre.sameTitleUuids = sameTitleTaskUuids(db, nonHeadingTitle(pre), "to-do");
     return pre;
   },
-  expectedDelta(pre, params, ctx) {
+  expectedDelta(pre, _params, ctx) {
     // Identity REPLACEMENT (UI2-a): the original to-do uuid dies; a NEW
-    // template row (type=0 with a recurrence rule) is born. Discover it with
-    // the create probe, and pick the template (not the spawned instance) by
-    // asserting it IS a template.
-    const target = pre.target;
-    const title = target !== null && target.type !== "heading" ? target.title : "";
+    // template row (type=0 with a recurrence rule) is born alongside a spawned
+    // instance sharing its title. Discover the template with the create probe,
+    // excluding the pre-existing same-title rows (incl. the dying original), and
+    // pick the template (not the spawned instance) by asserting it IS one.
     return {
       mode: "create",
-      probe: { title, type: "to-do", sinceEpoch: ctx.nowEpoch - 2 },
+      probe: {
+        title: nonHeadingTitle(pre),
+        type: "to-do",
+        sinceEpoch: ctx.nowEpoch - 2,
+        excludeUuids: pre.sameTitleUuids,
+      },
       assert: [{ field: "repeating.isTemplate", equals: true }],
     };
   },
@@ -1883,17 +1928,23 @@ const projectMakeRepeating: CommandSpec<"project.make-repeating"> = {
     const pre = emptyPreState();
     pre.target = loadTarget(db, params.uuid);
     pre.projectRepeat = classifyProjectRepeat(db, pre.target);
+    pre.sameTitleUuids = sameTitleTaskUuids(db, nonHeadingTitle(pre), "project");
     return pre;
   },
   expectedDelta(pre, _params, ctx) {
     // Identity REPLACEMENT (UIC4-b): the original project uuid dies; a NEW
     // template project (with a recurrence rule) is born alongside a spawned
-    // instance. Pick the TEMPLATE by asserting it IS one; area is preserved.
-    const target = pre.target;
-    const title = target !== null && target.type !== "heading" ? target.title : "";
+    // instance sharing its title. Pick the TEMPLATE by asserting it IS one
+    // (area preserved), excluding the pre-existing same-title rows so discovery
+    // cannot bind to the spawned instance or the dying original.
     return {
       mode: "create",
-      probe: { title, type: "project", sinceEpoch: ctx.nowEpoch - 2 },
+      probe: {
+        title: nonHeadingTitle(pre),
+        type: "project",
+        sinceEpoch: ctx.nowEpoch - 2,
+        excludeUuids: pre.sameTitleUuids,
+      },
       assert: [{ field: "repeating.isTemplate", equals: true }],
     };
   },
@@ -1947,17 +1998,24 @@ const todoConvertToProject: CommandSpec<"todo.convert-to-project"> = {
   preRead(db, params) {
     const pre = emptyPreState();
     pre.target = loadTarget(db, params.uuid);
+    // The new row is a PROJECT (type=1) — exclude pre-existing same-title
+    // projects, not the source to-do (a different type the probe never sees).
+    pre.sameTitleUuids = sameTitleTaskUuids(db, nonHeadingTitle(pre), "project");
     return pre;
   },
   expectedDelta(pre, _params, ctx) {
     // Identity REPLACEMENT (UI2-d): the to-do uuid dies; a NEW type=1 project
     // is born, notes preserved. Discover it (its uuid is returned).
     const target = pre.target;
-    const title = target !== null && target.type !== "heading" ? target.title : "";
     const notes = target !== null && target.type !== "heading" ? target.notes : "";
     return {
       mode: "create",
-      probe: { title, type: "project", sinceEpoch: ctx.nowEpoch - 2 },
+      probe: {
+        title: nonHeadingTitle(pre),
+        type: "project",
+        sinceEpoch: ctx.nowEpoch - 2,
+        excludeUuids: pre.sameTitleUuids,
+      },
       assert: [{ field: "notes", equals: notes }],
     };
   },
@@ -1973,6 +2031,11 @@ const headingConvertToProject: CommandSpec<"heading.convert-to-project"> = {
   preRead(db, params) {
     const pre = emptyPreState();
     pre.target = loadTarget(db, params.uuid);
+    // The new row is a PROJECT (type=1) carrying the former heading's title;
+    // exclude pre-existing same-title projects. The heading uses its raw title
+    // (headings are not covered by nonHeadingTitle).
+    const title = pre.target !== null ? pre.target.title : "";
+    pre.sameTitleUuids = sameTitleTaskUuids(db, title, "project");
     return pre;
   },
   expectedDelta(pre, _params, ctx) {
@@ -1983,7 +2046,12 @@ const headingConvertToProject: CommandSpec<"heading.convert-to-project"> = {
     const title = target !== null ? target.title : "";
     return {
       mode: "create",
-      probe: { title, type: "project", sinceEpoch: ctx.nowEpoch - 2 },
+      probe: {
+        title,
+        type: "project",
+        sinceEpoch: ctx.nowEpoch - 2,
+        excludeUuids: pre.sameTitleUuids,
+      },
       assert: [],
     };
   },

--- a/src/write/pre-state.ts
+++ b/src/write/pre-state.ts
@@ -5,7 +5,7 @@
 import type { DatabaseSync } from "node:sqlite";
 
 import { encodePackedDate, localToday } from "../model/dates.ts";
-import type { AnyTask, Project, TaskStatus, Todo } from "../model/entities.ts";
+import type { AnyTask, Project, TaskStatus, TaskType, Todo } from "../model/entities.ts";
 import { TASK_STATUS_FROM_DB } from "../model/entities.ts";
 import { byUuid } from "../read/detail.ts";
 import { resolveNamedRef } from "../read/queries.ts";
@@ -302,6 +302,26 @@ export function resolveTag(db: DatabaseSync, ref: string): ContainerResolution {
 
 export function loadTarget(db: DatabaseSync, uuid: string): AnyTask | null {
   return byUuid(db, uuid);
+}
+
+/**
+ * Uuids of pre-existing TMTask rows matching a create-probe's (title, type),
+ * captured in the pre-read and threaded into the probe as `excludeUuids`.
+ * Create-mode verification discovers the row the app just made by (title,
+ * type); without this exclusion the probe could bind to a DIFFERENT same-title
+ * row that merely appeared in the trailing sinceEpoch window (a concurrent add,
+ * a repeat-template spawn, a sync insert), recording the wrong discoveredUuid —
+ * and a later undo would then trash the wrong item. Matches `findCreated`'s
+ * exact `title = ? AND type = ?` filter (case-sensitive) so the captured set is
+ * precisely the pre-existing rows that discovery would otherwise consider.
+ */
+export function sameTitleTaskUuids(db: DatabaseSync, title: string, type: TaskType): string[] {
+  const dbType = type === "project" ? 1 : type === "heading" ? 2 : 0;
+  return (
+    db.prepare("SELECT uuid FROM TMTask WHERE title = ? AND type = ?").all(title, dbType) as {
+      uuid: string;
+    }[]
+  ).map((r) => r.uuid);
 }
 
 export function projectChildren(db: DatabaseSync, projectUuid: string): Todo[] {

--- a/test/unit/create-probe-exclusion.test.ts
+++ b/test/unit/create-probe-exclusion.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Create-mode verification must never bind to a PRE-EXISTING same-title row.
+ * These tests drive the real command specs (preRead → expectedDelta) against a
+ * fixture, then evaluate the produced DeltaSpec with the live createDbReader —
+ * proving the excludeUuids capture threads end to end. A pre-existing row is
+ * seeded INSIDE the create-probe's trailing window (recent creationDate), so
+ * without the exclusion it would be a false discovery candidate.
+ */
+import { describe, expect, it } from "vitest";
+
+import { COMMANDS } from "../../src/write/commands.ts";
+import { createDbReader, evaluateDelta } from "../../src/write/verify/delta.ts";
+import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
+import { seedProject, seedTodo } from "../fixtures/seed.ts";
+
+const NOW_EPOCH = Math.floor(Date.now() / 1000);
+const CTX = { nowEpoch: NOW_EPOCH, todayIso: "2026-07-16" as const };
+const EMPTY_PRE = { modDates: {}, fields: {} };
+
+function withDb<T>(fn: (db: FixtureDb["db"]) => T): T {
+  const fx = buildFixtureDb();
+  try {
+    return fn(fx.db);
+  } finally {
+    fx.close();
+  }
+}
+
+describe("todo.add create-probe excludes pre-existing rows", () => {
+  it("discovers only the newly-created row, skipping a recent same-title row", () => {
+    withDb((db) => {
+      // A same-title to-do already sitting inside the probe window (a concurrent
+      // add / repeat spawn / sync insert) — the exact trap the fix guards.
+      const preExisting = seedTodo(db, { title: "Buy milk", creationDate: NOW_EPOCH });
+
+      const params = { title: "Buy milk" };
+      const pre = COMMANDS["todo.add"].preRead(db, params, new Date());
+      expect(pre.sameTitleUuids).toContain(preExisting);
+
+      // The app write lands: a genuinely new row appears post-pre-read.
+      const created = seedTodo(db, { title: "Buy milk", creationDate: NOW_EPOCH });
+
+      const spec = COMMANDS["todo.add"].expectedDelta(pre, params, CTX);
+      expect(spec.mode).toBe("create");
+      if (spec.mode !== "create") throw new Error("unreachable");
+      expect(spec.probe.excludeUuids).toEqual([preExisting]);
+
+      const evaluation = evaluateDelta(spec, createDbReader(db), EMPTY_PRE);
+      expect(evaluation.satisfied).toBe(true);
+      expect(evaluation.discoveredUuid).toBe(created);
+      expect(evaluation.discoveredUuid).not.toBe(preExisting);
+    });
+  });
+
+  it("reports failure when ONLY the pre-existing row matches (silent write failure)", () => {
+    withDb((db) => {
+      // The app write silently failed: no new row. Only the pre-existing,
+      // in-window same-title row remains. The old sinceEpoch-only probe would
+      // discover it and report a false green; the exclusion makes it a failure.
+      const preExisting = seedTodo(db, { title: "Buy milk", creationDate: NOW_EPOCH });
+
+      const params = { title: "Buy milk" };
+      const pre = COMMANDS["todo.add"].preRead(db, params, new Date());
+      const spec = COMMANDS["todo.add"].expectedDelta(pre, params, CTX);
+      if (spec.mode !== "create") throw new Error("unreachable");
+      expect(spec.probe.excludeUuids).toEqual([preExisting]);
+
+      const evaluation = evaluateDelta(spec, createDbReader(db), EMPTY_PRE);
+      expect(evaluation.satisfied).toBe(false);
+      expect(evaluation.movement).toBe(false);
+      expect(evaluation.discoveredUuid).toBeUndefined();
+    });
+  });
+});
+
+describe("project.duplicate create-probe excludes the source project", () => {
+  it("discovers the copy, never the original it was duplicated from", () => {
+    withDb((db) => {
+      const original = seedProject(db, {
+        title: "Launch",
+        notes: "plan",
+        creationDate: NOW_EPOCH,
+      });
+
+      const params = { uuid: original };
+      const pre = COMMANDS["project.duplicate"].preRead(db, params, new Date());
+      // The source itself is the pre-existing same-title row that must be skipped.
+      expect(pre.sameTitleUuids).toEqual([original]);
+
+      const copy = seedProject(db, { title: "Launch", notes: "plan", creationDate: NOW_EPOCH });
+
+      const spec = COMMANDS["project.duplicate"].expectedDelta(pre, params, CTX);
+      if (spec.mode !== "create") throw new Error("unreachable");
+      expect(spec.probe.excludeUuids).toEqual([original]);
+
+      const evaluation = evaluateDelta(spec, createDbReader(db), EMPTY_PRE);
+      expect(evaluation.satisfied).toBe(true);
+      expect(evaluation.discoveredUuid).toBe(copy);
+      expect(evaluation.discoveredUuid).not.toBe(original);
+    });
+  });
+});

--- a/test/unit/verify-delta.test.ts
+++ b/test/unit/verify-delta.test.ts
@@ -1,0 +1,684 @@
+/**
+ * Isolated unit suite for the write-verification core: evaluateDelta and
+ * createDbReader (src/write/verify/delta.ts). This module is the literal
+ * implementation of the package's "verified writes" claim, so every DeltaSpec
+ * discriminant, every reader method, and every getField computed path is
+ * exercised DIRECTLY against fixture DBs here — a regression in any single mode
+ * fails a named test rather than relying on an engine round-trip to cross it.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  createDbReader,
+  evaluateDelta,
+  getField,
+  type DeltaSpec,
+  type PreModDates,
+} from "../../src/write/verify/delta.ts";
+import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
+import {
+  seedArea,
+  seedChecklistItem,
+  seedProject,
+  seedTag,
+  seedTodo,
+  tagArea,
+  tagTask,
+} from "../fixtures/seed.ts";
+
+type Db = FixtureDb["db"];
+
+function withDb<T>(fn: (db: Db) => T): T {
+  const fx = buildFixtureDb();
+  try {
+    return fn(fx.db);
+  } finally {
+    fx.close();
+  }
+}
+
+/** The pre-read bundle evaluateDelta consumes; overridable per test. */
+function pre(opts: {
+  modDates?: PreModDates;
+  fields?: Record<string, Record<string, unknown>>;
+  trashedCount?: number;
+}) {
+  return {
+    modDates: opts.modDates ?? {},
+    fields: opts.fields ?? {},
+    ...(opts.trashedCount !== undefined && { trashedCount: opts.trashedCount }),
+  };
+}
+
+const EMPTY_PRE = pre({});
+
+// ---------------------------------------------------------------- createDbReader
+
+describe("createDbReader", () => {
+  it("taskByUuid decodes a row and returns null for a missing uuid", () => {
+    withDb((db) => {
+      const uuid = seedTodo(db, { title: "Read me" });
+      const reader = createDbReader(db);
+      expect(reader.taskByUuid(uuid)?.title).toBe("Read me");
+      expect(reader.taskByUuid("nope")).toBeNull();
+    });
+  });
+
+  it("areaExists / tagExists reflect row presence", () => {
+    withDb((db) => {
+      const area = seedArea(db, "Home");
+      const tag = seedTag(db, "urgent");
+      const reader = createDbReader(db);
+      expect(reader.areaExists(area)).toBe(true);
+      expect(reader.areaExists("ghost")).toBe(false);
+      expect(reader.tagExists(tag)).toBe(true);
+      expect(reader.tagExists("ghost")).toBe(false);
+    });
+  });
+
+  it("areasByTitle / tagsByTitle match case-insensitively and expose the parent", () => {
+    withDb((db) => {
+      const area = seedArea(db, "Home");
+      const parent = seedTag(db, "work");
+      const child = seedTag(db, "deep", parent);
+      const reader = createDbReader(db);
+      expect(reader.areasByTitle("home")).toEqual([{ uuid: area }]);
+      expect(reader.tagsByTitle("DEEP")).toEqual([{ uuid: child, parent }]);
+      expect(reader.tagsByTitle("work")).toEqual([{ uuid: parent, parent: null }]);
+    });
+  });
+
+  it("rankOf reads index, todayIndex, and area-index; null when the row is absent", () => {
+    withDb((db) => {
+      const todo = seedTodo(db, { index: 5, todayIndex: 3 });
+      const area = seedArea(db, "A", 2);
+      const reader = createDbReader(db);
+      expect(reader.rankOf(todo, "index")).toBe(5);
+      expect(reader.rankOf(todo, "todayIndex")).toBe(3);
+      expect(reader.rankOf(area, "area-index")).toBe(2);
+      expect(reader.rankOf("ghost", "index")).toBeNull();
+    });
+  });
+
+  it("trashedCount counts only trashed rows", () => {
+    withDb((db) => {
+      seedTodo(db, { trashed: true });
+      seedTodo(db, { trashed: true });
+      seedTodo(db, { trashed: false });
+      expect(createDbReader(db).trashedCount()).toBe(2);
+    });
+  });
+
+  it("modDateOf returns userModificationDate; null for a missing row", () => {
+    withDb((db) => {
+      const uuid = seedTodo(db, { modificationDate: 1_784_000_123 });
+      const reader = createDbReader(db);
+      expect(reader.modDateOf(uuid)).toBe(1_784_000_123);
+      expect(reader.modDateOf("ghost")).toBeNull();
+    });
+  });
+
+  it("findCreated honors the sinceEpoch window when no excludeUuids are given", () => {
+    withDb((db) => {
+      seedTodo(db, { title: "Dup", creationDate: 1000 });
+      const fresh = seedTodo(db, { title: "Dup", creationDate: 5000 });
+      const found = createDbReader(db).findCreated({
+        title: "Dup",
+        type: "to-do",
+        sinceEpoch: 4000,
+      });
+      expect(found.map((t) => t.uuid)).toEqual([fresh]);
+    });
+  });
+
+  it("findCreated ignores sinceEpoch but honors excludeUuids when they are present", () => {
+    withDb((db) => {
+      const old = seedTodo(db, { title: "Dup", creationDate: 1000 });
+      const fresh = seedTodo(db, { title: "Dup", creationDate: 5000 });
+      const found = createDbReader(db).findCreated({
+        title: "Dup",
+        type: "to-do",
+        sinceEpoch: 9999, // would exclude BOTH on time — proves it is ignored here
+        excludeUuids: [old],
+      });
+      expect(found.map((t) => t.uuid)).toEqual([fresh]);
+    });
+  });
+
+  it("findCreated maps probe.type to the right TMTask type int", () => {
+    withDb((db) => {
+      seedTodo(db, { title: "Same", creationDate: 5000 });
+      const proj = seedProject(db, { title: "Same", creationDate: 5000 });
+      const found = createDbReader(db).findCreated({
+        title: "Same",
+        type: "project",
+        sinceEpoch: 0,
+      });
+      expect(found.map((t) => t.uuid)).toEqual([proj]);
+    });
+  });
+
+  it("entityFields returns area title + sorted tags, tag parent/shortcut, or null", () => {
+    withDb((db) => {
+      const area = seedArea(db, "Home");
+      const tZeta = seedTag(db, "zeta");
+      const tAlpha = seedTag(db, "alpha");
+      tagArea(db, area, tZeta);
+      tagArea(db, area, tAlpha);
+      const parent = seedTag(db, "parent");
+      const tag = seedTag(db, "leaf", parent);
+      db.prepare("UPDATE TMTag SET shortcut = 'ctrl-l' WHERE uuid = ?").run(tag);
+      const reader = createDbReader(db);
+      expect(reader.entityFields("area", area)).toEqual({
+        title: "Home",
+        tags: ["alpha", "zeta"],
+      });
+      expect(reader.entityFields("tag", tag)).toEqual({
+        title: "leaf",
+        parent,
+        shortcut: "ctrl-l",
+      });
+      expect(reader.entityFields("area", "ghost")).toBeNull();
+      expect(reader.entityFields("tag", "ghost")).toBeNull();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------- getField
+
+describe("getField computed paths", () => {
+  it("resolves `tags` to sorted direct-tag titles", () => {
+    withDb((db) => {
+      const todo = seedTodo(db);
+      tagTask(db, todo, seedTag(db, "zeta"));
+      tagTask(db, todo, seedTag(db, "alpha"));
+      const entity = createDbReader(db).taskByUuid(todo);
+      expect(entity && getField(entity, "tags")).toEqual(["alpha", "zeta"]);
+    });
+  });
+
+  it("resolves `checklistTitles` and `checklistStates` in order", () => {
+    withDb((db) => {
+      const todo = seedTodo(db);
+      seedChecklistItem(db, todo, "first", { index: 0 });
+      seedChecklistItem(db, todo, "second", { index: 1, status: "completed" });
+      const entity = createDbReader(db).taskByUuid(todo);
+      expect(entity && getField(entity, "checklistTitles")).toEqual(["first", "second"]);
+      expect(entity && getField(entity, "checklistStates")).toEqual(["open", "completed"]);
+    });
+  });
+
+  it("resolves `stoppedDate` / `createdDate` to a local YYYY-MM-DD string", () => {
+    withDb((db) => {
+      const createdEpoch = 1_780_000_000;
+      const stoppedEpoch = 1_781_500_000;
+      const todo = seedTodo(db, {
+        status: "completed",
+        creationDate: createdEpoch,
+        stopDate: stoppedEpoch,
+      });
+      const entity = createDbReader(db).taskByUuid(todo);
+      expect(entity && getField(entity, "createdDate")).toBe(localIso(createdEpoch));
+      expect(entity && getField(entity, "stoppedDate")).toBe(localIso(stoppedEpoch));
+    });
+  });
+
+  it("`stoppedDate` is null when the row was never stopped", () => {
+    withDb((db) => {
+      const todo = seedTodo(db);
+      const entity = createDbReader(db).taskByUuid(todo);
+      expect(entity && getField(entity, "stoppedDate")).toBeNull();
+    });
+  });
+
+  it("walks a dotted path (`area.uuid`) and returns undefined off the end", () => {
+    withDb((db) => {
+      const area = seedArea(db, "Home");
+      const todo = seedTodo(db, { area });
+      const entity = createDbReader(db).taskByUuid(todo);
+      expect(entity && getField(entity, "area.uuid")).toBe(area);
+      expect(entity && getField(entity, "area.nope")).toBeUndefined();
+      expect(entity && getField(entity, "does.not.exist")).toBeUndefined();
+    });
+  });
+
+  it("`checklistTitles` on a non-to-do falls through to undefined", () => {
+    withDb((db) => {
+      const proj = seedProject(db);
+      const entity = createDbReader(db).taskByUuid(proj);
+      expect(entity && getField(entity, "checklistTitles")).toBeUndefined();
+    });
+  });
+});
+
+// ------------------------------------------------------------------- update mode
+
+describe("evaluateDelta — update", () => {
+  it("satisfied when the asserted field reads back the target value", () => {
+    withDb((db) => {
+      const uuid = seedTodo(db, { title: "B", modificationDate: 200 });
+      const spec: DeltaSpec = { mode: "update", uuid, assert: [{ field: "title", equals: "B" }] };
+      const result = evaluateDelta(
+        spec,
+        createDbReader(db),
+        pre({ modDates: { [uuid]: 100 }, fields: { [uuid]: { title: "A" } } }),
+      );
+      expect(result.satisfied).toBe(true);
+      expect(result.movement).toBe(true);
+      expect(result.assertedMovement).toBe(true);
+      expect(result.observed).toEqual({ title: "B" });
+    });
+  });
+
+  it("mismatch: an asserted field MOVED but not to the target value", () => {
+    withDb((db) => {
+      const uuid = seedTodo(db, { title: "C", modificationDate: 200 });
+      const spec: DeltaSpec = { mode: "update", uuid, assert: [{ field: "title", equals: "B" }] };
+      const result = evaluateDelta(
+        spec,
+        createDbReader(db),
+        pre({ modDates: { [uuid]: 100 }, fields: { [uuid]: { title: "A" } } }),
+      );
+      expect(result.satisfied).toBe(false);
+      expect(result.movement).toBe(true);
+      expect(result.assertedMovement).toBe(true); // distinguishes a contrary write
+    });
+  });
+
+  it("silent no-op: nothing moved, so assertedMovement stays false", () => {
+    withDb((db) => {
+      const uuid = seedTodo(db, { title: "A", modificationDate: 100 });
+      const spec: DeltaSpec = { mode: "update", uuid, assert: [{ field: "title", equals: "B" }] };
+      const result = evaluateDelta(
+        spec,
+        createDbReader(db),
+        pre({ modDates: { [uuid]: 100 }, fields: { [uuid]: { title: "A" } } }),
+      );
+      expect(result.satisfied).toBe(false);
+      expect(result.movement).toBe(false);
+      expect(result.assertedMovement).toBe(false); // the open exit-0 trap
+    });
+  });
+
+  it("unsatisfied when the target row does not exist", () => {
+    withDb((db) => {
+      const spec: DeltaSpec = {
+        mode: "update",
+        uuid: "ghost",
+        assert: [{ field: "title", equals: "B" }],
+      };
+      const result = evaluateDelta(spec, createDbReader(db), EMPTY_PRE);
+      expect(result.satisfied).toBe(false);
+    });
+  });
+});
+
+// ------------------------------------------------------------------- create mode
+
+describe("evaluateDelta — create", () => {
+  it("discovers the fresh row inside the sinceEpoch window", () => {
+    withDb((db) => {
+      seedTodo(db, { title: "Task", creationDate: 1000 });
+      const fresh = seedTodo(db, { title: "Task", creationDate: 5000 });
+      const spec: DeltaSpec = {
+        mode: "create",
+        probe: { title: "Task", type: "to-do", sinceEpoch: 4000 },
+        assert: [],
+      };
+      const result = evaluateDelta(spec, createDbReader(db), EMPTY_PRE);
+      expect(result.satisfied).toBe(true);
+      expect(result.discoveredUuid).toBe(fresh);
+    });
+  });
+
+  it("skips excludeUuids (commit 1) and binds to the genuinely new row", () => {
+    withDb((db) => {
+      const preExisting = seedTodo(db, { title: "Task", creationDate: 5000 });
+      const fresh = seedTodo(db, { title: "Task", creationDate: 5000 });
+      const spec: DeltaSpec = {
+        mode: "create",
+        probe: { title: "Task", type: "to-do", sinceEpoch: 4000, excludeUuids: [preExisting] },
+        assert: [],
+      };
+      const result = evaluateDelta(spec, createDbReader(db), EMPTY_PRE);
+      expect(result.satisfied).toBe(true);
+      expect(result.discoveredUuid).toBe(fresh);
+      expect(result.discoveredUuid).not.toBe(preExisting);
+    });
+  });
+
+  it("reports failure (no discovery) when only an excluded row matches", () => {
+    withDb((db) => {
+      const preExisting = seedTodo(db, { title: "Task", creationDate: 5000 });
+      const spec: DeltaSpec = {
+        mode: "create",
+        probe: { title: "Task", type: "to-do", sinceEpoch: 4000, excludeUuids: [preExisting] },
+        assert: [],
+      };
+      const result = evaluateDelta(spec, createDbReader(db), EMPTY_PRE);
+      expect(result.satisfied).toBe(false);
+      expect(result.movement).toBe(false);
+      expect(result.discoveredUuid).toBeUndefined();
+    });
+  });
+
+  it("not-found: no candidate at all", () => {
+    withDb((db) => {
+      const spec: DeltaSpec = {
+        mode: "create",
+        probe: { title: "Nope", type: "to-do", sinceEpoch: 0 },
+        assert: [],
+      };
+      const result = evaluateDelta(spec, createDbReader(db), EMPTY_PRE);
+      expect(result.satisfied).toBe(false);
+      expect(result.movement).toBe(false);
+      expect(result.observed).toBeNull();
+    });
+  });
+
+  it("candidate present but assertion fails: movement true, satisfied false", () => {
+    withDb((db) => {
+      seedTodo(db, { title: "Task", notes: "actual", creationDate: 5000 });
+      const spec: DeltaSpec = {
+        mode: "create",
+        probe: { title: "Task", type: "to-do", sinceEpoch: 4000 },
+        assert: [{ field: "notes", equals: "expected" }],
+      };
+      const result = evaluateDelta(spec, createDbReader(db), EMPTY_PRE);
+      expect(result.satisfied).toBe(false);
+      expect(result.movement).toBe(true);
+      expect(result.discoveredUuid).toBeUndefined();
+      expect(result.observed).toEqual({ notes: "actual" });
+    });
+  });
+});
+
+// -------------------------------------------------------------- state (+ cascade)
+
+describe("evaluateDelta — state", () => {
+  it("satisfied when the row and every cascade child hold their asserted status", () => {
+    withDb((db) => {
+      const project = seedProject(db, { status: "completed" });
+      const child = seedTodo(db, { status: "completed", project });
+      const spec: DeltaSpec = {
+        mode: "state",
+        uuid: project,
+        assert: [{ field: "status", equals: "completed" }],
+        cascade: [{ uuid: child, assert: [{ field: "status", equals: "completed" }] }],
+      };
+      const result = evaluateDelta(spec, createDbReader(db), EMPTY_PRE);
+      expect(result.satisfied).toBe(true);
+      expect(result.observed).toMatchObject({ status: "completed" });
+      expect(result.observed?.[`${child}.status`]).toBe("completed");
+    });
+  });
+
+  it("unsatisfied when a cascade child is in the wrong status", () => {
+    withDb((db) => {
+      const project = seedProject(db, { status: "completed" });
+      const child = seedTodo(db, { status: "open", project });
+      const spec: DeltaSpec = {
+        mode: "state",
+        uuid: project,
+        assert: [{ field: "status", equals: "completed" }],
+        cascade: [{ uuid: child, assert: [{ field: "status", equals: "completed" }] }],
+      };
+      expect(evaluateDelta(spec, createDbReader(db), EMPTY_PRE).satisfied).toBe(false);
+    });
+  });
+
+  it("unsatisfied when a cascade child row is missing", () => {
+    withDb((db) => {
+      const project = seedProject(db, { status: "completed" });
+      const spec: DeltaSpec = {
+        mode: "state",
+        uuid: project,
+        assert: [{ field: "status", equals: "completed" }],
+        cascade: [{ uuid: "ghost", assert: [{ field: "status", equals: "completed" }] }],
+      };
+      expect(evaluateDelta(spec, createDbReader(db), EMPTY_PRE).satisfied).toBe(false);
+    });
+  });
+});
+
+// --------------------------------------------------------------------- gone mode
+
+describe("evaluateDelta — gone", () => {
+  it("area: satisfied only once the row is absent", () => {
+    withDb((db) => {
+      const area = seedArea(db, "Doomed");
+      const present: DeltaSpec = { mode: "gone", entity: "area", uuid: area };
+      expect(evaluateDelta(present, createDbReader(db), EMPTY_PRE).satisfied).toBe(false);
+      const absent: DeltaSpec = { mode: "gone", entity: "area", uuid: "ghost" };
+      const result = evaluateDelta(absent, createDbReader(db), EMPTY_PRE);
+      expect(result.satisfied).toBe(true);
+      expect(result.observed).toEqual({ exists: false });
+    });
+  });
+
+  it("tag: satisfied only once the row is absent", () => {
+    withDb((db) => {
+      const tag = seedTag(db, "doomed");
+      const present: DeltaSpec = { mode: "gone", entity: "tag", uuid: tag };
+      expect(evaluateDelta(present, createDbReader(db), EMPTY_PRE).satisfied).toBe(false);
+      const absent: DeltaSpec = { mode: "gone", entity: "tag", uuid: "ghost" };
+      expect(evaluateDelta(absent, createDbReader(db), EMPTY_PRE).satisfied).toBe(true);
+    });
+  });
+});
+
+// ----------------------------------------------------------- entity-created mode
+
+describe("evaluateDelta — entity-created", () => {
+  it("area: discovers a fresh same-title row and matches its tag set", () => {
+    withDb((db) => {
+      const existing = seedArea(db, "Work");
+      const created = seedArea(db, "Work");
+      tagArea(db, created, seedTag(db, "focus"));
+      const spec: DeltaSpec = {
+        mode: "entity-created",
+        entity: "area",
+        title: "Work",
+        excludeUuids: [existing],
+        assertTags: ["focus"],
+      };
+      const result = evaluateDelta(spec, createDbReader(db), EMPTY_PRE);
+      expect(result.satisfied).toBe(true);
+      expect(result.discoveredUuid).toBe(created);
+    });
+  });
+
+  it("area: fresh row whose tag set differs is not a match", () => {
+    withDb((db) => {
+      const existing = seedArea(db, "Work");
+      seedArea(db, "Work"); // created but tagless
+      const spec: DeltaSpec = {
+        mode: "entity-created",
+        entity: "area",
+        title: "Work",
+        excludeUuids: [existing],
+        assertTags: ["focus"],
+      };
+      expect(evaluateDelta(spec, createDbReader(db), EMPTY_PRE).satisfied).toBe(false);
+    });
+  });
+
+  it("tag: matches only the fresh row under the expected parent", () => {
+    withDb((db) => {
+      const parent = seedTag(db, "area51");
+      const existing = seedTag(db, "urgent");
+      const created = seedTag(db, "urgent", parent);
+      const spec: DeltaSpec = {
+        mode: "entity-created",
+        entity: "tag",
+        title: "urgent",
+        excludeUuids: [existing],
+        parentUuid: parent,
+      };
+      const result = evaluateDelta(spec, createDbReader(db), EMPTY_PRE);
+      expect(result.satisfied).toBe(true);
+      expect(result.discoveredUuid).toBe(created);
+    });
+  });
+
+  it("tag: wrong parent is not a match", () => {
+    withDb((db) => {
+      const existing = seedTag(db, "urgent");
+      seedTag(db, "urgent"); // created at root, not under the expected parent
+      const spec: DeltaSpec = {
+        mode: "entity-created",
+        entity: "tag",
+        title: "urgent",
+        excludeUuids: [existing],
+        parentUuid: "some-parent",
+      };
+      expect(evaluateDelta(spec, createDbReader(db), EMPTY_PRE).satisfied).toBe(false);
+    });
+  });
+
+  it("unsatisfied when only excluded rows carry the title", () => {
+    withDb((db) => {
+      const existing = seedArea(db, "Work");
+      const spec: DeltaSpec = {
+        mode: "entity-created",
+        entity: "area",
+        title: "Work",
+        excludeUuids: [existing],
+      };
+      const result = evaluateDelta(spec, createDbReader(db), EMPTY_PRE);
+      expect(result.satisfied).toBe(false);
+      expect(result.movement).toBe(false);
+    });
+  });
+});
+
+// ----------------------------------------------------------- entity-updated mode
+
+describe("evaluateDelta — entity-updated", () => {
+  it("area: title + tag assertions pass and movement is derived from pre-fields", () => {
+    withDb((db) => {
+      const area = seedArea(db, "Home");
+      tagArea(db, area, seedTag(db, "cozy"));
+      const spec: DeltaSpec = {
+        mode: "entity-updated",
+        entity: "area",
+        uuid: area,
+        assert: [
+          { field: "title", equals: "Home" },
+          { field: "tags", equals: ["cozy"] },
+        ],
+      };
+      const result = evaluateDelta(
+        spec,
+        createDbReader(db),
+        pre({ fields: { [area]: { title: "Old", tags: [] } } }),
+      );
+      expect(result.satisfied).toBe(true);
+      expect(result.movement).toBe(true);
+      expect(result.assertedMovement).toBe(true);
+    });
+  });
+
+  it("tag: parent + shortcut assertions, no movement when pre matches", () => {
+    withDb((db) => {
+      const tag = seedTag(db, "leaf");
+      const spec: DeltaSpec = {
+        mode: "entity-updated",
+        entity: "tag",
+        uuid: tag,
+        assert: [
+          { field: "parent", equals: null },
+          { field: "shortcut", equals: null },
+        ],
+      };
+      const result = evaluateDelta(
+        spec,
+        createDbReader(db),
+        pre({ fields: { [tag]: { parent: null, shortcut: null } } }),
+      );
+      expect(result.satisfied).toBe(true);
+      expect(result.assertedMovement).toBe(false);
+    });
+  });
+
+  it("row gone: unsatisfied, but movement fires (the row vanished)", () => {
+    withDb((db) => {
+      const spec: DeltaSpec = {
+        mode: "entity-updated",
+        entity: "tag",
+        uuid: "ghost",
+        assert: [{ field: "title", equals: "x" }],
+      };
+      const result = evaluateDelta(spec, createDbReader(db), EMPTY_PRE);
+      expect(result.satisfied).toBe(false);
+      expect(result.movement).toBe(true);
+    });
+  });
+});
+
+// ----------------------------------------------------------------- ordering mode
+
+describe("evaluateDelta — ordering", () => {
+  it("satisfied when the sequence reads back in strictly ascending rank", () => {
+    withDb((db) => {
+      const a = seedTodo(db, { index: 1 });
+      const b = seedTodo(db, { index: 2 });
+      const c = seedTodo(db, { index: 3 });
+      const spec: DeltaSpec = { mode: "ordering", key: "index", sequence: [a, b, c] };
+      const result = evaluateDelta(
+        spec,
+        createDbReader(db),
+        pre({ fields: { __ordering__: { [a]: 9, [b]: 8, [c]: 7 } } }),
+      );
+      expect(result.satisfied).toBe(true);
+      expect(result.movement).toBe(true);
+    });
+  });
+
+  it("unsatisfied when a pair is out of order", () => {
+    withDb((db) => {
+      const a = seedTodo(db, { index: 3 });
+      const b = seedTodo(db, { index: 1 });
+      const spec: DeltaSpec = { mode: "ordering", key: "index", sequence: [a, b] };
+      expect(evaluateDelta(spec, createDbReader(db), EMPTY_PRE).satisfied).toBe(false);
+    });
+  });
+
+  it("unsatisfied when a member has no rank", () => {
+    withDb((db) => {
+      const a = seedTodo(db, { index: 1 });
+      const spec: DeltaSpec = { mode: "ordering", key: "index", sequence: [a, "ghost"] };
+      expect(evaluateDelta(spec, createDbReader(db), EMPTY_PRE).satisfied).toBe(false);
+    });
+  });
+});
+
+// -------------------------------------------------------------- trash-emptied mode
+
+describe("evaluateDelta — trash-emptied", () => {
+  it("satisfied when no trashed rows remain", () => {
+    withDb((db) => {
+      const spec: DeltaSpec = { mode: "trash-emptied" };
+      const result = evaluateDelta(spec, createDbReader(db), pre({ trashedCount: 2 }));
+      expect(result.satisfied).toBe(true);
+      expect(result.observed).toEqual({ trashedCount: 0 });
+    });
+  });
+
+  it("unsatisfied while trashed rows survive", () => {
+    withDb((db) => {
+      seedTodo(db, { trashed: true });
+      const spec: DeltaSpec = { mode: "trash-emptied" };
+      const result = evaluateDelta(spec, createDbReader(db), pre({ trashedCount: 3 }));
+      expect(result.satisfied).toBe(false);
+    });
+  });
+});
+
+const pad2 = (n: number): string => String(n).padStart(2, "0");
+
+/** Local-calendar YYYY-MM-DD of an epoch-seconds instant (mirrors delta.ts). */
+function localIso(epochSeconds: number): string {
+  const d = new Date(epochSeconds * 1000);
+  return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())}`;
+}


### PR DESCRIPTION
## Summary

Two commits hardening write-verification (`src/write/verify/delta.ts`).

### Commit 1 — `fix(write)`: exclude pre-existing rows from create-probe discovery

Create-mode verification discovers the row the app just made by probing `title = ? AND type = ?` over a trailing `creationDate` window. With no exclusion of pre-existing rows, a create whose app write **silently failed** could verify green against a **different** same-title row that merely landed in that window (a concurrent add, a repeat-template spawn, a sync insert) — recording the wrong uuid as `discoveredUuid`, so a later undo would trash the wrong item.

Replicating the existing `todo.add-logged` mechanism, the pre-read now captures the uuids of pre-existing rows matching the probe (title + type) into `pre.sameTitleUuids`, and the delta threads them as `probe.excludeUuids`. Discovery skips them, and a probe that finds **only** a pre-existing row now reports failure instead of ok.

**Create-mode ops that gained exclusions:** `todo.add`, `project.add`, `todo.duplicate`, `project.duplicate`, `heading.create`, `todo.make-repeating`, `project.make-repeating`, `todo.convert-to-project`, `heading.convert-to-project`.

**Already had it:** `todo.add-logged` (the model being replicated) — refactored to share the extracted `sameTitleTaskUuids` helper. `area.add` / `tag.add` use the separate `entity-created` mode, which already excludes pre-existing uuids.

Notes on the trickier specs: the duplicate / identity-replacement ops thereby exclude the dying original (and any spawned instance) that shares the new row's title; the `convert-to-project` ops capture same-title **projects** (the created row's type), not the source to-do/heading.

Tests: `test/unit/create-probe-exclusion.test.ts` drives the real command specs end-to-end (preRead → expectedDelta → evaluateDelta) — a pre-existing row seeded *inside* the probe window is skipped, only the new row is discovered, and a probe finding only the pre-existing row reports failure.

### Commit 2 — `test(write)`: isolated unit suite for evaluateDelta/createDbReader

`delta.ts` is the literal implementation of the "verified writes" claim yet had zero direct unit tests. `test/unit/verify-delta.test.ts` drives `evaluateDelta` and `createDbReader` directly against fixture DBs — one named test per discriminant branch (update / create / state+cascade / gone / entity-created / entity-updated / ordering / trash-emptied), plus every `createDbReader` method and `getField` computed path, and the mismatch vs silent-noop distinction.

## Verification

`npm run check` passes by exit code (typecheck + lint + fmt:check + full vitest run). New tests: 3 (commit 1) + 43 (commit 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)