### PR TITLE
fix(audit): durable, un-losable audit trail — intent records + tear-resistant appends (M3+M5)

### DIFF
--- a/src/audit/log.ts
+++ b/src/audit/log.ts
@@ -2,14 +2,66 @@
  * JSONL audit writer: monthly files, never auto-deleted, structural token
  * redaction — the serializer refuses to emit any string containing the
  * loaded auth token.
+ *
+ * DURABILITY + TEAR-RESISTANCE (M5). Audit appends happen from processes that
+ * do NOT hold the mutation lock (e.g. a drift-gate or lock-contention block is
+ * recorded before/without ever acquiring it), so two things-api invocations can
+ * append to the same monthly file concurrently. The append path is therefore:
+ *
+ *   open(path, O_APPEND) → ONE writeSync(fd, completeLineBuffer) → fsyncSync → close
+ *
+ * Two properties make this safe for our use in practice, on regular files:
+ *  - ATOMIC APPEND. With O_APPEND the kernel positions the write at end-of-file
+ *    and performs the append under the inode lock, so a SINGLE write() call
+ *    cannot interleave with a concurrent write() from another fd — no torn or
+ *    spliced line. We hand writeSync the COMPLETE `${line}\n` buffer so exactly
+ *    one write() syscall carries the whole record. (The old appendFileSync path
+ *    gave neither a single-write guarantee nor a flush.)
+ *  - DURABILITY. fsyncSync flushes the record to disk before we return, so a
+ *    crash immediately after the append cannot lose an already-acknowledged
+ *    record — the pairing invariant the M3 intent record relies on holds.
+ *
+ * No lockfile is used, deliberately: for regular local files a single
+ * O_APPEND write() is already interleave-safe, our records are small and writes
+ * infrequent, and a lockfile would add a failure mode (stale locks, contention)
+ * into a path that must NEVER throw into the mutation result. A short write from
+ * write() only occurs on signals/full disks/pipes — not local regular-file
+ * appends of records this size — so the "one writeSync = one record" assumption
+ * holds; the >1MB round-trip test exercises the large-buffer case.
+ *
+ * NEVER THROWS INTO THE MUTATION PATH. If the durable path fails for any reason
+ * (fsync unsupported on an exotic FS, transient open error, …) we fall back to a
+ * best-effort plain append, and if THAT throws we swallow it: a mutation's
+ * result must never break because auditing hit an I/O error.
  */
-import { appendFileSync, mkdirSync } from "node:fs";
+import { appendFileSync, closeSync, fsyncSync, mkdirSync, openSync, writeSync } from "node:fs";
 import { join } from "node:path";
 
 import type { AuditRecord } from "./schema.ts";
 
 export interface AuditWriter {
   append(record: AuditRecord): void;
+}
+
+/** Durable single-write append (O_APPEND + fsync), best-effort fallback on failure. */
+function durableAppend(path: string, buf: Buffer): void {
+  try {
+    const fd = openSync(path, "a"); // "a" → O_APPEND
+    try {
+      writeSync(fd, buf); // one write() with the complete line — atomic append
+      fsyncSync(fd); // flush to disk before returning
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    // Best-effort fallback: try a plain append, then give up silently. An audit
+    // write must never throw into the mutation path that called it.
+    try {
+      appendFileSync(path, buf);
+    } catch {
+      /* swallow — a mutation result must never break because auditing failed */
+    }
+  }
 }
 
 export function createAuditWriter(options: {
@@ -34,7 +86,7 @@ export function createAuditWriter(options: {
         }
         return value;
       });
-      appendFileSync(join(options.dir, `${month}.jsonl`), `${line}\n`);
+      durableAppend(join(options.dir, `${month}.jsonl`), Buffer.from(`${line}\n`, "utf8"));
     },
   };
 }

--- a/src/audit/schema.ts
+++ b/src/audit/schema.ts
@@ -4,6 +4,15 @@
  *
  * Every mutation ATTEMPT is recorded: successes, verification failures, and
  * blocked decisions (with invocation null — the app was never touched).
+ *
+ * A successful mutation writes TWO records: an `intent` marker immediately
+ * before the app is touched (M3 durability — so a crash between the app-side
+ * mutation and the final record leaves evidence the change may have landed),
+ * then the final `ok`/`verify-failed:*` record after read-after-write. The two
+ * share ts+op+actor+host (both derive from the same startedAt); an intent with
+ * no later final sibling is the signature of a crashed write. Intent records
+ * are NEVER undo targets — every undo reader filters `result === "ok"`, which
+ * an intent (result `"intent"`) is not, so it is excluded uniformly.
  */
 import { createHash } from "node:crypto";
 
