### PR TITLE
fix(read): escape search wildcards, thread injected clock, star deadline-driven Today members

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -471,8 +471,8 @@ export function openThings(options: OpenOptions = {}): ThingsClient {
       anytime: (f) => anytimeView(conn.db, now(), f),
       upcoming: (f) => upcomingView(conn.db, now(), f),
       someday: (f) => somedayView(conn.db, now(), f),
-      logbook: (o) => logbookView(conn.db, o),
-      trash: (o) => trashView(conn.db, o),
+      logbook: (o) => logbookView(conn.db, now(), o),
+      trash: (o) => trashView(conn.db, now(), o),
       // Thread the injected clock so `--overdue`'s (and later's) today boundary
       // rides the same clock as every other view — never a hardcoded date.
       projects: (o) => projectsView(conn.db, { ...o, now: now() }),
@@ -482,8 +482,8 @@ export function openThings(options: OpenOptions = {}): ThingsClient {
       areas: () => areasView(conn.db),
       tags: () => tagsView(conn.db),
       search: (query, o) => searchView(conn.db, query, o, now()),
-      liteTitleSearch: (query, o) => liteTitleSearch(conn.db, query, o),
-      changes: (o) => changesView(conn.db, o),
+      liteTitleSearch: (query, o) => liteTitleSearch(conn.db, query, o, now()),
+      changes: (o) => changesView(conn.db, now(), o),
       showTarget: (ref) => classifyShowTarget(conn.db, ref),
       byUuid: (uuid) => {
         // Prefix-friendly: unknown refs keep the null contract; ambiguity throws.

--- a/src/read/views.ts
+++ b/src/read/views.ts
@@ -119,6 +119,20 @@ import { compareSearchMatches, type MatchField, type SearchMatch } from "./searc
 
 export type ListItem = Todo | Project;
 
+/**
+ * Escape a user term for a SQL LIKE pattern so `%` and `_` match LITERALLY,
+ * not as wildcards (search "my_task" must not match "myXtask"; "50%" must not
+ * match "50"-anything). Backslash is the escape character — escape it first,
+ * then the two wildcard metacharacters. Every LIKE fed an escaped term must
+ * append `ESCAPE '\'` (see {@link LIKE_ESCAPE}).
+ */
+function escapeLike(term: string): string {
+  return term.replace(/[\\%_]/g, (c) => `\\${c}`);
+}
+
+/** SQL clause suffix pairing an escaped LIKE pattern with its escape char. */
+const LIKE_ESCAPE = " ESCAPE '\\'";
+
 /** Optional list-view filters. */
 export interface ViewFilter {
   /**
@@ -920,8 +934,8 @@ export function liteTitleSearch(
       type === "to-do" ? "t.type = 0" : type === "project" ? "t.type = 1" : "t.type IN (0, 1)";
     const rows = fetchTaskRows(
       db,
-      `${OPEN} AND ${CONTAINER_UNTRASHED} AND ${typeSql} AND t.title LIKE ?`,
-      [`%${query}%`],
+      `${OPEN} AND ${CONTAINER_UNTRASHED} AND ${typeSql} AND t.title LIKE ?${LIKE_ESCAPE}`,
+      [`%${escapeLike(query)}%`],
     );
     tasks = materialize(db, rows);
   }
@@ -947,7 +961,7 @@ export function searchView(
   now?: Date,
 ): SearchResultItem[] {
   const cap = options?.limit === null ? null : (options?.limit ?? 50);
-  const needle = `%${query}%`;
+  const needle = `%${escapeLike(query)}%`;
   // `--overdue` narrows to OPEN, past-deadline matches. Its open-only predicate
   // is contradictory with the status-widening flags (logged/trashed/all); the
   // CLI/MCP surfaces reject that combination, so here it simply intersects.
@@ -991,7 +1005,7 @@ export function searchView(
   // Needle matches: title OR notes. No SQL LIMIT — ranking runs before the cap.
   const rows = fetchTaskRows(
     db,
-    `${scope.join(" AND ")} AND (t.title LIKE ? OR t.notes LIKE ?)${tf.sql}${of.sql}`,
+    `${scope.join(" AND ")} AND (t.title LIKE ?${LIKE_ESCAPE} OR t.notes LIKE ?${LIKE_ESCAPE})${tf.sql}${of.sql}`,
     [...scopeBinds, needle, needle, ...tf.binds, ...of.binds],
   );
   const needleLower = query.toLowerCase();
@@ -1010,7 +1024,7 @@ export function searchView(
     const headingRows = db
       .prepare(
         `SELECT project AS projectUuid, title FROM TMTask
-         WHERE type = 2 AND project IS NOT NULL AND trashed = 0 AND title LIKE ?`,
+         WHERE type = 2 AND project IS NOT NULL AND trashed = 0 AND title LIKE ?${LIKE_ESCAPE}`,
       )
       .all(needle) as unknown as Array<{ projectUuid: string; title: string | null }>;
     const headingTitleFor = new Map<string, string>();

--- a/src/read/views.ts
+++ b/src/read/views.ts
@@ -246,7 +246,11 @@ function overdueFilter(
   return { sql: ` AND ${OVERDUE}`, binds: [packedToday] };
 }
 
-function materialize(db: DatabaseSync, rows: TaskRow[], boundary = logBoundary(db)): ListItem[] {
+// `boundary` is REQUIRED (no wall-clock default): every caller threads the
+// view's injected `now` via logBoundary(db, now) so the `logged` flag it stamps
+// honors the same clock as the SQL membership filter (a pinned test clock, a
+// lab run) — nothing here silently reaches for real time.
+function materialize(db: DatabaseSync, rows: TaskRow[], boundary: Date): ListItem[] {
   const refs = makeRefResolver(db);
   const headingProject = makeHeadingProjectResolver(db);
   const tags = fetchTagsForTasks(
@@ -385,7 +389,7 @@ export function inboxView(db: DatabaseSync, now?: Date, filter?: InboxFilter): L
     `${where.join(" AND ")}${tf.sql}${of.sql} ORDER BY t."index" ASC`,
     [...binds, ...tf.binds, ...of.binds],
   );
-  return materialize(db, rows);
+  return materialize(db, rows, logBoundary(db, now));
 }
 
 /**
@@ -467,6 +471,7 @@ const groupKey = (i: ListItem): string => i.startDate ?? i.deadline ?? "";
 
 export function upcomingView(db: DatabaseSync, now?: Date, filter?: UpcomingFilter): ListItem[] {
   const packedToday = encodePackedDate(localToday(now));
+  const boundary = logBoundary(db, now);
   const until = filter?.until;
   const since = filter?.since;
   const untilBinds = until === undefined ? [] : [encodePackedDate(until)];
@@ -505,8 +510,8 @@ export function upcomingView(db: DatabaseSync, now?: Date, filter?: UpcomingFilt
     [packedToday, ...untilBinds, ...sinceBinds, ...tf.binds],
   );
 
-  const scheduled = materialize(db, rows);
-  const forecast = materialize(db, forecastRows);
+  const scheduled = materialize(db, rows, boundary);
+  const forecast = materialize(db, forecastRows, boundary);
 
   // The merged date-ordered stream keys on COALESCE(startDate, deadline) — a
   // scheduled row groups under its when-date, a forecast row under its deadline
@@ -546,7 +551,7 @@ export function upcomingView(db: DatabaseSync, now?: Date, filter?: UpcomingFilt
   );
   const horizon = Math.max(1, Math.min(10, Math.trunc(filter?.horizon ?? 1)));
   const rawByUuid = new Map(templateRows.map((r) => [r.uuid, r.rt1_recurrenceRule]));
-  const occurrences = materialize(db, templateRows).flatMap((template) => {
+  const occurrences = materialize(db, templateRows, boundary).flatMap((template) => {
     const startDate = template.repeating.nextOccurrence ?? null;
     if (startDate === null) return [];
     // Whether occurrences deadline is the TEMPLATE's property, not the rule's:
@@ -614,7 +619,7 @@ export function upcomingView(db: DatabaseSync, now?: Date, filter?: UpcomingFilt
      ORDER BY t.todayIndex ASC, t."index" ASC`,
     [packedToday, ...tf.binds],
   );
-  const resting = materialize(db, restingRows).map((item) => {
+  const resting = materialize(db, restingRows, boundary).map((item) => {
     const raw = restingRows.find((r) => r.uuid === item.uuid)?.rt1_recurrenceRule;
     if (raw !== null && raw !== undefined) {
       try {
@@ -664,7 +669,7 @@ export function somedayView(
      AND (${EFF_PROJECT} IS NULL OR ${childArm})${tf.sql}${of.sql} ORDER BY t."index" ASC`,
     [...(withActiveChildren ? [packedToday, packedToday] : []), ...tf.binds, ...of.binds],
   );
-  const sections = groupBySidebar(db, materialize(db, rows));
+  const sections = groupBySidebar(db, materialize(db, rows, logBoundary(db, now)));
   // GUI order within a Someday group (live side-by-side, 2026-07-12):
   // PROJECT rows first (their sidebar order preserved), then direct to-dos in
   // drag order. Someday children of active projects (the activeProjectItems
@@ -697,7 +702,7 @@ export interface LogbookFilter extends ViewFilter {
   until?: Date;
 }
 
-export function logbookView(db: DatabaseSync, options?: LogbookFilter): ListItem[] {
+export function logbookView(db: DatabaseSync, now?: Date, options?: LogbookFilter): ListItem[] {
   const cap = options?.limit === null ? null : (options?.limit ?? 100);
   const tf = tagFilter(db, options);
   const where: string[] = [];
@@ -723,16 +728,23 @@ export function logbookView(db: DatabaseSync, options?: LogbookFilter): ListItem
   }
   const extra = where.length > 0 ? ` AND ${where.join(" AND ")}` : "";
   // Completion ≠ logged: closed items past the log-move boundary still sit
-  // checked in their original lists, exactly like the GUI's Logbook.
+  // checked in their original lists, exactly like the GUI's Logbook. The
+  // membership boundary rides the injected clock (threaded into both the SQL
+  // filter and materialize so presence and the `logged` flag agree).
+  const boundary = logBoundary(db, now);
   const rows = fetchTaskRows(
     db,
     `${LIVE} AND t.status IN (2, 3) AND t.stopDate <= ?${extra}${tf.sql} ORDER BY t.stopDate DESC${cap === null ? "" : " LIMIT ?"}`,
-    [logBoundary(db).getTime() / 1000, ...binds, ...tf.binds, ...(cap === null ? [] : [cap])],
+    [boundary.getTime() / 1000, ...binds, ...tf.binds, ...(cap === null ? [] : [cap])],
   );
-  return materialize(db, rows);
+  return materialize(db, rows, boundary);
 }
 
-export function trashView(db: DatabaseSync, options?: { limit?: number | null }): ListItem[] {
+export function trashView(
+  db: DatabaseSync,
+  now?: Date,
+  options?: { limit?: number | null },
+): ListItem[] {
   const cap = options?.limit === null ? null : (options?.limit ?? 200);
   const rows = fetchTaskRows(
     db,
@@ -740,7 +752,7 @@ export function trashView(db: DatabaseSync, options?: { limit?: number | null })
      ORDER BY t.userModificationDate DESC${cap === null ? "" : " LIMIT ?"}`,
     cap === null ? [] : [cap],
   );
-  return materialize(db, rows);
+  return materialize(db, rows, logBoundary(db, now));
 }
 
 export function projectsView(
@@ -792,7 +804,7 @@ export function projectsView(
     ...tf.binds,
     ...activeFirstBinds,
   ]);
-  const items = materialize(db, rows) as Project[];
+  const items = materialize(db, rows, logBoundary(db, options?.now)) as Project[];
   if (options?.later !== true) return items;
   // Each group's later sub-block reads like Upcoming: SCHEDULED projects
   // first — date ascending, todayIndex within a day (the UI's drag order,
@@ -867,6 +879,7 @@ export type ChangedItem = ListItem & { changeKind: ChangeKind };
  */
 export function changesView(
   db: DatabaseSync,
+  now: Date | undefined,
   options: { since: Date; limit?: number | null },
 ): ChangedItem[] {
   const cap = options.limit === null ? null : (options.limit ?? 200);
@@ -878,7 +891,7 @@ export function changesView(
     [sinceEpoch, ...(cap === null ? [] : [cap])],
   );
   // oxlint-disable-next-line no-map-spread -- building fresh change objects, not mutating
-  return materialize(db, rows).map((item, i) => ({
+  return materialize(db, rows, logBoundary(db, now)).map((item, i) => ({
     ...item,
     changeKind:
       (rows[i]?.creationDate ?? 0) > sinceEpoch ? ("created" as const) : ("modified" as const),
@@ -916,6 +929,7 @@ export function liteTitleSearch(
   db: DatabaseSync,
   query: string,
   options?: { type?: "to-do" | "project" | "area"; limit?: number },
+  now?: Date,
 ): LiteSearchResult {
   const cap = options?.limit ?? 10;
   const type = options?.type;
@@ -937,7 +951,7 @@ export function liteTitleSearch(
       `${OPEN} AND ${CONTAINER_UNTRASHED} AND ${typeSql} AND t.title LIKE ?${LIKE_ESCAPE}`,
       [`%${escapeLike(query)}%`],
     );
-    tasks = materialize(db, rows);
+    tasks = materialize(db, rows, logBoundary(db, now));
   }
 
   const projects = tasks.filter((t) => t.type === "project").toSorted(byStatusThenRecent);
@@ -966,6 +980,9 @@ export function searchView(
   // is contradictory with the status-widening flags (logged/trashed/all); the
   // CLI/MCP surfaces reject that combination, so here it simply intersects.
   const of = overdueFilter(options, encodePackedDate(localToday(now)));
+  // Threaded into every materialize so the `logged` flag (--logged widens to
+  // closed rows) honors the injected clock, not wall time.
+  const boundary = logBoundary(db, now);
 
   // The scope predicates (everything except the match needle), reused verbatim
   // for the needle query AND the heading-credited-project query so both honor
@@ -1010,7 +1027,7 @@ export function searchView(
   );
   const needleLower = query.toLowerCase();
   const matches = new Map<string, SearchMatch>();
-  for (const item of materialize(db, rows)) {
+  for (const item of materialize(db, rows, boundary)) {
     // Field credit: title beats notes when both carry the substring.
     const field: MatchField = item.title.toLowerCase().includes(needleLower) ? "title" : "notes";
     matches.set(item.uuid, { item, field });
@@ -1042,7 +1059,7 @@ export function searchView(
         `${scope.join(" AND ")} AND t.type = 1 AND t.uuid IN (${placeholders})${tf.sql}${of.sql}`,
         [...scopeBinds, ...wanted, ...tf.binds, ...of.binds],
       );
-      for (const item of materialize(db, projectRows)) {
+      for (const item of materialize(db, projectRows, boundary)) {
         const matchedVia = {
           kind: "heading" as const,
           title: headingTitleFor.get(item.uuid) ?? "",

--- a/src/read/views.ts
+++ b/src/read/views.ts
@@ -433,9 +433,23 @@ export function anytimeView(db: DatabaseSync, now?: Date, filter?: ViewFilter): 
   return groupBySidebar(db, materialize(db, rows, boundary));
 }
 
-/** The UI's star marker in Anytime: the item is also a Today member. */
+/**
+ * The UI's star marker in Anytime: the item is also a Today member. Mirrors
+ * {@link todayView}'s two membership arms so an unscheduled item pulled into
+ * Today by a due deadline stars exactly like a scheduled one:
+ *   - SCHEDULED — a When-date that has arrived (startDate <= today); or
+ *   - DEADLINE-DRIVEN — no When-date, but a due/overdue deadline (deadline <=
+ *     today) pulls it into Today (the todayView arm that lets a bare deadline
+ *     surface an item). Only reached for anytime-visible rows (start=1,
+ *     startDate NULL), so it never over-stars someday/inbox rows.
+ * KNOWN LIMITATION: todayView's deadline arm also drops a DISMISSED-nag
+ * deadline (deadlineSuppressionDate >= deadline); that column is not surfaced
+ * on the entity, so a suppressed unscheduled overdue row is over-starred here.
+ */
 export function isTodayMember(item: ListItem, now?: Date): boolean {
-  return item.startDate !== null && item.startDate <= localToday(now);
+  const today = localToday(now);
+  if (item.startDate !== null) return item.startDate <= today;
+  return item.deadline !== null && item.deadline <= today;
 }
 
 export interface UpcomingFilter extends ViewFilter {

--- a/test/cli/render.test.ts
+++ b/test/cli/render.test.ts
@@ -468,21 +468,21 @@ describe("logbook", () => {
   it("--area includes direct, project-child, and HEADING-child entries", () => {
     fixture = buildFixtureDb();
     const { area } = seedLoggedWorld(fixture);
-    const titles = logbookView(fixture.db, { area }).map((i) => i.title);
+    const titles = logbookView(fixture.db, undefined, { area }).map((i) => i.title);
     expect(titles).toEqual(["Direct area win", "Project child win", "Heading child win"]);
   });
 
   it("--project includes heading-nested children", () => {
     fixture = buildFixtureDb();
     const { project } = seedLoggedWorld(fixture);
-    const titles = logbookView(fixture.db, { project }).map((i) => i.title);
+    const titles = logbookView(fixture.db, undefined, { project }).map((i) => i.title);
     expect(titles).toEqual(["Project child win", "Heading child win"]);
   });
 
   it("--since/--until bound by logged instant", () => {
     fixture = buildFixtureDb();
     const { area } = seedLoggedWorld(fixture);
-    const titles = logbookView(fixture.db, {
+    const titles = logbookView(fixture.db, undefined, {
       area,
       since: new Date("2026-01-01T00:00:00Z"),
       until: parsePeriodEnd("2026-06"),
@@ -493,7 +493,7 @@ describe("logbook", () => {
   it("renders month headings (year appended beyond the current year) and no heading rows", () => {
     fixture = buildFixtureDb();
     const { area } = seedLoggedWorld(fixture);
-    const lines = renderLogbook(logbookView(fixture.db, { area }), NOW);
+    const lines = renderLogbook(logbookView(fixture.db, undefined, { area }), NOW);
     expect(lines[0]).toBe("── July ──");
     expect(lines).toContain("── June ──");
     expect(lines).toContain("── March 2025 ──");

--- a/test/cli/render.test.ts
+++ b/test/cli/render.test.ts
@@ -886,6 +886,24 @@ describe("todayMark", () => {
     expect(todayMark(night, NOW)).toBe("⏾");
     expect(todayMark(future, NOW)).toBeNull();
   });
+
+  it("stars an unscheduled to-do pulled into Today by a due deadline (anytime ★)", () => {
+    fixture = buildFixtureDb();
+    // Unscheduled (start=1, no When-date) but DUE today: todayView's deadline
+    // arm pulls it into Today, so Anytime stars it exactly like a scheduled one.
+    seedTodo(fixture.db, { title: "due today", start: "active", deadline: "2026-07-05" });
+    // Control — unscheduled with a FUTURE deadline: forecast into Upcoming, not
+    // Today, so no star (proves the deadline must be DUE, not merely present).
+    seedTodo(fixture.db, { title: "due later", start: "active", deadline: "2026-07-20" });
+    const items = anytimeView(fixture.db, NOW).flatMap((s) => s.items);
+    const mark = (t: string) => {
+      const item = items.find((i) => i.title === t);
+      if (!item) throw new Error(`missing anytime item: ${t}`);
+      return todayMark(item, NOW);
+    };
+    expect(mark("due today")).toBe("★");
+    expect(mark("due later")).toBeNull();
+  });
 });
 
 describe("renderToday (things today split)", () => {

--- a/test/unit/views.test.ts
+++ b/test/unit/views.test.ts
@@ -1172,6 +1172,43 @@ describe("searchView (Phase 12 ergonomics)", () => {
     expect(() => searchView(fx.db, "widget", { area: "nope" })).toThrow(/no area matching/);
     expect(() => searchView(fx.db, "widget", { tag: "nope" })).toThrow(/no tag matching/);
   });
+
+  it("treats LIKE wildcards in the query as literal characters", () => {
+    fx = buildFixtureDb();
+    seedTodo(fx.db, { title: "my task" });
+    seedTodo(fx.db, { title: "my_task" });
+    seedTodo(fx.db, { title: "myXtask" });
+    seedTodo(fx.db, { title: "50% off" });
+    seedTodo(fx.db, { title: "500 off" });
+    // `_` is a single-char wildcard unless escaped: "my_task" must match ONLY
+    // the literal underscore title, never "my task"/"myXtask".
+    expect(searchView(fx.db, "my_task").map((i) => i.title)).toEqual(["my_task"]);
+    // `%` is a multi-char wildcard unless escaped: "50%" must match "50% off"
+    // and NOT "500 off".
+    expect(searchView(fx.db, "50%").map((i) => i.title)).toEqual(["50% off"]);
+    // Control: an ordinary substring still matches every title containing it.
+    expect(
+      searchView(fx.db, "task")
+        .map((i) => i.title)
+        .toSorted(),
+    ).toEqual(["my task", "myXtask", "my_task"]);
+  });
+
+  it("liteTitleSearch treats LIKE wildcards as literal characters", () => {
+    fx = buildFixtureDb();
+    seedTodo(fx.db, { title: "my task" });
+    seedTodo(fx.db, { title: "my_task" });
+    seedTodo(fx.db, { title: "myXtask" });
+    const literal = liteTitleSearch(fx.db, "my_task").candidates.map((c) =>
+      c.kind === "task" ? c.task.title : c.area.title,
+    );
+    expect(literal).toEqual(["my_task"]);
+    // Control: a plain substring still matches every title containing it.
+    const substr = liteTitleSearch(fx.db, "task")
+      .candidates.map((c) => (c.kind === "task" ? c.task.title : c.area.title))
+      .toSorted();
+    expect(substr).toEqual(["my task", "myXtask", "my_task"]);
+  });
 });
 
 describe("searchView heading doctrine + ranking (item 5)", () => {

--- a/test/unit/views.test.ts
+++ b/test/unit/views.test.ts
@@ -321,6 +321,39 @@ describe("list views", () => {
   });
 });
 
+describe("injected clock threads through logged/logbook membership", () => {
+  // logInterval 1 (daily) makes the sweep boundary local MIDNIGHT of the
+  // injected `now`, so a fixed stopDate can be straddled by two pinned clocks —
+  // no dependence on real wall time.
+  const STOP = new Date(2026, 6, 10, 12, 0).getTime() / 1000; // 2026-07-10 noon
+  const BEFORE = new Date(2026, 6, 2, 12, 0); // pinned 07-02: boundary 07-02 00:00 < STOP
+  const AFTER = new Date(2026, 6, 12, 12, 0); // pinned 07-12: boundary 07-12 00:00 > STOP
+
+  it("logbook membership honors the pinned clock (stopDate straddling the boundary)", () => {
+    fx = buildFixtureDb();
+    seedSettings(fx.db, { logInterval: 1 });
+    seedTodo(fx.db, { title: "mid-window win", status: "completed", stopDate: STOP });
+    // Pinned BEFORE the sweep reaches it: unswept, so absent from the Logbook.
+    expect(logbookView(fx.db, BEFORE).map((i) => i.title)).toEqual([]);
+    // Pinned AFTER the boundary advances past its stopDate: it appears.
+    expect(logbookView(fx.db, AFTER).map((i) => i.title)).toEqual(["mid-window win"]);
+  });
+
+  it("search's logged flag honors the pinned clock (same materialize boundary)", () => {
+    fx = buildFixtureDb();
+    seedSettings(fx.db, { logInterval: 1 });
+    seedTodo(fx.db, { title: "widget win", status: "completed", stopDate: STOP });
+    // The closed row appears in a --logged search under either clock; only the
+    // `logged` flag (completion vs. swept-into-Logbook) tracks the boundary.
+    expect(
+      searchView(fx.db, "widget", { logged: true }, BEFORE).map((i) => [i.title, i.logged]),
+    ).toEqual([["widget win", false]]);
+    expect(
+      searchView(fx.db, "widget", { logged: true }, AFTER).map((i) => [i.title, i.logged]),
+    ).toEqual([["widget win", true]]);
+  });
+});
+
 describe("upcomingView deadline-forecast cohort (UPC1)", () => {
   it("forecasts future-deadline anytime/someday to-dos and someday projects under the DEADLINE date, excludes Inbox", () => {
     fx = buildFixtureDb();
@@ -781,7 +814,9 @@ describe("tag-filtered list views (Phase 10)", () => {
       "unrelated",
     );
     expect(somedayView(fx.db, NOW, { tag: "focus" })).toEqual([]);
-    expect(logbookView(fx.db, { tag: "focus" }).map((i) => i.title)).not.toContain("done-tagged");
+    expect(logbookView(fx.db, undefined, { tag: "focus" }).map((i) => i.title)).not.toContain(
+      "done-tagged",
+    );
   });
 });
 
@@ -1668,7 +1703,7 @@ describe("changesView (Phase 13)", () => {
       modificationDate: SINCE + 40,
     });
 
-    const changes = changesView(fx.db, { since: new Date(SINCE * 1000) });
+    const changes = changesView(fx.db, undefined, { since: new Date(SINCE * 1000) });
     expect(changes.map((c) => [c.title, c.changeKind])).toEqual([
       ["template-edited", "modified"],
       ["trashed-after", "modified"],
@@ -1677,7 +1712,9 @@ describe("changesView (Phase 13)", () => {
     ]);
     expect(changes.find((c) => c.title === "trashed-after")?.trashed).toBe(true);
     expect(changes.find((c) => c.title === "template-edited")?.repeating.isTemplate).toBe(true);
-    expect(changesView(fx.db, { since: new Date(SINCE * 1000), limit: 2 })).toHaveLength(2);
+    expect(changesView(fx.db, undefined, { since: new Date(SINCE * 1000), limit: 2 })).toHaveLength(
+      2,
+    );
   });
 });
 


### PR DESCRIPTION
Three independent read-layer fixes, one commit each (independently revertable).

## 1. `fix(read)`: escape LIKE wildcards in search
User `%` and `_` in a search term acted as SQL LIKE wildcards — `search "my_task"` matched "myXtask", `"50%"` matched "50"-anything. Escapes `\`, `%`, `_` in the user term and appends `ESCAPE '\'` to every LIKE (`searchView` title/notes + heading-title probe, `liteTitleSearch` title). Tests prove literal `_`/`%` matching plus a plain-substring control.

## 2. `fix(read)`: thread the injected clock through every view
Only `todayView`/`anytimeView` threaded their injected `now` into both the SQL boundary and `materialize`; the rest fell back to wall-clock time (and `logbookView` had no `now` at all, computing its log-move membership boundary from real time). Under a pinned clock the `logged` flag and logbook membership silently drifted to real now.

- `materialize` now REQUIRES an explicit boundary (no wall-clock default) — compile-time proof every call site threads its clock.
- `inbox`/`someday`/`upcoming`/`search`/`projects`/`changes`/`trash`/`liteTitleSearch` thread `logBoundary(db, now)`.
- `logbookView` gains a `now` parameter (threaded into both membership boundary and materialize); `trashView`/`changesView` gain `now` too.
- Client read methods pass `now()` consistently (the `todayView` pattern).
- No behavior change under real wall time. Tests pin a fake clock and assert both the search `logged` flag and logbook membership honor a stopDate that straddles the pinned vs. real boundary.

## 3. `fix(cli)`: Anytime ★ for deadline-driven Today members (claim CONFIRMED)
`isTodayMember` (the Anytime ★ predicate) only tested the scheduled arm, so an unscheduled to-do (`start=1`, no When-date) pulled into Today by a due/overdue deadline appeared in Anytime with no star, though `todayView` counts it a Today member and the GUI stars it. Mirrors `todayView`'s second membership arm (no startDate + due deadline). Render test asserts an unscheduled to-do with a deadline today gets ★, and a future-deadline control does not.

Known limitation (documented at the predicate): `todayView`'s arm also drops a dismissed-nag deadline (`deadlineSuppressionDate >= deadline`); that column is not surfaced on the read-model entity, so a suppressed unscheduled overdue row is over-starred. Closing it fully would require exposing suppression on the entity — out of scope for this render fix.

## Verification
`npm run check` — exit 0 (1208 tests pass). `npm run fmt` run before each commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)