### PR TITLE
chore: AGENTS.md is the shared instruction file; CLAUDE.md imports it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# things-api — repo instructions
+
+## Living documents — keep them current (part of every change)
+
+- **[docs/capability-matrix.md](docs/capability-matrix.md)** — the CRUD × vector wish-list/checklist. Update it in the SAME change as: any operation-catalog edit (`src/write/operations.ts`), any vector-matrix edit, any new probe verdict, or any gap opened/closed.
+- **[docs/things-app-oddities.md](docs/things-app-oddities.md)** — the future Cultured Code bug report. Record every newly discovered app bug/quirk THE MOMENT it is found, with probe evidence.
+- **[docs/gaps.md](docs/gaps.md)** — roadmap: one entry per phase, updated when a phase lands.
+- **[docs/roadmap.md](docs/roadmap.md)** — durable parked-work plan (survives compaction): decided-but-unbuilt items, distribution/onboarding, doctrine decisions. Update when a parked item lands or a new one is deferred.
+- **[docs/reference/](docs/reference/README.md)** — the evidence compendium: probe-id index ([README](docs/reference/README.md)), [novel-paths.md](docs/reference/novel-paths.md) (add each newly discovered working path), [suite-audit.md](docs/reference/suite-audit.md) (update when ops or suites change).
+- **CHANGELOG.md** — every user-visible change goes under `## Unreleased`.
+
+## Safety rails (non-negotiable)
+
+- Production Things DB (this host): READS ONLY, and only via `scripts/prod-read.sh` (one stable command shape — ad-hoc shapes re-trigger macOS consent). NEVER write to production; never point new binary shapes at the prod container (even `doctor`).
+- Writes go exclusively through official app surfaces (URL scheme / AppleScript / Shortcuts) — never direct SQLite writes. All write probing happens in disposable Tart VMs (`docs/lab/`).
+
+## Conventions
+
+- Verify `npm run check` by EXIT CODE, never by grepping piped output. Run `npm run fmt` before committing (oxfmt also formats committed JSON).
+- Feature branches (`mg/<topic>`), PRs for the audit trail, self-merge after CI is fine.
+- All consumer-facing copy (CLI `--help`, MCP tool descriptions, exported JSDoc) follows [docs/design/surface-copy.md](docs/design/surface-copy.md) — behavior and side effects only; banned-vocabulary regression tests enforce it.
+- Guest e2e bundles ship node + dist + commander ONLY — heavyweight deps (MCP SDK, zod) must stay lazily imported from CLI actions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,22 +1,3 @@
-# things-api — repo instructions
+@AGENTS.md
 
-## Living documents — keep them current (part of every change)
-
-- **[docs/capability-matrix.md](docs/capability-matrix.md)** — the CRUD × vector wish-list/checklist. Update it in the SAME change as: any operation-catalog edit (`src/write/operations.ts`), any vector-matrix edit, any new probe verdict, or any gap opened/closed.
-- **[docs/things-app-oddities.md](docs/things-app-oddities.md)** — the future Cultured Code bug report. Record every newly discovered app bug/quirk THE MOMENT it is found, with probe evidence.
-- **[docs/gaps.md](docs/gaps.md)** — roadmap: one entry per phase, updated when a phase lands.
-- **[docs/roadmap.md](docs/roadmap.md)** — durable parked-work plan (survives compaction): decided-but-unbuilt items, distribution/onboarding, doctrine decisions. Update when a parked item lands or a new one is deferred.
-- **[docs/reference/](docs/reference/README.md)** — the evidence compendium: probe-id index ([README](docs/reference/README.md)), [novel-paths.md](docs/reference/novel-paths.md) (add each newly discovered working path), [suite-audit.md](docs/reference/suite-audit.md) (update when ops or suites change).
-- **CHANGELOG.md** — every user-visible change goes under `## Unreleased`.
-
-## Safety rails (non-negotiable)
-
-- Production Things DB (this host): READS ONLY, and only via `scripts/prod-read.sh` (one stable command shape — ad-hoc shapes re-trigger macOS consent). NEVER write to production; never point new binary shapes at the prod container (even `doctor`).
-- Writes go exclusively through official app surfaces (URL scheme / AppleScript / Shortcuts) — never direct SQLite writes. All write probing happens in disposable Tart VMs (`docs/lab/`).
-
-## Conventions
-
-- Verify `npm run check` by EXIT CODE, never by grepping piped output. Run `npm run fmt` before committing (oxfmt also formats committed JSON).
-- Feature branches (`mg/<topic>`), PRs for the audit trail, self-merge after CI is fine.
-- All consumer-facing copy (CLI `--help`, MCP tool descriptions, exported JSDoc) follows [docs/design/surface-copy.md](docs/design/surface-copy.md) — behavior and side effects only; banned-vocabulary regression tests enforce it.
-- Guest e2e bundles ship node + dist + commander ONLY — heavyweight deps (MCP SDK, zod) must stay lazily imported from CLI actions.
+<!-- Shared repo instructions live in AGENTS.md (imported above, read by all agent harnesses). Claude Code–specific guidance, if any, goes below this line. -->


### PR DESCRIPTION
Renames the repo `CLAUDE.md` to `AGENTS.md` (byte-identical) so other agent harnesses (Codex, etc.) pick up the same project instructions, and replaces `CLAUDE.md` with an `@AGENTS.md` import.

Per the official Claude Code memory docs (code.claude.com/docs/en/memory): Claude Code does **not** read AGENTS.md natively, and a pointer CLAUDE.md with an `@`-import is the documented pattern for shared instruction files — imports are expanded at launch and are functionally identical to inline content, so there is no behavioral change for Claude Code and no double-inclusion. The existing instructions were fully harness-agnostic, so nothing Claude-specific needed extracting; the pointer file leaves a marked slot for any future Claude-only guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiiUK4qXABDtVKoW7S9Cft