@@ -39,6 +48,7 @@ export interface AuditRecord {
   /** Post-verify observation (best-effort on failure). */
   observed: Record<string, unknown> | null;
   result:
+    | "intent"
     | "ok"
     | "verify-failed:timeout"
     | "verify-failed:mismatch"

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -120,6 +120,14 @@ export function registerDoctor(program: Command): void {
             `repeats:     ${report.recurrence.templates} template(s), ${
               report.recurrence.undecodable
             } undecodable${report.recurrence.undecodable > 0 ? ` — ${report.recurrence.detail}` : ""}`,
+            ...(report.audit.orphanedIntents > 0
+              ? [
+                  `changes:     ${report.audit.orphanedIntents} change(s) were started but their ` +
+                    `result was not recorded (newest ${report.audit.newestOrphanIntent}) — a ` +
+                    `change may have been applied in Things without being saved to the local ` +
+                    `history; review your recent changes in Things`,
+                ]
+              : []),
             ...syncHealthLines(report.syncHealth),
             ...uiVectorLines(report.ui),
           ];

--- a/src/diagnose.ts
+++ b/src/diagnose.ts
@@ -6,6 +6,8 @@
 import { existsSync } from "node:fs";
 
 import { loadConfig } from "./config.ts";
+import { auditDir } from "./paths.ts";
+import { readAuditRecords, scanAuditIntegrity } from "./write/undo.ts";
 import { decodeRecurrenceRule } from "./model/recurrence.ts";
 import { BASELINES } from "./db/baselines/index.ts";
 import { openConnection, ThingsDbOpenError } from "./db/connection.ts";
@@ -163,6 +165,17 @@ export interface DiagnoseReport {
     detail: string;
   };
   /**
+   * Local-history integrity: writes that were STARTED but whose result was
+   * never recorded (M3). Each mutation records its intent before touching the
+   * app and its outcome after; an intent with no recorded outcome means the
+   * process died mid-write, so a change may have been applied without being
+   * saved to the local history. A non-zero count is advisory, not a failure.
+   */
+  audit: {
+    orphanedIntents: number;
+    newestOrphanIntent: string | null;
+  };
+  /**
    * Freshness + sync-liveness proxies for long-running headless operation
    * (docs/lab/headless-research.md SYNC1 + SYNC2): app-running, WAL write
    * activity, last local edit, last foreground, and — only when a Things Cloud
@@ -193,6 +206,8 @@ export interface DiagnoseOptions {
   availability?: AvailabilityDeps;
   /** Test seams for the sync-health section (clock, process check, WAL/plist readers). */
   syncHealth?: SyncHealthDeps;
+  /** Directory holding the audit JSONL files; defaults to the state dir. Test seam. */
+  auditDir?: string;
 }
 
 export interface DiagnoseResult {
@@ -344,6 +359,7 @@ export function diagnose(dbPath?: string, options: DiagnoseOptions = {}): Diagno
       },
       recurrence: scanRecurrenceRules(conn.db),
       syncHealth: computeSyncHealth(conn.db, located.path, options.syncHealth),
+      audit: scanAuditIntegrity(readAuditRecords(options.auditDir ?? auditDir())),
     };
     return {
       report,

--- a/src/write/pipeline.ts
+++ b/src/write/pipeline.ts
@@ -1,7 +1,10 @@
 /**
  * The mutation pipeline: fingerprint gate → lock → pre-read → guards →
  * vector planning → ensure-running → execute → verified read-after-write →
- * audit. Every mutation attempt is audited, including blocked decisions.
+ * audit. Every mutation attempt is audited, including blocked decisions. A
+ * write that reaches the app records TWICE: an `intent` marker right before
+ * execute (so a crash mid-write leaves evidence — M3) and the final outcome
+ * after verify.
  */
 import { execFile, execFileSync } from "node:child_process";
 import type { DatabaseSync } from "node:sqlite";
@@ -502,6 +505,30 @@ export async function runMutation<K extends OperationKind>(
         : [];
 
     const preCapture = capturePre(delta, deps, pre);
+
+    // M3 durability: record the INTENT to mutate BEFORE the app is touched.
+    // The guards have passed and the invocation is compiled, so this carries
+    // op/uuid/actor/redacted invocation/startedAt (+ the captured pre-state).
+    // If the process dies between vector.execute and the final record below,
+    // this intent has no matching final sibling (same ts+op+actor+host) — the
+    // ONLY evidence the mutation may have landed. `things doctor` surfaces such
+    // orphans; the final record written after verify supersedes this one.
+    // (dry-run returned above, so nothing is recorded for a dry-run — preserved.)
+    const intentUuid =
+      delta.mode === "update" || delta.mode === "state"
+        ? delta.uuid
+        : delta.mode === "ordering"
+          ? (delta.subject ?? null)
+          : null;
+    audit({
+      result: "intent",
+      vector: vector.id,
+      disruption: effectiveTier,
+      invocation: invocation.redactedPayload,
+      pre: flattenPreFields(preCapture.fields),
+      uuid: intentUuid,
+    });
+
     const executeResult = await vector.execute(invocation);
     if (executeResult.exitCode !== 0 || executeResult.timedOut === true) {
       audit({

--- a/src/write/undo.ts
+++ b/src/write/undo.ts
@@ -151,6 +151,7 @@ export function readAuditRecords(dir: string): AuditRecord[] {
     return [];
   }
   const records: AuditRecord[] = [];
+  let torn = 0;
   for (const file of files) {
     let raw: string;
     try {
@@ -164,9 +165,18 @@ export function readAuditRecords(dir: string): AuditRecord[] {
         const parsed = JSON.parse(line) as AuditRecord;
         if (parsed.v === 1 && typeof parsed.op === "string") records.push(parsed);
       } catch {
-        // tolerate a torn/corrupt line — audit files are append-only
+        // tolerate a torn/corrupt line — append-only files can hold a partial
+        // trailing write — but make it VISIBLE rather than silently dropping it.
+        torn += 1;
       }
     }
+  }
+  // One note per read (M5): silent line-dropping could hide a lost record.
+  if (torn > 0) {
+    process.stderr.write(
+      `things: skipped ${torn} unreadable line(s) in the local change history (${dir}) — ` +
+        "a change record may be incomplete; recent history is otherwise intact\n",
+    );
   }
   return records.toSorted((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
 }

--- a/src/write/undo.ts
+++ b/src/write/undo.ts
@@ -184,11 +184,58 @@ export interface UndoSelector {
  * Which audit records are undoable at all: only SUCCESSFUL mutations, never an
  * inverse mutation (actor `undo:…` — no undo-the-undo), and never a compound
  * leg (its summary record is the single undoable unit for the whole sequence).
+ *
+ * `result === "ok"` also excludes INTENT records (result `"intent"`, the
+ * pre-execute marker — M3): an intent is not a completed mutation, so it is
+ * never an undo target. This is the single choke point every selector flows
+ * through (selectUndoTargets, its `--txn` and `by` branches), so intent records
+ * are skipped there uniformly. The two OTHER audit readers that scan by result
+ * — runUndo's already-undone check and planUndo's compound-leg lookup — also
+ * filter `result === "ok"`, so they skip intent records too.
  */
 function undoableRecords(records: AuditRecord[]): AuditRecord[] {
   return records.filter(
     (r) => r.result === "ok" && !r.actor.startsWith("undo:") && r.txn?.role !== "leg",
   );
+}
+
+// ------------------------------------------------------- audit integrity scan
+
+export interface AuditIntegrity {
+  /** Intent records with no later matching final record — a write MAY have landed unrecorded. */
+  orphanedIntents: number;
+  /** Newest orphaned intent's timestamp (ISO), or null when there are none. */
+  newestOrphanIntent: string | null;
+}
+
+/** Pairing key for an intent and its final record (both derive from startedAt). */
+function intentKey(r: AuditRecord): string {
+  // uuid is DELIBERATELY excluded: a create discovers its uuid only in the
+  // final record, so the intent (uuid null) and final (uuid set) must still pair.
+  return JSON.stringify([r.ts, r.op, r.actor, r.host]);
+}
+
+/**
+ * Detect crashed writes: INTENT records left without a matching final record.
+ * A mutation writes an intent immediately before touching the app and a final
+ * record after read-after-write; the two share ts+op+actor+host. An intent
+ * with no non-intent sibling on that key means the process died mid-write — the
+ * app may have applied the change, but no result was recorded, so the change is
+ * invisible to undo. Surfaced by `things doctor` so the user can reconcile.
+ */
+export function scanAuditIntegrity(records: AuditRecord[]): AuditIntegrity {
+  const finalKeys = new Set<string>();
+  for (const r of records) {
+    if (r.result !== "intent") finalKeys.add(intentKey(r));
+  }
+  let orphanedIntents = 0;
+  let newestOrphanIntent: string | null = null;
+  for (const r of records) {
+    if (r.result !== "intent" || finalKeys.has(intentKey(r))) continue;
+    orphanedIntents += 1;
+    if (newestOrphanIntent === null || r.ts > newestOrphanIntent) newestOrphanIntent = r.ts;
+  }
+  return { orphanedIntents, newestOrphanIntent };
 }
 
 /**

--- a/test/cli/doctor.test.ts
+++ b/test/cli/doctor.test.ts
@@ -1,10 +1,39 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { buildProgram } from "../../src/cli/main.ts";
 import { runDoctor } from "../../src/cli/commands/doctor.ts";
 import { diagnose } from "../../src/diagnose.ts";
+import type { AuditRecord } from "../../src/audit/schema.ts";
 import type { EnvironmentTracker, EnvironmentTuple } from "../../src/write/environment.ts";
 import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
 import { bplistScalarDouble, seedSyncronyMetadata, seedTodo } from "../fixtures/seed.ts";
+
+/** Minimal audit record for the integrity-scan fixtures. */
+function auditLine(over: Partial<AuditRecord>): string {
+  const rec: AuditRecord = {
+    v: 1,
+    ts: "2026-07-16T12:00:00.000Z",
+    actor: "mike",
+    host: "test-host",
+    op: "todo.update",
+    uuid: "U-1",
+    vector: "url-scheme",
+    disruption: 0,
+    invocation: null,
+    requested: {},
+    pre: null,
+    observed: null,
+    result: "ok",
+    verify: null,
+    durationMs: 1,
+    env: { pkg: "0.0.0", dbVersion: 26, fingerprint: "ok" },
+    ...over,
+  };
+  return JSON.stringify(rec);
+}
 
 let fixture: FixtureDb | null = null;
 afterEach(() => {
@@ -166,6 +195,40 @@ describe("doctor environment & automation sections", () => {
     expect(report?.syncHealth.cloud.ageSeconds).toBe(30);
   });
 
+  it("counts orphaned intent records (a change may have landed unrecorded — M3)", () => {
+    fixture = buildFixtureDb();
+    const auditDir = mkdtempSync(join(tmpdir(), "things-api-doctor-audit-"));
+    try {
+      writeFileSync(
+        join(auditDir, "2026-07.jsonl"),
+        [
+          // A completed write: intent + final pair → not orphaned.
+          auditLine({ ts: "2026-07-16T09:00:00.000Z", op: "todo.update", result: "intent" }),
+          auditLine({ ts: "2026-07-16T09:00:00.000Z", op: "todo.update", result: "ok" }),
+          // A crashed write: intent with no final → orphaned.
+          auditLine({ ts: "2026-07-16T10:30:00.000Z", op: "todo.complete", result: "intent" }),
+        ].join("\n"),
+      );
+      const { report } = diagnose(fixture.path, {
+        environment: fixedTracker(null, TUPLE_A),
+        auditDir,
+      });
+      expect(report?.audit.orphanedIntents).toBe(1);
+      expect(report?.audit.newestOrphanIntent).toBe("2026-07-16T10:30:00.000Z");
+    } finally {
+      rmSync(auditDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reports zero orphans against an empty/absent audit trail", () => {
+    fixture = buildFixtureDb();
+    const { report } = diagnose(fixture.path, {
+      environment: fixedTracker(null, TUPLE_A),
+      auditDir: "/nonexistent/audit",
+    });
+    expect(report?.audit).toEqual({ orphanedIntents: 0, newestOrphanIntent: null });
+  });
+
   it("reports the on-disk URL-scheme state and proxy-shortcut presence", () => {
     fixture = buildFixtureDb();
     const { report } = diagnose(fixture.path, {
@@ -180,5 +243,71 @@ describe("doctor environment & automation sections", () => {
     expect(report?.availability.urlScheme.detail).toContain("Enable Things URLs");
     expect(report?.availability.shortcuts.present).toEqual(["things-proxy-find-items"]);
     expect(report?.availability.shortcuts.missing).toHaveLength(5);
+  });
+});
+
+describe("doctor CLI — orphaned-intent advisory line", () => {
+  let stateDir: string;
+  let stdout: string[];
+  const envBackup: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    fixture = buildFixtureDb();
+    stateDir = mkdtempSync(join(tmpdir(), "things-api-doctor-cli-"));
+    for (const key of ["THINGS_DB", "THINGS_API_STATE_DIR", "THINGS_API_CONFIG_DIR"]) {
+      envBackup[key] = process.env[key];
+    }
+    process.env["THINGS_DB"] = fixture.path;
+    process.env["THINGS_API_STATE_DIR"] = stateDir;
+    process.env["THINGS_API_CONFIG_DIR"] = join(stateDir, "config");
+    stdout = [];
+    vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+      stdout.push(String(chunk));
+      return true;
+    });
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const [key, value] of Object.entries(envBackup)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(stateDir, { recursive: true, force: true });
+    process.exitCode = undefined;
+  });
+
+  async function runDoctorCli(): Promise<string> {
+    const program = buildProgram();
+    program.exitOverride();
+    await program.parseAsync(["node", "things", "doctor"]);
+    return stdout.join("");
+  }
+
+  it("prints the one-line advisory (count + newest) when an intent has no recorded result", async () => {
+    mkdirSync(join(stateDir, "audit"), { recursive: true });
+    writeFileSync(
+      join(stateDir, "audit", "2026-07.jsonl"),
+      `${auditLine({ ts: "2026-07-16T10:30:00.000Z", op: "todo.complete", result: "intent" })}\n`,
+    );
+    const out = await runDoctorCli();
+    expect(out).toContain("1 change(s) were started but their result was not recorded");
+    expect(out).toContain("2026-07-16T10:30:00.000Z");
+    expect(out).toContain("review your recent changes in Things");
+  });
+
+  it("omits the advisory entirely when the trail is clean", async () => {
+    mkdirSync(join(stateDir, "audit"), { recursive: true });
+    writeFileSync(
+      join(stateDir, "audit", "2026-07.jsonl"),
+      [
+        auditLine({ ts: "2026-07-16T09:00:00.000Z", op: "todo.update", result: "intent" }),
+        auditLine({ ts: "2026-07-16T09:00:00.000Z", op: "todo.update", result: "ok" }),
+      ].join("\n"),
+    );
+    const out = await runDoctorCli();
+    expect(out).not.toContain("were started but their result was not recorded");
   });
 });

--- a/test/engine/write-batch.test.ts
+++ b/test/engine/write-batch.test.ts
@@ -102,8 +102,12 @@ describe("runBatch", () => {
     expect(results[3]?.outcome.kind === "invalid" && results[3].outcome.detail).toMatch(
       /exclusive/,
     );
-    // ok + blocked both audited (invalid ops never reach the pipeline)
-    expect(auditRecords.map((r) => r.result)).toEqual(["ok", "blocked:H-PERMANENT-DELETE"]);
+    // ok + blocked both audited (invalid ops never reach the pipeline); the ok
+    // op also records its pre-execute intent, excluded here.
+    expect(auditRecords.filter((r) => r.result !== "intent").map((r) => r.result)).toEqual([
+      "ok",
+      "blocked:H-PERMANENT-DELETE",
+    ]);
   });
 
   it("failFast skips everything after the first failure", async () => {

--- a/test/engine/write-clear-reminder.test.ts
+++ b/test/engine/write-clear-reminder.test.ts
@@ -182,7 +182,7 @@ describe("runClearReminder — vector selection + URL bounce", () => {
     }
     expect(calls).toHaveLength(2);
     // Two legs (excluded from undo) + one summary (the single undoable unit).
-    const legs = auditRecords.filter((r) => r.txn?.role === "leg");
+    const legs = auditRecords.filter((r) => r.txn?.role === "leg" && r.result !== "intent");
     const summary = auditRecords.find((r) => r.txn?.role === "summary");
     expect(legs.map((r) => r.op)).toEqual(["todo.update", "todo.update"]);
     expect(summary?.op).toBe("todo.clear-dated-reminder");

--- a/test/engine/write-pipeline.test.ts
+++ b/test/engine/write-pipeline.test.ts
@@ -126,14 +126,25 @@ describe("verified mutations", () => {
       expect(result.uuid).toBe(uuid);
       expect(result.observed).toEqual({ title: "New" });
     }
-    expect(auditRecords).toHaveLength(1);
+    // M3: a successful write records an INTENT before execute, then the final
+    // ok — the pair shares ts/op/actor/host (both derive from startedAt).
+    expect(auditRecords).toHaveLength(2);
     expect(auditRecords[0]).toMatchObject({
+      op: "todo.update",
+      result: "intent",
+      actor: "test-actor",
+      uuid,
+      pre: { title: "Old" },
+      observed: null,
+    });
+    expect(auditRecords[1]).toMatchObject({
       op: "todo.update",
       result: "ok",
       actor: "test-actor",
       pre: { title: "Old" },
       observed: { title: "New" },
     });
+    expect(auditRecords[0]?.ts).toBe(auditRecords[1]?.ts);
   });
 
   it("ok result carries an undoToken matching the audit record (additive)", async () => {
@@ -161,7 +172,10 @@ describe("verified mutations", () => {
     const result = await runMutation(deps(vector), "todo.add", { title: "Fresh" });
     expect(result.kind).toBe("ok");
     if (result.kind === "ok") expect(result.uuid).toBe("NEW-1");
-    expect(auditRecords[0]?.uuid).toBe("NEW-1");
+    // The final record carries the discovered uuid; the preceding intent has
+    // uuid null (a create discovers its uuid only at verify).
+    expect(auditRecords.find((r) => r.result === "ok")?.uuid).toBe("NEW-1");
+    expect(auditRecords[0]).toMatchObject({ result: "intent", uuid: null });
   });
 
   it("project.complete verifies the child cascade (T08 semantics)", async () => {
@@ -253,7 +267,9 @@ describe("verification failure classification", () => {
     );
     expect(result.kind).toBe("verify-failed");
     if (result.kind === "verify-failed") expect(result.reason).toBe("silent-noop");
-    expect(auditRecords[0]?.result).toBe("verify-failed:silent-noop");
+    // Intent precedes the failed outcome; the pair keeps the crash-signature
+    // invariant (a verify-failed is NOT an orphan — it has a recorded result).
+    expect(auditRecords.map((r) => r.result)).toEqual(["intent", "verify-failed:silent-noop"]);
   });
 
   it("timeout: tripwire moved but asserted fields did not", async () => {
@@ -314,7 +330,11 @@ describe("blocked / unsupported paths", () => {
     expect(result.kind).toBe("blocked");
     if (result.kind === "blocked") expect(result.hazard).toBe("H-PERMANENT-DELETE");
     expect(calls).toHaveLength(0);
+    // A guard block audits ONCE (the blocked record) — no intent is written,
+    // since the app is never touched (M3: intent precedes execute only).
+    expect(auditRecords).toHaveLength(1);
     expect(auditRecords[0]?.result).toBe("blocked:H-PERMANENT-DELETE");
+    expect(auditRecords.some((r) => r.result === "intent")).toBe(false);
   });
 
   it("drift block: writes refuse before anything else", async () => {

--- a/test/engine/write-reorder.test.ts
+++ b/test/engine/write-reorder.test.ts
@@ -355,7 +355,9 @@ describe("bounce reorder (verified when= round-trips)", () => {
     const summary = auditRecords.filter((r) => r.op === "reorder");
     expect(summary).toHaveLength(1);
     expect(summary[0]?.result).toBe("ok");
-    expect(auditRecords.filter((r) => r.op === "todo.update")).toHaveLength(4);
+    expect(
+      auditRecords.filter((r) => r.op === "todo.update" && r.result !== "intent"),
+    ).toHaveLength(4);
   });
 
   it("today scope falls back to bounce when experimental is off", async () => {

--- a/test/unit/audit-log.test.ts
+++ b/test/unit/audit-log.test.ts
@@ -116,3 +116,35 @@ describe("createAuditWriter — monthly file naming + JSONL append", () => {
     expect(augRecords.map((r) => r.uuid)).toEqual(["c"]);
   });
 });
+
+describe("createAuditWriter — durable, tear-resistant appends (M5)", () => {
+  it("the fsync/O_APPEND path writes parseable one-line-per-record JSONL", () => {
+    const writer = createAuditWriter({ dir, secrets: [], enabled: true });
+    // Several appends to the SAME monthly file, each a complete O_APPEND write.
+    writer.append(makeRecord({ ts: "2026-07-10T09:00:00.000Z", uuid: "a", result: "intent" }));
+    writer.append(makeRecord({ ts: "2026-07-10T09:00:00.000Z", uuid: "a", result: "ok" }));
+    writer.append(makeRecord({ ts: "2026-07-11T09:00:00.000Z", uuid: "b" }));
+
+    const raw = readFileSync(join(dir, "2026-07.jsonl"), "utf8");
+    // Exactly one newline-terminated line per record, each independently valid.
+    const lines = raw.split("\n");
+    expect(lines.at(-1)).toBe(""); // trailing newline
+    const records = lines.slice(0, -1).map((l) => JSON.parse(l) as AuditRecord);
+    expect(records.map((r) => `${r.uuid}:${r.result}`)).toEqual(["a:intent", "a:ok", "b:ok"]);
+  });
+
+  it("round-trips a huge record (>1MB) as a single intact line", () => {
+    const writer = createAuditWriter({ dir, secrets: [], enabled: true });
+    const big = "x".repeat(1_500_000); // 1.5 MB, well over PIPE_BUF
+    writer.append(makeRecord({ uuid: "big", requested: { blob: big } }));
+
+    const raw = readFileSync(join(dir, "2026-07.jsonl"), "utf8");
+    // One record, one trailing newline — no split/torn buffer.
+    const lines = raw.split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toBe("");
+    const parsed = JSON.parse(lines[0] as string) as AuditRecord;
+    expect(parsed.uuid).toBe("big");
+    expect((parsed.requested["blob"] as string).length).toBe(big.length);
+  });
+});

--- a/test/unit/undo-plan.test.ts
+++ b/test/unit/undo-plan.test.ts
@@ -6,7 +6,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { undoToken, type AuditRecord } from "../../src/audit/schema.ts";
 import type { AnyTask } from "../../src/model/entities.ts";
@@ -209,7 +209,16 @@ describe("scanAuditIntegrity — crashed-write detection (M3)", () => {
 });
 
 describe("readAuditRecords", () => {
-  it("parses monthly files, tolerates torn lines, sorts by ts", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parses monthly files, tolerates torn lines, sorts by ts — WITH a note (M5)", () => {
+    const stderr: string[] = [];
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderr.push(String(chunk));
+      return true;
+    });
     const dir = mkdtempSync(join(tmpdir(), "things-api-undo-test-"));
     try {
       writeFileSync(
@@ -222,6 +231,29 @@ describe("readAuditRecords", () => {
       );
       const records = readAuditRecords(dir);
       expect(records.map((r) => r.op)).toEqual(["a", "b"]);
+      // The dropped torn line is now VISIBLE — exactly one note, once per read.
+      const note = stderr.join("");
+      expect(note).toContain("skipped 1 unreadable line(s)");
+      expect(stderr).toHaveLength(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("emits NO note for a clean trail", () => {
+    const stderr: string[] = [];
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+    const dir = mkdtempSync(join(tmpdir(), "things-api-undo-clean-"));
+    try {
+      writeFileSync(
+        join(dir, "2026-07.jsonl"),
+        `${JSON.stringify(record({ ts: "2026-07-05T10:00:00Z", op: "b" }))}\n`,
+      );
+      expect(readAuditRecords(dir).map((r) => r.op)).toEqual(["b"]);
+      expect(stderr).toEqual([]);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/test/unit/undo-plan.test.ts
+++ b/test/unit/undo-plan.test.ts
@@ -10,7 +10,12 @@ import { describe, expect, it } from "vitest";
 
 import { undoToken, type AuditRecord } from "../../src/audit/schema.ts";
 import type { AnyTask } from "../../src/model/entities.ts";
-import { planUndo, readAuditRecords, selectUndoTargets } from "../../src/write/undo.ts";
+import {
+  planUndo,
+  readAuditRecords,
+  scanAuditIntegrity,
+  selectUndoTargets,
+} from "../../src/write/undo.ts";
 
 const NOW = new Date("2026-07-05T12:00:00Z");
 
@@ -112,6 +117,25 @@ describe("selectUndoTargets", () => {
     expect(selectUndoTargets([a, b], { txn: "m-does-not-exist" })).toEqual([]);
   });
 
+  it("skips INTENT records everywhere: last/by scoping AND --txn (M3)", () => {
+    // An intent whose final never landed (crashed write) must never be an undo
+    // target — not by last, not by actor scoping, not by its would-be token.
+    const intent = record({
+      ts: "2026-07-05T09:30:00Z",
+      op: "todo.add",
+      uuid: "CRASH",
+      actor: "mike",
+      result: "intent",
+    });
+    const ok = record({ ts: "2026-07-05T09:00:00Z", op: "todo.add", uuid: "DONE", actor: "mike" });
+    const all = [ok, intent];
+    // last/by never surface the intent…
+    expect(selectUndoTargets(all, { last: 5 }).map((t) => t.uuid)).toEqual(["DONE"]);
+    expect(selectUndoTargets(all, { by: "mike", last: 5 }).map((t) => t.uuid)).toEqual(["DONE"]);
+    // …and the token the intent WOULD hash to selects nothing.
+    expect(selectUndoTargets(all, { txn: undoToken(intent) })).toEqual([]);
+  });
+
   it("--txn matches a compound summary by its txn id", () => {
     const summary = record({
       ts: "2026-07-05T09:00:00Z",
@@ -136,6 +160,51 @@ describe("undoToken", () => {
     expect(undoToken(base)).not.toBe(undoToken({ ...base, uuid: "B" }));
     expect(undoToken(base)).not.toBe(undoToken({ ...base, actor: "mcp" }));
     expect(undoToken(base)).not.toBe(undoToken({ ...base, ts: "2026-07-05T09:00:01Z" }));
+  });
+});
+
+describe("scanAuditIntegrity — crashed-write detection (M3)", () => {
+  it("flags an intent with no matching final; pairs on ts+op+actor+host, not uuid", () => {
+    const records = [
+      // A completed write: intent + final share ts/op/actor/host — NOT orphaned.
+      record({ ts: "2026-07-05T09:00:00Z", op: "todo.update", uuid: "A", result: "intent" }),
+      record({ ts: "2026-07-05T09:00:00Z", op: "todo.update", uuid: "A", result: "ok" }),
+      // A create: intent has null uuid, final discovered "NEW" — still pairs
+      // (uuid is excluded from the pairing key), so NOT orphaned.
+      record({ ts: "2026-07-05T09:05:00Z", op: "todo.add", uuid: null, result: "intent" }),
+      record({ ts: "2026-07-05T09:05:00Z", op: "todo.add", uuid: "NEW", result: "ok" }),
+      // A crashed write: intent with no final at its key — ORPHANED.
+      record({ ts: "2026-07-05T09:10:00Z", op: "todo.complete", uuid: "C", result: "intent" }),
+    ];
+    const integrity = scanAuditIntegrity(records);
+    expect(integrity.orphanedIntents).toBe(1);
+    expect(integrity.newestOrphanIntent).toBe("2026-07-05T09:10:00Z");
+  });
+
+  it("reports zero when every intent has a recorded outcome (incl. verify-failed)", () => {
+    const records = [
+      record({ ts: "2026-07-05T09:00:00Z", op: "todo.update", result: "intent" }),
+      record({
+        ts: "2026-07-05T09:00:00Z",
+        op: "todo.update",
+        result: "verify-failed:silent-noop",
+      }),
+    ];
+    expect(scanAuditIntegrity(records)).toEqual({
+      orphanedIntents: 0,
+      newestOrphanIntent: null,
+    });
+  });
+
+  it("newest wins across multiple orphans", () => {
+    const records = [
+      record({ ts: "2026-07-05T08:00:00Z", op: "todo.add", result: "intent" }),
+      record({ ts: "2026-07-05T11:00:00Z", op: "todo.delete", result: "intent" }),
+      record({ ts: "2026-07-05T10:00:00Z", op: "todo.move", result: "intent" }),
+    ];
+    const integrity = scanAuditIntegrity(records);
+    expect(integrity.orphanedIntents).toBe(3);
+    expect(integrity.newestOrphanIntent).toBe("2026-07-05T11:00:00Z");
   });
 });
 


### PR DESCRIPTION
Hardens the audit trail's durability, closing two adversarial-review findings.

## M3 — success-path un-audited window (Commit 1)

A crash between a successful `vector.execute` and the final audit append left a permanent app-side mutation that was un-audited and un-undoable — "every mutation attempt is audited" failed exactly on the success path.

Fix: record an **intent** marker immediately before `vector.execute` (guards passed, invocation compiled), carrying op/uuid/actor/redacted invocation/startedAt + captured pre-state. The final `ok`/`verify-failed` record written after verify supersedes it. An intent with no matching final (paired on ts+op+actor+host, since a create discovers its uuid only in the final record) is the signature of a crashed write.

- **Schema:** new `result: "intent"` union member — it rides EVERY existing `result === "ok"` undo filter, so `undoableRecords` (and thus `selectUndoTargets`, its `--txn` and `by` branches), `runUndo`'s already-undone check, and `planUndo`'s compound-leg lookup all skip intent records with no per-reader changes.
- **Undo:** `scanAuditIntegrity()` reports orphan count + newest timestamp.
- **Doctor:** one-line consumer-voiced advisory when orphaned intents exist (plus a structured `report.audit` field), so the user learns a change may have landed unrecorded.
- No intent on dry-run (returns before execute) or guard-blocked ops (app never touched; blocked audits already exist, not double-written).

## M5 — non-durable, silently-lossy appends (Commit 2)

Audit appends happen from processes that do NOT hold the mutation lock (a drift-gate or lock-contention block is recorded before/without acquiring it), so concurrent appends to one monthly file are possible. The old `appendFileSync` path gave neither a single-write guarantee nor an fsync — a torn/interleaved line was possible, and `readAuditRecords` dropped it **silently**, so the casualty could be a successful mutation's record (then un-undoable).

- **Writer:** `open(O_APPEND)` → ONE `writeSync` with the complete line buffer → `fsyncSync` → `close`. On regular files a single O_APPEND write() appends under the inode lock and cannot interleave (no torn line); fsync makes it durable before returning. No lockfile — justified in the module header. Any append failure falls back to best-effort `appendFileSync` then swallows: auditing must never throw into a mutation result. Public signature stays synchronous.
- **Reader:** still tolerates torn lines, but now emits ONE stderr note per read when any were skipped — corruption is visible, not silent.

## Tests

All green by exit code (`npm run check` → 0; 1322 tests). Added: intent+final pair on a successful write; intent skipped by undo selection (last/by/--txn); `scanAuditIntegrity` orphan detection incl. create uuid-independence; doctor advisory on an orphaned-intent fixture (structured + rendered CLI line); no intent on dry-run / guard-blocked; fsync path writes parseable JSONL; >1MB record round-trips intact; torn line skipped WITH the note (clean trail emits none).

## Not included

CHANGELOG.md left untouched per brief (bullets proposed in the task report). No operation-catalog / vector-matrix / probe changes, so the mandatory living docs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)