### PR TITLE
Air-gap policy: CLI + MCP consume the library through src/index.ts only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,4 @@
 - Feature branches (`mg/<topic>`), PRs for the audit trail, self-merge after CI is fine.
 - All consumer-facing copy (CLI `--help`, MCP tool descriptions, exported JSDoc) follows [docs/design/surface-copy.md](docs/design/surface-copy.md) — behavior and side effects only; banned-vocabulary regression tests enforce it.
 - Guest e2e bundles ship node + dist + commander ONLY — heavyweight deps (MCP SDK, zod) must stay lazily imported from CLI actions.
+- **Consumer boundary (air gap):** `src/cli/**` and `src/mcp/**` are pure consumers of the library through the single entry point `src/index.ts` — never import a library internal directly (intra-surface presentation imports are fine). Enforced by `test/unit/import-boundary.test.ts`; see [docs/design/architecture.md](docs/design/architecture.md) (Consumer boundary).

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -114,6 +114,22 @@ things-api/
 
 One runtime dependency total (commander). Bin name `things` — reads naturally in agent transcripts (`things today --json`); verified no collision (no PATH binary, no brew formula, npm's `things` package ships no bin).
 
+### Consumer boundary (air gap)
+
+The CLI (`src/cli/**`) and the MCP server (`src/mcp/**`) are pure **consumers** of the library: they reach it through **one entry point, `src/index.ts`**, and never import a library internal directly. The client API is a black box to them — as if each surface were published as its own package depending on `things-api`. Nothing under `src/index.ts` ever imports back into `src/cli/**` or `src/mcp/**` (the library must never depend on a consumer).
+
+Concretely, within a surface a file may import its own siblings (presentation stays intra-surface — `cli/render.ts`, `cli/glyphs.ts`, `cli/width.ts`, `cli/style.ts`), but **every import that leaves the surface's own directory tree must resolve to exactly `src/index.ts`**. When a surface needs a value that lived in an internal module, that value is exported deliberately from the barrel (grouped and commented); when it needs a real capability (e.g. shortcut-proxy availability), the library grows a proper accessor (`shortcutProxies()` in `diagnose.ts`) rather than leaking the internal.
+
+Why:
+
+- **Drift prevention** — the two surfaces cannot silently diverge on logic that should be shared. The per-view filter contract (`read/filter-contract.ts`: `FILTER_CONTRACT`, `validateViewArgs`, the tag-conflict predicates) and the `<when>@<time>` sugar parser (`model/when-sugar.ts`) each live once and are consumed by both.
+- **Contract stress-testing** — routing everything through `index.ts` continuously exercises the public surface exactly as an external embedder would, so gaps in the exported API surface show up immediately.
+- **Future package split** — the CLI and MCP server can be extracted into their own packages with no import rewrites, because they already depend only on the published barrel.
+
+The MCP server is itself a consumer surface (not part of the client library API) and its module eagerly pulls in zod + the MCP SDK. It is therefore exposed through a **lazy loader**, `loadMcpServer()`, so importing the barrel never drags those heavyweight deps into a consumer's eager graph — they load only when `things mcp` constructs the server. This keeps the guest e2e bundle (node + dist + commander only) lean.
+
+**Enforcement:** `test/unit/import-boundary.test.ts` statically scans every file under `src/cli/**` and `src/mcp/**` and fails — naming `file:line` and the offending specifier — if any relative import that leaves the surface resolves anywhere other than `src/index.ts`.
+
 ## 2. Core TypeScript API shape
 
 ### Entities (`model/entities.ts`) — enums verified against live DB

--- a/src/cli/commands/area.ts
+++ b/src/cli/commands/area.ts
@@ -4,15 +4,10 @@
  */
 import type { Command } from "commander";
 
-import type { Project, Todo } from "../../model/entities.ts";
-import type { AreaView } from "../../read/area-view.ts";
-import { localToday } from "../../model/dates.ts";
 import { bold, dim, green } from "../style.ts";
 import { areaMark, thingsLink } from "../glyphs.ts";
 import { Option } from "commander";
 
-import type { GroupedLimits } from "../../read/sections.ts";
-import type { BoundedAreaView } from "../../client.ts";
 import { openInThings } from "./reads.ts";
 import {
   invocation,
@@ -25,7 +20,16 @@ import {
 import { disclosureHint, formatItem, quoteTitle, uuidDisplayWidth } from "../render.ts";
 import { DidYouMeanError } from "../did-you-mean.ts";
 import { showToggleFlags } from "./project.ts";
-import { AREA_PREVIEW_LIMIT, GROUPED_ALL_DESC } from "../../surface-copy.ts";
+import {
+  AREA_PREVIEW_LIMIT,
+  GROUPED_ALL_DESC,
+  localToday,
+  type AreaView,
+  type BoundedAreaView,
+  type GroupedLimits,
+  type Project,
+  type Todo,
+} from "../../index.ts";
 import {
   addTagFilterOptions,
   CONTAINER_TAG_HINT,

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -4,9 +4,15 @@
  */
 import type { Command } from "commander";
 
-import { diagnose, type DiagnoseReport, type DiagnoseResult } from "../../diagnose.ts";
-import { describeEnvironmentChanges } from "../../write/environment.ts";
-import { errorEnvelope, okEnvelope, type EnvelopeMeta } from "../../contracts.ts";
+import {
+  describeEnvironmentChanges,
+  diagnose,
+  errorEnvelope,
+  okEnvelope,
+  type DiagnoseReport,
+  type DiagnoseResult,
+  type EnvelopeMeta,
+} from "../../index.ts";
 
 // Back-compat aliases for pre-seam consumers of the CLI module.
 export type DoctorReport = DiagnoseReport;

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -5,7 +5,7 @@
  */
 import type { Command } from "commander";
 
-import type { DisruptionTier } from "../../config.ts";
+import type { DisruptionTier } from "../../index.ts";
 
 export function registerMcp(program: Command): void {
   program

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -5,7 +5,7 @@
  */
 import type { Command } from "commander";
 
-import type { DisruptionTier } from "../../index.ts";
+import { loadMcpServer, type DisruptionTier } from "../../index.ts";
 
 export function registerMcp(program: Command): void {
   program
@@ -27,8 +27,10 @@ export function registerMcp(program: Command): void {
         // LAZY imports: the MCP SDK + zod load only when `things mcp` actually
         // runs. Every other CLI command must work in environments that ship a
         // minimal dependency set (the guest e2e bundle carries only commander).
+        // The server surface is reached through the library's lazy loader
+        // (loadMcpServer), keeping the air-gap boundary intact.
         const [{ createThingsMcpServer }, { StdioServerTransport }] = await Promise.all([
-          import("../../mcp/server.ts"),
+          loadMcpServer(),
           import("@modelcontextprotocol/sdk/server/stdio.js"),
         ]);
         // Same mapping the CLI's per-call write flags use (writeOptionsFrom):

--- a/src/cli/commands/project.ts
+++ b/src/cli/commands/project.ts
@@ -3,9 +3,7 @@
  */
 import type { Command } from "commander";
 
-import type { Todo } from "../../model/entities.ts";
-import type { ProjectView } from "../../read/project-view.ts";
-import { localToday } from "../../model/dates.ts";
+import { localToday, type ProjectView, type Todo } from "../../index.ts";
 import { bold, dim, green, underline } from "../style.ts";
 import {
   countChip,

--- a/src/cli/commands/reads.ts
+++ b/src/cli/commands/reads.ts
@@ -10,8 +10,6 @@ import { execFileSync } from "node:child_process";
 
 import { runAreaShow, type AreaShowActionOpts } from "./area.ts";
 import { runProjectShow, type ProjectShowActionOpts } from "./project.ts";
-import type { ListItem, TodayView, ViewFilter } from "../../read/views.ts";
-import { localToday } from "../../model/dates.ts";
 import { dim } from "../style.ts";
 import { areaMark, LEGEND, shortDate } from "../glyphs.ts";
 import {
@@ -57,20 +55,27 @@ import {
   type TagFlags,
 } from "../tag-filters.ts";
 import { doublePeriod, parsePeriodEnd, parsePeriodStart } from "../period.ts";
-import { FILTER_CONTRACT, validateViewArgs } from "../../index.ts";
-import { ExitCode, okEnvelope, type EnvelopeMeta } from "../../contracts.ts";
-import type { GroupedLimits } from "../../read/sections.ts";
 import {
   ALL_DESC,
   AREA_LIMIT_DESC,
   AREA_PREVIEW_LIMIT,
+  ExitCode,
+  FILTER_CONTRACT,
   GROUPED_ALL_DESC,
   LIMIT_DESC,
+  localToday,
+  okEnvelope,
   PERIOD_SINCE,
   PERIOD_UNTIL,
   PROJECT_LIMIT_DESC,
   PROJECT_PREVIEW_LIMIT,
-} from "../../surface-copy.ts";
+  validateViewArgs,
+  type EnvelopeMeta,
+  type GroupedLimits,
+  type ListItem,
+  type TodayView,
+  type ViewFilter,
+} from "../../index.ts";
 
 /**
  * Foreground the Things app on a resource via its share URI. A GUI action

--- a/src/cli/commands/reads.ts
+++ b/src/cli/commands/reads.ts
@@ -57,6 +57,7 @@ import {
   type TagFlags,
 } from "../tag-filters.ts";
 import { doublePeriod, parsePeriodEnd, parsePeriodStart } from "../period.ts";
+import { FILTER_CONTRACT, validateViewArgs } from "../../index.ts";
 import { ExitCode, okEnvelope, type EnvelopeMeta } from "../../contracts.ts";
 import type { GroupedLimits } from "../../read/sections.ts";
 import {
@@ -883,8 +884,9 @@ export function registerReadCommands(program: Command): void {
     }
     // The areas LIST has no deadline to compare against — an area is not a
     // dated entity — so --overdue is vacuous here and rejected fail-closed
-    // (the same exclusion style #159 used for upcoming/logbook/trash).
-    if (opts.overdue === true) {
+    // (the same exclusion style #159 used for upcoming/logbook/trash). The
+    // decision is the contract's (areas: overdue = false).
+    if (!FILTER_CONTRACT.areas.overdue && opts.overdue === true) {
       usageError(
         opts,
         "--overdue does not apply to the areas list — areas have no deadline; use it on `things areas <ref>` (that area's rows) or `things projects --overdue`",
@@ -893,8 +895,12 @@ export function registerReadCommands(program: Command): void {
     }
     // The tag filters scope an area's ROWS, not the area LIST — the bare list
     // shows every area with its direct tags. Rejected fail-closed here (same
-    // style as --overdue); use `things areas <ref>` or `things projects --tag`.
-    if (hasTagPresence(opts) || opts.untagged === true) {
+    // style as --overdue; contract: areas tag = "rejected"). Use
+    // `things areas <ref>` or `things projects --tag`.
+    if (
+      FILTER_CONTRACT.areas.tag === "rejected" &&
+      (hasTagPresence(opts) || opts.untagged === true)
+    ) {
       usageError(
         opts,
         "the tag filters (--tag/--untagged) do not apply to the areas list — use them on `things areas <ref>` (that area's rows) or `things projects --tag`",
@@ -1032,14 +1038,29 @@ export function registerReadCommands(program: Command): void {
         exactTag: opts["exactTag"] === true,
         untagged: opts["untagged"] === true,
       };
-      if (tagFlagConflict({ ...tagFlags, json })) return;
       const overdue = opts["overdue"] === true;
       const all = opts["all"] === true;
-      // --overdue lists OPEN, past-deadline items; the status-widening flags
-      // pull in completed/canceled/trashed rows, so the combination is
-      // contradictory (like --untagged with --tag).
-      if (overdue && (opts["logged"] === true || opts["trashed"] === true || all)) {
-        usageError({ json }, "--overdue does not combine with --logged/--trashed/--all");
+      // Tag-conflict AND the --overdue/status-widening incompatibility both
+      // derive from the shared contract (search: statusWidening = true) —
+      // --overdue lists OPEN, past-deadline items, so combining it with the
+      // completed/canceled/trashed-widening flags is contradictory.
+      const validated = validateViewArgs(
+        "search",
+        {
+          ...tagFlags,
+          overdue,
+          logged: opts["logged"] === true,
+          trashed: opts["trashed"] === true,
+          all,
+        },
+        {
+          untaggedConflict: "--untagged does not combine with --tag/--exact-tag",
+          overdueRejected: "--overdue does not apply to search",
+          overdueStatusWiden: "--overdue does not combine with --logged/--trashed/--all",
+        },
+      );
+      if (!validated.ok) {
+        usageError({ json }, validated.message);
         return;
       }
       const limitOpt = opts["limit"] as string | undefined;
@@ -1065,8 +1086,7 @@ export function registerReadCommands(program: Command): void {
             limit: lim.limit,
             ...(opts["project"] !== undefined && { project: opts["project"] as string }),
             ...(opts["area"] !== undefined && { area: opts["area"] as string }),
-            ...tagFilterFields(tagFlags),
-            ...(overdue && { overdue: true }),
+            ...validated.filter,
             ...(type !== undefined && { type: type === "todo" ? "to-do" : "project" }),
             ...(opts["logged"] === true && { logged: true }),
             ...(opts["trashed"] === true && { trashed: true }),

--- a/src/cli/commands/repeat-flags.ts
+++ b/src/cli/commands/repeat-flags.ts
@@ -14,7 +14,7 @@ import type {
   Weekday,
   WeekdayOrdinal,
   YearlyAnchor,
-} from "../../write/operations.ts";
+} from "../../index.ts";
 
 /** The extended fields (everything a rule carries beyond uuid/frequency/interval). */
 export type RepeatRuleFlagFields = Omit<RepeatRuleParams, "uuid" | "frequency" | "interval">;

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -11,8 +11,13 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Command } from "commander";
 
-import { readShortcutProxies, type ShortcutsState } from "../../write/availability.ts";
-import { ExitCode, okEnvelope, type EnvelopeMeta } from "../../contracts.ts";
+import {
+  ExitCode,
+  okEnvelope,
+  shortcutProxies,
+  type EnvelopeMeta,
+  type ShortcutsState,
+} from "../../index.ts";
 
 /** Package root — one level above src/ AND dist/, so both layouts resolve. */
 const SHORTCUTS_DIR = fileURLToPath(new URL("../../../shortcuts", import.meta.url));
@@ -68,7 +73,7 @@ export function registerSetup(program: Command): void {
     .option("--json", "emit versioned JSON envelope on stdout")
     .action((opts: { check?: boolean; json?: boolean }) => {
       const started = Date.now();
-      const state = readShortcutProxies();
+      const state = shortcutProxies();
       const opened: string[] = [];
       let exitCode: number = ExitCode.Ok;
       let detail = state.detail;

--- a/src/cli/commands/show.ts
+++ b/src/cli/commands/show.ts
@@ -7,13 +7,16 @@
  */
 import { type Command, Option } from "commander";
 
-import type { AnyTask } from "../../model/entities.ts";
-import type { AreaView } from "../../read/area-view.ts";
-import type { ProjectView } from "../../read/project-view.ts";
-import type { ShowTarget } from "../../read/show-target.ts";
-import type { GroupedLimits } from "../../read/sections.ts";
-import { stripThingsUri } from "../../read/queries.ts";
-import { AREA_PREVIEW_LIMIT, GROUPED_ALL_DESC } from "../../surface-copy.ts";
+import {
+  AREA_PREVIEW_LIMIT,
+  GROUPED_ALL_DESC,
+  stripThingsUri,
+  type AnyTask,
+  type AreaView,
+  type GroupedLimits,
+  type ProjectView,
+  type ShowTarget,
+} from "../../index.ts";
 import {
   getInvocation,
   OPEN_KEYWORDS,

--- a/src/cli/commands/snapshot.ts
+++ b/src/cli/commands/snapshot.ts
@@ -5,7 +5,7 @@
  */
 import type { Command } from "commander";
 
-import type { Snapshot } from "../../read/snapshot.ts";
+import type { Snapshot } from "../../index.ts";
 import { withClient } from "../read-driver.ts";
 
 function renderCounts(snapshot: Snapshot): string[] {

--- a/src/cli/commands/todo.ts
+++ b/src/cli/commands/todo.ts
@@ -4,9 +4,7 @@
  */
 import type { Command } from "commander";
 
-import type { AnyTask } from "../../model/entities.ts";
-import { localToday } from "../../model/dates.ts";
-import { templateStatus } from "../../model/recurrence.ts";
+import { localToday, templateStatus, type AnyTask } from "../../index.ts";
 import { blue, bold, dim, green, red } from "../style.ts";
 import {
   deadlineDetail,

--- a/src/cli/commands/writes.ts
+++ b/src/cli/commands/writes.ts
@@ -9,34 +9,37 @@ import type { Command } from "commander";
 
 import { readFileSync } from "node:fs";
 
-import { openThings, type ThingsClient } from "../../client.ts";
-import { saveConfigKey, type DisruptionTier } from "../../config.ts";
-import { ThingsDbNotFoundError } from "../../db/locate.ts";
-import { ThingsDbOpenError } from "../../db/connection.ts";
-import type {
-  OperationKind,
-  RepeatFrequency,
-  ReorderScope,
-  ReorderStrategy,
-} from "../../write/operations.ts";
 import { addRepeatRuleFlags, repeatRuleFlagsFromOpts } from "./repeat-flags.ts";
-import type { WriteOptions } from "../../write/pipeline.ts";
-import { capabilitiesTable } from "../../write/capabilities.ts";
-import { outcomeFailed, type BatchItemResult, type BatchOp } from "../../write/batch.ts";
-import { BOUNCE_MAX_ITEMS, type ReorderResult } from "../../write/reorder.ts";
-import type { UndoItemResult } from "../../write/undo.ts";
-import type { VectorId } from "../../write/vectors/types.ts";
-
 import {
   aggregateExitCode,
   blockedCode,
+  BOUNCE_MAX_ITEMS,
+  capabilitiesTable,
   errorEnvelope,
   ExitCode,
   okEnvelope,
+  openThings,
+  outcomeFailed,
+  ReferenceResolutionError,
+  saveConfigKey,
+  splitWhenSugar,
+  ThingsDbNotFoundError,
+  ThingsDbOpenError,
   verifyFailedCode,
+  type BatchItemResult,
+  type BatchOp,
+  type DisruptionTier,
   type EnvelopeMeta,
-} from "../../contracts.ts";
-import { ReferenceResolutionError, splitWhenSugar } from "../../index.ts";
+  type OperationKind,
+  type ReorderResult,
+  type ReorderScope,
+  type ReorderStrategy,
+  type RepeatFrequency,
+  type ThingsClient,
+  type UndoItemResult,
+  type VectorId,
+  type WriteOptions,
+} from "../../index.ts";
 import { usageError } from "../read-driver.ts";
 
 interface WriteFlagOpts {

--- a/src/cli/commands/writes.ts
+++ b/src/cli/commands/writes.ts
@@ -36,7 +36,7 @@ import {
   verifyFailedCode,
   type EnvelopeMeta,
 } from "../../contracts.ts";
-import { ReferenceResolutionError } from "../../read/queries.ts";
+import { ReferenceResolutionError, splitWhenSugar } from "../../index.ts";
 import { usageError } from "../read-driver.ts";
 
 interface WriteFlagOpts {
@@ -125,22 +125,17 @@ function collect(value: string, previous: string[]): string[] {
 
 /**
  * URL-style `--when DATE@TIME` sugar: splits into when + reminder for the
- * ops that take both (an explicit --reminder alongside the suffix errors).
+ * ops that take both (an explicit --reminder alongside the suffix errors). The
+ * `@` split and its usage copy are the shared {@link splitWhenSugar} core; this
+ * only mutates the parsed opts on a successful split.
  */
 function applyWhenSugar(opts: Record<string, unknown>): string | null {
-  const when = opts["when"];
-  if (typeof when !== "string" || !when.includes("@")) return null;
-  const at = when.indexOf("@");
-  const date = when.slice(0, at);
-  const time = when.slice(at + 1);
-  if (date === "" || time === "" || time.includes("@")) {
-    return `invalid --when "${when}" — expected today | evening | anytime | someday | YYYY-MM-DD (set a reminder with --reminder HH:mm)`;
+  const r = splitWhenSugar(opts["when"], opts["reminder"] !== undefined);
+  if (r.kind === "error") return r.message;
+  if (r.kind === "split") {
+    opts["when"] = r.when;
+    opts["reminder"] = r.reminder;
   }
-  if (opts["reminder"] !== undefined) {
-    return `--when "${when}" carries an @time suffix and --reminder was also given — use one`;
-  }
-  opts["when"] = date;
-  opts["reminder"] = time;
   return null;
 }
 

--- a/src/cli/did-you-mean.ts
+++ b/src/cli/did-you-mean.ts
@@ -7,7 +7,7 @@
  * suggestion, and — under `--json` — stamps the candidates onto
  * `error.details.candidates` so an agent can self-correct.
  */
-import type { LiteCandidate, LiteSearchResult, ListItem } from "../read/views.ts";
+import type { LiteCandidate, LiteSearchResult, ListItem } from "../index.ts";
 import { dim } from "./style.ts";
 import { areaMark } from "./glyphs.ts";
 import { formatItem, uuidDisplayWidth } from "./render.ts";

--- a/src/cli/glyphs.ts
+++ b/src/cli/glyphs.ts
@@ -8,7 +8,7 @@
  * Every glyph lives here so a cross-terminal rendering audit
  * (docs/roadmap.md) can retune the language in one file.
  */
-import type { Project, TagRef, Todo } from "../model/entities.ts";
+import type { Project, TagRef, Todo } from "../index.ts";
 import { blue, bold, brightBlue, dim, green, red, strike, underline, yellow } from "./style.ts";
 
 const MONTHS = [

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -15,8 +15,7 @@
  */
 import type { Command } from "commander";
 
-import { PKG_VERSION } from "../contracts.ts";
-import { ExitCode } from "../contracts.ts";
+import { ExitCode, PKG_VERSION } from "../index.ts";
 
 /** One command's index line: its argument sketch and its ≤58-char descriptor. */
 interface IndexEntry {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -23,7 +23,7 @@ import { registerWriteCommands } from "./commands/writes.ts";
 import { resolveInvocation } from "./resolve-invocation.ts";
 import { runVerbHint } from "./verb-hint.ts";
 import { resolveWidth, setFitWidth } from "./width.ts";
-import { ExitCode, PKG_VERSION } from "../contracts.ts";
+import { ExitCode, PKG_VERSION } from "../index.ts";
 
 export function buildProgram(): Command {
   const program = new Command();

--- a/src/cli/read-driver.ts
+++ b/src/cli/read-driver.ts
@@ -12,7 +12,7 @@ import { getInvocation } from "./resolve-invocation.ts";
 import { dim } from "./style.ts";
 import { viewHeaderLines } from "./render.ts";
 import { candidatesJson, DidYouMeanError, renderDidYouMean } from "./did-you-mean.ts";
-import { ReferenceResolutionError } from "../read/queries.ts";
+import { ReferenceResolutionError } from "../index.ts";
 import {
   errorEnvelope,
   ExitCode,

--- a/src/cli/read-driver.ts
+++ b/src/cli/read-driver.ts
@@ -5,24 +5,26 @@
  * cap parsing and the invocation-echo helpers every read command reuses. No
  * commander dependency — command registration lives in the command modules.
  */
-import { openThings, type ThingsClient } from "../client.ts";
-import { ThingsDbNotFoundError } from "../db/locate.ts";
-import { ThingsDbOpenError } from "../db/connection.ts";
 import { getInvocation } from "./resolve-invocation.ts";
 import { dim } from "./style.ts";
 import { viewHeaderLines } from "./render.ts";
 import { candidatesJson, DidYouMeanError, renderDidYouMean } from "./did-you-mean.ts";
-import { ReferenceResolutionError } from "../index.ts";
 import {
+  DEFAULT_LIST_LIMIT,
   errorEnvelope,
   ExitCode,
   okEnvelope,
+  omitEmpty,
+  openThings,
+  ReferenceResolutionError,
+  schemaWarnings,
+  ThingsDbNotFoundError,
+  ThingsDbOpenError,
   type EnvelopeMeta,
   type GroupedTruncation,
+  type ThingsClient,
   type Truncation,
-} from "../contracts.ts";
-import { omitEmpty } from "../model/serialize.ts";
-import { DEFAULT_LIST_LIMIT, schemaWarnings } from "../surface-copy.ts";
+} from "../index.ts";
 
 export interface GlobalReadOpts {
   json?: boolean;

--- a/src/cli/render.ts
+++ b/src/cli/render.ts
@@ -9,12 +9,16 @@
  */
 import {
   isTodayMember,
+  localToday,
+  partitionSomedaySection,
+  splitSectionBlocks,
+  templateStatus,
+  type GroupedLimits,
   type ListItem,
+  type Project,
   type SidebarSection,
   type TodayView,
-} from "../read/views.ts";
-import { localToday } from "../model/dates.ts";
-import { templateStatus } from "../model/recurrence.ts";
+} from "../index.ts";
 import { bold, dim, strike, underline } from "./style.ts";
 import {
   areaMark,
@@ -33,13 +37,7 @@ import {
   todayStar,
   todoBox,
 } from "./glyphs.ts";
-import {
-  partitionSomedaySection,
-  splitSectionBlocks,
-  type GroupedLimits,
-} from "../read/sections.ts";
 import { FULL_MONTHS, upcomingBucket } from "./period.ts";
-import type { Project } from "../model/entities.ts";
 import {
   fitRow,
   getFitWidth,

--- a/src/cli/tag-filters.ts
+++ b/src/cli/tag-filters.ts
@@ -15,7 +15,13 @@
  */
 import type { Command } from "commander";
 
-import type { ViewFilter } from "../read/views.ts";
+import {
+  hasTagPresence as hasTagPresenceShared,
+  tagFilterFields as tagFilterFieldsShared,
+  tagFlagConflict as tagFlagConflictShared,
+  type TagPresence,
+  type ViewFilter,
+} from "../index.ts";
 import { shellQuote, usageError } from "./read-driver.ts";
 
 /** Commander repeatable-collect: accumulate each `--tag` value. */
@@ -43,8 +49,12 @@ export const CONTAINER_TAG_HINT =
   "inherited from this container (every child inherits them). --exact-tag still\n" +
   "drops hierarchy descendants.";
 
-/** The parsed shape of the three tag-filter flags on any tag-accepting view. */
-export interface TagFlags {
+/**
+ * The parsed shape of the three tag-filter flags on any tag-accepting view.
+ * A structural subtype of the shared {@link TagPresence}, so the CLI's parsed
+ * commander options feed the shared predicates without adaptation.
+ */
+export interface TagFlags extends TagPresence {
   tag?: string[];
   exactTag?: boolean;
   untagged?: boolean;
@@ -59,18 +69,17 @@ export function addTagFilterOptions(cmd: Command): Command {
 }
 
 /** True when any tag-PRESENCE flag was passed (a positive filter, not a negation). */
-export function hasTagPresence(opts: TagFlags): boolean {
-  return (opts.tag?.length ?? 0) > 0 || opts.exactTag === true;
-}
+export const hasTagPresence = hasTagPresenceShared;
 
 /**
  * Shared usage guard for the tag-filter flags. The negation (`--untagged`)
  * inverts a tag presence, so it does not combine with a tag-presence flag.
  * Emits the usage error (the view's conflict style) and returns true when it
- * fires.
+ * fires. The predicate is the shared {@link tagFlagConflictShared}; only the
+ * CLI-voiced copy and the `--json`-aware emit stay here.
  */
 export function tagFlagConflict(opts: TagFlags & { json?: boolean }): boolean {
-  if (opts.untagged === true && hasTagPresence(opts)) {
+  if (tagFlagConflictShared(opts)) {
     usageError(opts, "--untagged does not combine with --tag/--exact-tag");
     return true;
   }
@@ -79,11 +88,7 @@ export function tagFlagConflict(opts: TagFlags & { json?: boolean }): boolean {
 
 /** The ViewFilter tag fields built from the parsed flags (empty keys omitted). */
 export function tagFilterFields(opts: TagFlags): ViewFilter {
-  return {
-    ...(opts.tag !== undefined && opts.tag.length > 0 && { tags: opts.tag }),
-    ...(opts.exactTag === true && { exactTag: true }),
-    ...(opts.untagged === true && { untagged: true }),
-  };
+  return tagFilterFieldsShared(opts);
 }
 
 /** The invocation-echo fragments for the tag flags (one `--tag <ref>` per ref). */

--- a/src/cli/verb-hint.ts
+++ b/src/cli/verb-hint.ts
@@ -19,8 +19,7 @@
  */
 import type { Command } from "commander";
 
-import { openThings } from "../client.ts";
-import { errorEnvelope, ExitCode, type EnvelopeMeta } from "../contracts.ts";
+import { errorEnvelope, ExitCode, openThings, type EnvelopeMeta } from "../index.ts";
 import { indexPastLeadingFlags, subcommandsOf, WRITE_GROUP_ORDER } from "./resolve-invocation.ts";
 import { shellQuote } from "./shell-quote.ts";
 

--- a/src/diagnose.ts
+++ b/src/diagnose.ts
@@ -217,6 +217,16 @@ export interface DiagnoseResult {
   meta: Pick<EnvelopeMeta, "dbVersion" | "fingerprint">;
 }
 
+/**
+ * Which bundled Apple Shortcuts proxies are installed — a standalone
+ * environment accessor that needs no database (the shortcuts probe is a pure
+ * host check). The public capability behind `things setup shortcuts`; the full
+ * {@link diagnose} report carries the same state under `availability.shortcuts`.
+ */
+export function shortcutProxies(deps: AvailabilityDeps = {}): ShortcutsState {
+  return readShortcutProxies(deps);
+}
+
 export function diagnose(dbPath?: string, options: DiagnoseOptions = {}): DiagnoseResult {
   let located: ReturnType<typeof locateThingsDb>;
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,9 +198,15 @@ export type {
 export { shortcutProxies } from "./diagnose.ts";
 export type { ShortcutsState } from "./write/availability.ts";
 
-// The MCP server is itself a CONSUMER of this barrel (it imports from
-// ../index.ts), so its re-export MUST come last: evaluated after every symbol
-// above is bound, the index↔mcp import cycle resolves without a temporal
-// dead-zone on the eval-time schema constants (surface-copy) it references.
-export { createThingsMcpServer } from "./mcp/server.ts";
+// The MCP server is a CONSUMER surface (like the CLI), not part of the client
+// library API — and its module eagerly imports zod + the MCP SDK. Expose it
+// through a LAZY loader so importing this barrel never drags those heavyweight
+// deps into a consumer's eager graph (the CLI guest bundle ships neither, and
+// they must stay lazily imported from the `things mcp` action). zod/the SDK
+// load only when the server is actually constructed. The `type` re-export is
+// erased at runtime, so it adds no eager dependency. See
+// docs/design/architecture.md (Consumer boundary).
 export type { McpServerOptions } from "./mcp/server.ts";
+export function loadMcpServer(): Promise<typeof import("./mcp/server.ts")> {
+  return import("./mcp/server.ts");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,8 +40,6 @@ export type { FailureHint, LikelyCause } from "./write/failure-hints.ts";
 export { capabilitiesTable } from "./write/capabilities.ts";
 export type { CapabilityEntry } from "./write/capabilities.ts";
 export { saveConfigKey } from "./config.ts";
-export { createThingsMcpServer } from "./mcp/server.ts";
-export type { McpServerOptions } from "./mcp/server.ts";
 export type { UndoItemResult, UndoOptions, UndoPlan, UndoStep } from "./write/undo.ts";
 export type { BatchItemResult, BatchOp, BatchOptions } from "./write/batch.ts";
 export type { ReorderResult } from "./write/reorder.ts";
@@ -148,5 +146,61 @@ export { ThingsDbNotFoundError } from "./db/locate.ts";
 export { ThingsDbOpenError } from "./db/connection.ts";
 export type { Baseline, FingerprintStatus, SchemaObservation } from "./db/fingerprint.ts";
 
-export { API_VERSION, ExitCode, PKG_VERSION } from "./contracts.ts";
+export {
+  aggregateExitCode,
+  API_VERSION,
+  blockedCode,
+  errorEnvelope,
+  ExitCode,
+  okEnvelope,
+  PKG_VERSION,
+  verifyFailedCode,
+} from "./contracts.ts";
 export type { Envelope, EnvelopeMeta, ErrorEnvelope, OkEnvelope } from "./contracts.ts";
+
+// ---------------------------------------------------------------------------
+// Consumer-surface support: everything below is exported so the CLI and MCP
+// server can consume it through this one entry point (the air-gap boundary,
+// docs/design/architecture.md). None of it reaches back into surface code.
+// ---------------------------------------------------------------------------
+
+// Consumer-facing shared copy (parameter vocabulary + read-path advisory).
+export * from "./surface-copy.ts";
+
+// Pure model/read helpers the presentation layers reuse.
+export { omitEmpty } from "./model/serialize.ts";
+export { localToday } from "./model/dates.ts";
+export { templateStatus } from "./model/recurrence.ts";
+export { isTodayMember } from "./read/views.ts";
+export type { LiteCandidate, LiteSearchResult } from "./read/views.ts";
+export { partitionSomedaySection, splitSectionBlocks } from "./read/sections.ts";
+export type { GroupedLimits } from "./read/sections.ts";
+export { noUuidMatch, stripThingsUri } from "./read/queries.ts";
+export type { Snapshot } from "./read/snapshot.ts";
+export type { ShowTarget } from "./read/show-target.ts";
+export type { ChecklistEdit } from "./client.ts";
+export type { TagRef } from "./model/entities.ts";
+
+// Write-path values/types the surfaces render or gate on.
+export { outcomeFailed } from "./write/batch.ts";
+export { BOUNCE_MAX_ITEMS } from "./write/reorder.ts";
+export type {
+  MonthlyAnchor,
+  RepeatFrequency,
+  RepeatRuleParams,
+  Weekday,
+  WeekdayOrdinal,
+  YearlyAnchor,
+} from "./write/operations.ts";
+
+// Shortcut-proxy availability: a proper library accessor (setup consumes it
+// without opening a database). See shortcutProxies in diagnose.ts.
+export { shortcutProxies } from "./diagnose.ts";
+export type { ShortcutsState } from "./write/availability.ts";
+
+// The MCP server is itself a CONSUMER of this barrel (it imports from
+// ../index.ts), so its re-export MUST come last: evaluated after every symbol
+// above is bound, the index↔mcp import cycle resolves without a temporal
+// dead-zone on the eval-time schema constants (surface-copy) it references.
+export { createThingsMcpServer } from "./mcp/server.ts";
+export type { McpServerOptions } from "./mcp/server.ts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,27 @@ export type {
   ChangedItem,
 } from "./read/views.ts";
 
+// The per-view read-filter contract: the declarative applicability table plus
+// the shared tag-conflict predicates both surfaces enforce. See
+// docs/design/architecture.md (Consumer boundary).
+export {
+  FILTER_CONTRACT,
+  hasTagPresence,
+  tagFlagConflict,
+  tagFilterFields,
+  validateViewArgs,
+} from "./read/filter-contract.ts";
+export type {
+  BoundModel,
+  FilterArgs,
+  FilterVocab,
+  TagPresence,
+  TagSemantics,
+  ViewFilterSpec,
+  ViewName,
+  ViewValidation,
+} from "./read/filter-contract.ts";
+
 export type {
   Acknowledgements,
   AreaAddParams,

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,6 +133,17 @@ export type { ListItem, SidebarSection, TodayView } from "./read/views.ts";
 export type { ProjectView } from "./read/project-view.ts";
 export type { AreaView } from "./read/area-view.ts";
 export { ProjectNotFoundError } from "./read/project-view.ts";
+
+// Reference resolution: the stable public error a uuid/partial-uuid/name raises
+// when it resolves to zero or several entities, carrying the machine shape the
+// CLI --json envelope and MCP tool errors surface (code + candidates).
+export { ReferenceResolutionError } from "./read/queries.ts";
+export type { RefCandidate } from "./read/queries.ts";
+
+// The shared `<when>@<time>` scheduling sugar parser (CLI + MCP).
+export { splitWhenSugar, CLI_WHEN_LABELS, MCP_WHEN_LABELS } from "./model/when-sugar.ts";
+export type { WhenSugar, WhenSugarLabels } from "./model/when-sugar.ts";
+
 export { ThingsDbNotFoundError } from "./db/locate.ts";
 export { ThingsDbOpenError } from "./db/connection.ts";
 export type { Baseline, FingerprintStatus, SchemaObservation } from "./db/fingerprint.ts";

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -25,6 +25,15 @@ import {
   type Truncation,
 } from "../contracts.ts";
 import { diagnose } from "../diagnose.ts";
+import {
+  FILTER_CONTRACT,
+  hasTagPresence,
+  tagFilterFields,
+  tagFlagConflict,
+  validateViewArgs,
+  type TagPresence,
+  type ViewName,
+} from "../index.ts";
 import { noUuidMatch, ReferenceResolutionError } from "../read/queries.ts";
 import {
   ALL_DESC,
@@ -253,31 +262,23 @@ interface TagArgs {
   untagged?: boolean | undefined;
 }
 
-/** True when any tag-PRESENCE input was passed (a positive filter, not a negation). */
-function hasTagPresence(args: TagArgs): boolean {
-  return (args.tag?.length ?? 0) > 0 || args.exact_tag === true;
-}
-
 /**
- * The tag-filter mutual-exclusivity guard: the `untagged` negation inverts a
- * presence, so it does not combine with a tag-presence input. Returns the usage
- * message when incoherent, else null.
+ * Map the MCP tool's snake_case tag inputs onto the shared {@link TagPresence}
+ * shape (canonical CLI-flag spelling) so the one set of contract predicates —
+ * {@link hasTagPresence}, {@link tagFlagConflict}, {@link tagFilterFields},
+ * {@link validateViewArgs} — serves both surfaces. The only difference is
+ * `exact_tag` → `exactTag`.
  */
-function tagFlagConflict(args: TagArgs): string | null {
-  if (args.untagged === true && hasTagPresence(args)) {
-    return "untagged does not combine with tag/exact_tag";
-  }
-  return null;
-}
-
-/** Map the tag-filter inputs into the ViewFilter tag fields (empty keys omitted). */
-function tagFilterFromArgs(args: TagArgs): Record<string, unknown> {
+function tagPresence(args: TagArgs): TagPresence {
   return {
-    ...(args.tag !== undefined && args.tag.length > 0 && { tags: args.tag }),
-    ...(args.exact_tag === true && { exactTag: true }),
-    ...(args.untagged === true && { untagged: true }),
+    ...(args.tag !== undefined && { tag: args.tag }),
+    ...(args.exact_tag !== undefined && { exactTag: args.exact_tag }),
+    ...(args.untagged !== undefined && { untagged: args.untagged }),
   };
 }
+
+/** The MCP-voiced usage copy for the tag-filter mutual-exclusivity conflict. */
+const MCP_UNTAGGED_CONFLICT = "untagged does not combine with tag/exact_tag";
 
 const dryRunShape = {
   dry_run: z.boolean().optional().describe("Preview the planned change without applying anything"),
@@ -559,8 +560,19 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
     },
     async (args) =>
       readGuard(() => {
-        const tagConflict = tagFlagConflict(args);
-        if (tagConflict !== null) return usage(tagConflict);
+        // Tag-conflict AND overdue-applicability both derive from the shared
+        // contract: read_view honors overdue only on today/inbox/anytime/someday
+        // (the current-work views), matching FILTER_CONTRACT.
+        const validated = validateViewArgs(
+          args.view as ViewName,
+          { ...tagPresence(args), overdue: args.overdue },
+          {
+            untaggedConflict: MCP_UNTAGGED_CONFLICT,
+            overdueRejected: `overdue applies to today/inbox/anytime/someday, not ${args.view}`,
+            overdueStatusWiden: "",
+          },
+        );
+        if (!validated.ok) return usage(validated.message);
         // show_active_project_items is the preferred name; active_project_items
         // stays accepted as a compatibility alias.
         const showActiveProjectItems = args.show_active_project_items ?? args.active_project_items;
@@ -580,17 +592,6 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
         if (args.view !== "today" && args.evening === true) {
           return usage(`evening applies only to today, not ${args.view}`);
         }
-        // --overdue is a current-work content scope: the forward-looking
-        // `upcoming` and the closed-item `logbook`/`trash` do not accept it.
-        if (
-          args.overdue === true &&
-          args.view !== "today" &&
-          args.view !== "inbox" &&
-          args.view !== "anytime" &&
-          args.view !== "someday"
-        ) {
-          return usage(`overdue applies to today/inbox/anytime/someday, not ${args.view}`);
-        }
         if (args.view === "someday" && args.project_limit !== undefined) {
           return usage(
             "project_limit does not apply to someday — pass a number as show_active_project_items " +
@@ -605,10 +606,7 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
           return usage("pass at most one of area_limit/project_limit / all");
         }
         const c = getClient();
-        const filter = {
-          ...tagFilterFromArgs(args),
-          ...(args.overdue === true && { overdue: true }),
-        };
+        const filter = validated.filter;
         switch (args.view) {
           case "today": {
             const { view, truncation } = c.read.today({
@@ -694,20 +692,30 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
     },
     async (args) =>
       readGuard(() => {
-        const tagConflict = tagFlagConflict(args);
-        if (tagConflict !== null) return usage(tagConflict);
-        if (
-          args.overdue === true &&
-          (args.logged === true || args.trashed === true || args.all === true)
-        ) {
-          return usage("overdue lists open items; it does not combine with logged/trashed/all");
-        }
+        // Tag-conflict AND the overdue/status-widening incompatibility both
+        // derive from the shared contract (search: statusWidening = true).
+        const validated = validateViewArgs(
+          "search",
+          {
+            ...tagPresence(args),
+            overdue: args.overdue,
+            logged: args.logged,
+            trashed: args.trashed,
+            all: args.all,
+          },
+          {
+            untaggedConflict: MCP_UNTAGGED_CONFLICT,
+            overdueRejected: "overdue does not apply to search",
+            overdueStatusWiden:
+              "overdue lists open items; it does not combine with logged/trashed/all",
+          },
+        );
+        if (!validated.ok) return usage(validated.message);
         const limit = resolveLimit(args);
         if (limit === "conflict") return usage("pass at most one of limit / all");
         const { items, truncation } = getClient().read.search(args.query, {
           limit,
-          ...tagFilterFromArgs(args),
-          ...(args.overdue === true && { overdue: true }),
+          ...validated.filter,
           ...(args.project !== undefined && { project: args.project }),
           ...(args.area !== undefined && { area: args.area }),
           ...(args.type !== undefined && { type: args.type }),
@@ -788,12 +796,11 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
     },
     async (args) =>
       readGuard(() => {
-        const tagConflict = tagFlagConflict(args);
-        if (tagConflict !== null) return usage(tagConflict);
+        if (tagFlagConflict(tagPresence(args))) return usage(MCP_UNTAGGED_CONFLICT);
         return readResult(
           getClient().read.projectView(args.uuid, {
             overdue: args.overdue === true,
-            ...tagFilterFromArgs(args),
+            ...tagFilterFields(tagPresence(args)),
           }),
         );
       }),
@@ -836,8 +843,7 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
     },
     async (args) =>
       readGuard(() => {
-        const tagConflict = tagFlagConflict(args);
-        if (tagConflict !== null) return usage(tagConflict);
+        if (tagFlagConflict(tagPresence(args))) return usage(MCP_UNTAGGED_CONFLICT);
         const areaLimit = resolveCap(args.area_limit, args.all, AREA_PREVIEW_LIMIT);
         const projectLimit = resolveCap(args.project_limit, args.all, AREA_PREVIEW_LIMIT);
         if (areaLimit === "conflict" || projectLimit === "conflict") {
@@ -845,7 +851,7 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
         }
         const { view, grouped } = getClient().read.areaView(args.ref, {
           overdue: args.overdue === true,
-          ...tagFilterFromArgs(args),
+          ...tagFilterFields(tagPresence(args)),
           areaLimit,
           projectLimit,
         });
@@ -878,18 +884,32 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
         const c = getClient();
         // areas/tags are not dated entities and have no per-row tag list to
         // filter — overdue and the tag filters are vacuous there, rejected
-        // fail-closed (the same style read_view uses for the wrong views).
-        if (args.overdue === true && args.kind !== "projects") {
+        // fail-closed (the same style read_view uses for the wrong views). The
+        // decision derives from the contract: only the `projects` list carries
+        // a deadline (overdue) and per-row (inheritance-inclusive) tags; the
+        // `areas` list rejects both, and `tags` has no contract row.
+        const kindSpec =
+          args.kind === "projects"
+            ? FILTER_CONTRACT.projects
+            : args.kind === "areas"
+              ? FILTER_CONTRACT.areas
+              : null;
+        if (args.overdue === true && (kindSpec === null || !kindSpec.overdue)) {
           return usage(`overdue applies only to projects, not ${args.kind}`);
         }
-        if (args.kind !== "projects" && (hasTagPresence(args) || args.untagged === true)) {
+        if (
+          (kindSpec === null || kindSpec.tag === "rejected") &&
+          (hasTagPresence(tagPresence(args)) || args.untagged === true)
+        ) {
           return usage(`the tag filters apply only to projects, not ${args.kind}`);
         }
-        const tagConflict = tagFlagConflict(args);
-        if (tagConflict !== null) return usage(tagConflict);
+        if (tagFlagConflict(tagPresence(args))) return usage(MCP_UNTAGGED_CONFLICT);
         return readResult(
           args.kind === "projects"
-            ? c.read.projects({ overdue: args.overdue === true, ...tagFilterFromArgs(args) })
+            ? c.read.projects({
+                overdue: args.overdue === true,
+                ...tagFilterFields(tagPresence(args)),
+              })
             : args.kind === "areas"
               ? c.read.areas()
               : c.read.tags(),

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -28,13 +28,16 @@ import { diagnose } from "../diagnose.ts";
 import {
   FILTER_CONTRACT,
   hasTagPresence,
+  MCP_WHEN_LABELS,
+  ReferenceResolutionError,
+  splitWhenSugar,
   tagFilterFields,
   tagFlagConflict,
   validateViewArgs,
   type TagPresence,
   type ViewName,
 } from "../index.ts";
-import { noUuidMatch, ReferenceResolutionError } from "../read/queries.ts";
+import { noUuidMatch } from "../read/queries.ts";
 import {
   ALL_DESC,
   AREA_LIMIT_DESC,
@@ -951,14 +954,18 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
       annotations: NON_DESTRUCTIVE,
     },
     async (args) =>
-      guard(async () =>
-        mutationResult(
+      guard(async () => {
+        const sugar = splitWhenSugar(args.when, args.reminder !== undefined, MCP_WHEN_LABELS);
+        if (sugar.kind === "error") return usage(sugar.message);
+        const when = sugar.kind === "split" ? sugar.when : args.when;
+        const reminder = sugar.kind === "split" ? sugar.reminder : args.reminder;
+        return mutationResult(
           await getClient().write.addTodo(
             {
               title: args.title,
               ...(args.notes !== undefined && { notes: args.notes }),
-              ...(args.when !== undefined && { when: args.when as never }),
-              ...(args.reminder !== undefined && { reminder: args.reminder }),
+              ...(when !== undefined && { when: when as never }),
+              ...(reminder !== undefined && { reminder }),
               ...(args.deadline !== undefined && { deadline: args.deadline }),
               ...(args.tags !== undefined && { tags: args.tags }),
               ...(args.checklist_items !== undefined && { checklistItems: args.checklist_items }),
@@ -968,8 +975,8 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
             },
             writeOptions(args),
           ),
-        ),
-      ),
+        );
+      }),
   );
 
   server.registerTool(
@@ -1012,6 +1019,10 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
         if (args.deadline !== undefined && args.clear_deadline === true) {
           return usage("pass at most one of deadline / clear_deadline");
         }
+        const sugar = splitWhenSugar(args.when, args.reminder !== undefined, MCP_WHEN_LABELS);
+        if (sugar.kind === "error") return usage(sugar.message);
+        const when = sugar.kind === "split" ? sugar.when : args.when;
+        const reminder = sugar.kind === "split" ? sugar.reminder : args.reminder;
         return mutationResult(
           await getClient().write.updateTodo(
             args.uuid,
@@ -1020,8 +1031,8 @@ export function createThingsMcpServer(options: McpServerOptions = {}): McpServer
               ...(args.notes !== undefined && { notes: args.notes }),
               ...(args.append_notes !== undefined && { appendNotes: args.append_notes }),
               ...(args.prepend_notes !== undefined && { prependNotes: args.prepend_notes }),
-              ...(args.when !== undefined && { when: args.when as never }),
-              ...(args.reminder !== undefined && { reminder: args.reminder }),
+              ...(when !== undefined && { when: when as never }),
+              ...(reminder !== undefined && { reminder }),
               ...(args.clear_reminder === true && { reminder: null }),
               ...(args.deadline !== undefined && { deadline: args.deadline }),
               ...(args.clear_deadline === true && { deadline: null }),

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -14,58 +14,57 @@
 import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-import { openThings, type ChecklistEdit, type OpenOptions, type ThingsClient } from "../client.ts";
-import type { DisruptionTier } from "../config.ts";
-import { omitEmpty } from "../model/serialize.ts";
-import {
-  blockedCode,
-  PKG_VERSION,
-  verifyFailedCode,
-  type GroupedTruncation,
-  type Truncation,
-} from "../contracts.ts";
-import { diagnose } from "../diagnose.ts";
-import {
-  FILTER_CONTRACT,
-  hasTagPresence,
-  MCP_WHEN_LABELS,
-  ReferenceResolutionError,
-  splitWhenSugar,
-  tagFilterFields,
-  tagFlagConflict,
-  validateViewArgs,
-  type TagPresence,
-  type ViewName,
-} from "../index.ts";
-import { noUuidMatch } from "../read/queries.ts";
 import {
   ALL_DESC,
   AREA_LIMIT_DESC,
   AREA_PREVIEW_LIMIT,
+  blockedCode,
+  BOUNCE_MAX_ITEMS,
+  capabilitiesTable,
   DATE_FORMAT,
   DEFAULT_LIST_LIMIT,
+  diagnose,
+  FILTER_CONTRACT,
+  hasTagPresence,
   LIMIT_DESC,
+  MCP_WHEN_LABELS,
+  noUuidMatch,
+  omitEmpty,
   OMIT_EMPTY_NOTE,
+  OPERATION_KINDS,
+  openThings,
+  PKG_VERSION,
   PROJECT_LIMIT_DESC,
   PROJECT_PREVIEW_LIMIT,
   REF_FORMAT,
+  ReferenceResolutionError,
   REMINDER_FORMAT,
   schemaWarnings,
+  splitWhenSugar,
+  tagFilterFields,
+  tagFlagConflict,
+  validateViewArgs,
+  verifyFailedCode,
   WHEN_VALUES,
-} from "../surface-copy.ts";
-import { capabilitiesTable } from "../write/capabilities.ts";
-import {
-  OPERATION_KINDS,
+  type BatchOp,
+  type ChecklistEdit,
+  type DisruptionTier,
+  type GroupedTruncation,
   type MonthlyAnchor,
+  type MutationResult,
+  type OpenOptions,
   type OperationKind,
   type RepeatFrequency,
   type RepeatRuleParams,
+  type ReorderResult,
+  type TagPresence,
+  type ThingsClient,
+  type Truncation,
+  type ViewName,
   type Weekday,
+  type WriteOptions,
   type YearlyAnchor,
-} from "../write/operations.ts";
-import type { MutationResult, WriteOptions } from "../write/pipeline.ts";
-import { BOUNCE_MAX_ITEMS, type ReorderResult } from "../write/reorder.ts";
-import type { BatchOp } from "../write/batch.ts";
+} from "../index.ts";
 
 export interface McpServerOptions {
   dbPath?: string;

--- a/src/model/when-sugar.ts
+++ b/src/model/when-sugar.ts
@@ -1,0 +1,68 @@
+/**
+ * The `<when>@<time>` scheduling sugar, shared by every consumer surface. A
+ * single string like `2026-07-05@09:00` (or `today@evening`-style keyword +
+ * time) carries BOTH the schedule and its reminder; this splits it into the
+ * separate `when` + `reminder` the write pipeline expects, or reports the one
+ * usage error. Extracted from the CLI so the CLI and MCP validate the suffix
+ * identically instead of each re-deriving it — see docs/design/architecture.md
+ * (Consumer boundary).
+ *
+ * Pure: it neither mutates its input nor validates the DATE/TIME values (the
+ * pipeline does that downstream) — it only owns the `@` split and the two
+ * usage messages. The flag/parameter LABELS are injected so each surface keeps
+ * its own vocabulary (`--when`/`--reminder` vs `when`/`reminder`).
+ */
+
+/** The surface's spelling of the two parameters, interpolated into usage copy. */
+export interface WhenSugarLabels {
+  when: string;
+  reminder: string;
+}
+
+/** CLI flag spellings — the default, since the sugar originated there. */
+export const CLI_WHEN_LABELS: WhenSugarLabels = { when: "--when", reminder: "--reminder" };
+
+/** MCP tool-parameter spellings. */
+export const MCP_WHEN_LABELS: WhenSugarLabels = { when: "when", reminder: "reminder" };
+
+/**
+ * The result of inspecting a `when` value for the `@time` suffix:
+ * - `unchanged` — no suffix; pass `when` through as-is.
+ * - `split` — a valid suffix; use the split `when` + `reminder`.
+ * - `error` — a malformed suffix, or a suffix given ALONGSIDE a separate
+ *   reminder; emit `message` as a usage error.
+ */
+export type WhenSugar =
+  | { kind: "unchanged" }
+  | { kind: "split"; when: string; reminder: string }
+  | { kind: "error"; message: string };
+
+/**
+ * Split a `when` value on its `@time` suffix. `reminderProvided` reflects
+ * whether the caller ALSO passed a separate reminder — a suffix plus an
+ * explicit reminder is ambiguous and rejected. A non-string or suffix-free
+ * `when` is `unchanged`.
+ */
+export function splitWhenSugar(
+  when: unknown,
+  reminderProvided: boolean,
+  labels: WhenSugarLabels = CLI_WHEN_LABELS,
+): WhenSugar {
+  if (typeof when !== "string" || !when.includes("@")) return { kind: "unchanged" };
+  const at = when.indexOf("@");
+  const date = when.slice(0, at);
+  const time = when.slice(at + 1);
+  if (date === "" || time === "" || time.includes("@")) {
+    return {
+      kind: "error",
+      message: `invalid ${labels.when} "${when}" — expected today | evening | anytime | someday | YYYY-MM-DD (set a reminder with ${labels.reminder} HH:mm)`,
+    };
+  }
+  if (reminderProvided) {
+    return {
+      kind: "error",
+      message: `${labels.when} "${when}" carries an @time suffix and ${labels.reminder} was also given — use one`,
+    };
+  }
+  return { kind: "split", when: date, reminder: time };
+}

--- a/src/read/filter-contract.ts
+++ b/src/read/filter-contract.ts
@@ -1,0 +1,191 @@
+/**
+ * The per-view filter contract — the ONE declarative statement of which read
+ * filters each view honors, plus the shared predicates that enforce them. Both
+ * consumer surfaces (CLI commands, MCP tools) derive their per-view guards from
+ * this table instead of hand-coding view lists, so a filter's applicability is
+ * stated once and can never drift between surfaces.
+ *
+ * The table says, per view: whether the `overdue` content scope applies; what
+ * tag semantics the view carries (inheritance-inclusive `inherited`, container-
+ * direct `direct`, or `rejected` where the view has no per-row tags to filter);
+ * the bound model the view truncates under (`flat` row cap, `grouped` per-block
+ * caps, or `none`); and whether the view offers the status-widening flags
+ * (search's logged/trashed/all) that `overdue` refuses to combine with.
+ *
+ * The exact usage-error COPY stays surface-owned (consumer voice differs per
+ * surface — CLI `--tag`, MCP `tag`; docs/design/surface-copy.md): a surface
+ * hands {@link validateViewArgs} its own phrasing via {@link FilterVocab}, and
+ * this module owns only the DECISION of which message applies.
+ */
+import type { ViewFilter } from "./views.ts";
+
+/** Every read view whose filter applicability the contract governs. */
+export type ViewName =
+  | "today"
+  | "inbox"
+  | "anytime"
+  | "someday"
+  | "upcoming"
+  | "logbook"
+  | "trash"
+  | "search"
+  | "changes"
+  | "projects"
+  | "areas"
+  | "project-show"
+  | "area-show";
+
+/**
+ * How a view's tag filter behaves:
+ * - `inherited` — FLAT views: a `--tag` matches direct OR container-inherited
+ *   membership (plus hierarchy descendants).
+ * - `direct` — CONTAINER views (`project show`, `area show`): a `--tag` matches
+ *   a tag carried DIRECTLY on the row (the container's own inherited tags are
+ *   suppressed, since every child inherits them).
+ * - `rejected` — the view has no per-row tag list to filter (an area list row,
+ *   a tag list row, the changes feed); tag flags do not apply.
+ */
+export type TagSemantics = "inherited" | "direct" | "rejected";
+
+/** The truncation model a view bounds under. */
+export type BoundModel = "flat" | "grouped" | "none";
+
+/** One row of {@link FILTER_CONTRACT}: a single view's filter applicability. */
+export interface ViewFilterSpec {
+  /** Whether the `overdue` content scope (open, past-deadline) applies. */
+  readonly overdue: boolean;
+  /** The view's tag-filter semantics. */
+  readonly tag: TagSemantics;
+  /** The bound model the view truncates under. */
+  readonly bound: BoundModel;
+  /**
+   * Whether the view offers the status-widening flags (logged/trashed/all).
+   * Only `search` does; `overdue` refuses to combine with them there.
+   */
+  readonly statusWidening: boolean;
+}
+
+/**
+ * The single source of truth for read-filter applicability, one row per view.
+ * Consumed by both surfaces' per-view guards (CLI command actions, MCP tool
+ * handlers) so no surface hand-maintains its own view list.
+ */
+export const FILTER_CONTRACT: Record<ViewName, ViewFilterSpec> = {
+  // Current-work flat views: overdue applies, tags are inheritance-inclusive.
+  today: { overdue: true, tag: "inherited", bound: "flat", statusWidening: false },
+  inbox: { overdue: true, tag: "inherited", bound: "flat", statusWidening: false },
+  // Grouped catalogues: overdue applies, per-block caps.
+  anytime: { overdue: true, tag: "inherited", bound: "grouped", statusWidening: false },
+  someday: { overdue: true, tag: "inherited", bound: "grouped", statusWidening: false },
+  // Forward-looking / closed-item flat views: overdue deliberately does NOT apply.
+  upcoming: { overdue: false, tag: "inherited", bound: "flat", statusWidening: false },
+  logbook: { overdue: false, tag: "inherited", bound: "flat", statusWidening: false },
+  trash: { overdue: false, tag: "rejected", bound: "flat", statusWidening: false },
+  // Search: overdue applies but refuses the status-widening flags.
+  search: { overdue: true, tag: "inherited", bound: "flat", statusWidening: true },
+  // Sync feed: neither overdue nor tags apply.
+  changes: { overdue: false, tag: "rejected", bound: "flat", statusWidening: false },
+  // Projects LIST is a FLAT view — each project row filtered by its own
+  // (inheritance-inclusive) tags; overdue keeps past-deadline projects.
+  projects: { overdue: true, tag: "inherited", bound: "none", statusWidening: false },
+  // Areas LIST rows carry no deadline and no per-row tag filter.
+  areas: { overdue: false, tag: "rejected", bound: "none", statusWidening: false },
+  // Single-container views: overdue and DIRECT-tag filtering apply to children.
+  "project-show": { overdue: true, tag: "direct", bound: "grouped", statusWidening: false },
+  "area-show": { overdue: true, tag: "direct", bound: "grouped", statusWidening: false },
+};
+
+/**
+ * The three universal tag-filter inputs in their canonical (CLI-flag) spelling.
+ * The CLI's parsed options match this verbatim; the MCP surface maps its
+ * snake_case inputs (`exact_tag`) onto it before calling the shared predicates.
+ */
+export interface TagPresence {
+  tag?: readonly string[] | undefined;
+  exactTag?: boolean | undefined;
+  untagged?: boolean | undefined;
+}
+
+/** True when any tag-PRESENCE flag was passed (a positive filter, not a negation). */
+export function hasTagPresence(a: TagPresence): boolean {
+  return (a.tag?.length ?? 0) > 0 || a.exactTag === true;
+}
+
+/**
+ * True when the tag flags are mutually incoherent: the `untagged` negation
+ * inverts a tag presence, so it does not combine with a tag-presence flag. A
+ * pure predicate — each surface emits its own usage error in its own voice.
+ */
+export function tagFlagConflict(a: TagPresence): boolean {
+  return a.untagged === true && hasTagPresence(a);
+}
+
+/** Build the {@link ViewFilter} tag fields from the parsed flags (empty keys omitted). */
+export function tagFilterFields(a: TagPresence): ViewFilter {
+  return {
+    ...(a.tag !== undefined && a.tag.length > 0 && { tags: [...a.tag] }),
+    ...(a.exactTag === true && { exactTag: true }),
+    ...(a.untagged === true && { untagged: true }),
+  };
+}
+
+/** The parsed read-filter inputs {@link validateViewArgs} inspects. */
+export interface FilterArgs extends TagPresence {
+  overdue?: boolean | undefined;
+  /** search only: the status-widening flags overdue refuses to combine with. */
+  logged?: boolean | undefined;
+  trashed?: boolean | undefined;
+  all?: boolean | undefined;
+}
+
+/**
+ * The surface's exact usage-error copy for each conflict {@link validateViewArgs}
+ * can detect. Built per call by the surface (it knows the view/kind and its own
+ * flag spellings), so the SHARED module decides WHICH message applies while the
+ * message text stays consumer-voiced per surface.
+ */
+export interface FilterVocab {
+  /** `untagged` combined with a tag-presence flag. */
+  untaggedConflict: string;
+  /** `overdue` passed to a view that does not honor it. */
+  overdueRejected: string;
+  /** `overdue` combined with a status-widening flag (search). */
+  overdueStatusWiden: string;
+}
+
+/** {@link validateViewArgs} outcome: the built filter, or the usage message to emit. */
+export type ViewValidation = { ok: true; filter: ViewFilter } | { ok: false; message: string };
+
+/**
+ * Validate a view's filter arguments against {@link FILTER_CONTRACT} and, when
+ * coherent, build the {@link ViewFilter} tag+overdue portion. The checks (and
+ * their precedence) live here so both surfaces stay in lockstep; the surface
+ * supplies its own exact copy via {@link FilterVocab}.
+ *
+ * Does NOT enforce tag-REJECTION (a view refusing tag flags outright): that
+ * lives at the two call sites that currently reject — the areas/projects/tags
+ * collection listers — so this stays a pure no-op for the flat/container views
+ * that merely ignore tags on a sub-path (e.g. `trash`).
+ */
+export function validateViewArgs(
+  view: ViewName,
+  args: FilterArgs,
+  vocab: FilterVocab,
+): ViewValidation {
+  const spec = FILTER_CONTRACT[view];
+  if (tagFlagConflict(args)) return { ok: false, message: vocab.untaggedConflict };
+  if (args.overdue === true && !spec.overdue) {
+    return { ok: false, message: vocab.overdueRejected };
+  }
+  if (
+    args.overdue === true &&
+    spec.statusWidening &&
+    (args.logged === true || args.trashed === true || args.all === true)
+  ) {
+    return { ok: false, message: vocab.overdueStatusWiden };
+  }
+  return {
+    ok: true,
+    filter: { ...tagFilterFields(args), ...(args.overdue === true && { overdue: true }) },
+  };
+}

--- a/src/read/queries.ts
+++ b/src/read/queries.ts
@@ -215,6 +215,11 @@ export interface RefCandidate {
  * it (CLI --json envelope, MCP tool result) additionally lift the structured
  * `candidates` onto `error.details.candidates` so an agent can self-correct
  * without re-parsing the prose message. `code` mirrors the envelope error code.
+ *
+ * PUBLIC API — exported from src/index.ts. This is the one error the consumer
+ * surfaces catch to render structured disambiguation; its `code`
+ * ("not-found" | "ambiguous") and `candidates` ({@link RefCandidate}[]) are the
+ * documented machine shape (docs/design/architecture.md, Consumer boundary).
  */
 export class ReferenceResolutionError extends RangeError {
   readonly code: "not-found" | "ambiguous";

--- a/test/unit/import-boundary.test.ts
+++ b/test/unit/import-boundary.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The air-gap boundary enforcement (docs/design/architecture.md, Consumer
+ * boundary). The CLI and MCP server are pure CONSUMERS of the library: every
+ * relative import that leaves a surface's own directory tree MUST resolve to
+ * exactly src/index.ts — the one public entry point. This statically scans the
+ * two surfaces and fails, naming file:line and the offending specifier, the
+ * moment any file reaches past the barrel into a library internal.
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const SRC = resolve(dirname(fileURLToPath(import.meta.url)), "../../src");
+const INDEX = join(SRC, "index.ts");
+const SURFACES = [join(SRC, "cli"), join(SRC, "mcp")];
+
+/** Every .ts file under a directory tree (recursive). */
+function tsFiles(root: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(root)) {
+    const full = join(root, entry);
+    if (statSync(full).isDirectory()) out.push(...tsFiles(full));
+    else if (entry.endsWith(".ts")) out.push(full);
+  }
+  return out;
+}
+
+/** The relative import/export specifiers in a file, with 1-based line numbers. */
+function relativeSpecifiers(file: string): { line: number; spec: string }[] {
+  const found: { line: number; spec: string }[] = [];
+  // `from "..."` covers both `import … from` and `export … from`; the second
+  // pattern catches dynamic `import("...")`. Only relative specifiers matter.
+  const patterns = [/\bfrom\s+["'](\.[^"']+)["']/g, /\bimport\s*\(\s*["'](\.[^"']+)["']/g];
+  readFileSync(file, "utf8")
+    .split("\n")
+    .forEach((text, i) => {
+      for (const re of patterns) {
+        for (const m of text.matchAll(re)) {
+          if (m[1] !== undefined) found.push({ line: i + 1, spec: m[1] });
+        }
+      }
+    });
+  return found;
+}
+
+describe("consumer boundary (air gap): CLI + MCP import only through src/index.ts", () => {
+  for (const surface of SURFACES) {
+    for (const file of tsFiles(surface)) {
+      const rel = file.slice(SRC.length + 1);
+      it(`${rel} reaches library internals only via src/index.ts`, () => {
+        const violations: string[] = [];
+        for (const { line, spec } of relativeSpecifiers(file)) {
+          const target = resolve(dirname(file), spec);
+          // Intra-surface imports (a sibling file within the same surface tree)
+          // are allowed; anything that leaves the tree must be src/index.ts.
+          const insideSurface = target === surface || target.startsWith(surface + sep);
+          if (insideSurface) continue;
+          if (target === INDEX) continue;
+          violations.push(
+            `${rel}:${line} imports "${spec}" (resolves to ${target.slice(SRC.length + 1)})`,
+          );
+        }
+        expect(violations, violations.join("\n")).toEqual([]);
+      });
+    }
+  }
+});

--- a/test/unit/when-sugar.test.ts
+++ b/test/unit/when-sugar.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { CLI_WHEN_LABELS, MCP_WHEN_LABELS, splitWhenSugar } from "../../src/model/when-sugar.ts";
+
+describe("splitWhenSugar (shared <when>@<time> parser)", () => {
+  it("passes a suffix-free when through unchanged", () => {
+    expect(splitWhenSugar("2026-07-05", false)).toEqual({ kind: "unchanged" });
+    expect(splitWhenSugar("today", false)).toEqual({ kind: "unchanged" });
+    expect(splitWhenSugar(undefined, false)).toEqual({ kind: "unchanged" });
+  });
+
+  it("splits DATE@TIME into when + reminder", () => {
+    expect(splitWhenSugar("2026-07-05@09:00", false)).toEqual({
+      kind: "split",
+      when: "2026-07-05",
+      reminder: "09:00",
+    });
+    expect(splitWhenSugar("today@18:30", false)).toEqual({
+      kind: "split",
+      when: "today",
+      reminder: "18:30",
+    });
+  });
+
+  it("rejects a malformed suffix with the CLI copy by default", () => {
+    const r = splitWhenSugar("2026-07-05@", false);
+    expect(r).toEqual({
+      kind: "error",
+      message:
+        'invalid --when "2026-07-05@" — expected today | evening | anytime | someday | YYYY-MM-DD (set a reminder with --reminder HH:mm)',
+    });
+    expect(splitWhenSugar("@09:00", false).kind).toBe("error");
+    expect(splitWhenSugar("a@b@c", false).kind).toBe("error");
+  });
+
+  it("rejects a suffix alongside a separately-provided reminder", () => {
+    expect(splitWhenSugar("2026-07-05@09:00", true)).toEqual({
+      kind: "error",
+      message:
+        '--when "2026-07-05@09:00" carries an @time suffix and --reminder was also given — use one',
+    });
+  });
+
+  it("uses the MCP parameter labels when asked", () => {
+    expect(splitWhenSugar("2026-07-05@", false, MCP_WHEN_LABELS)).toEqual({
+      kind: "error",
+      message:
+        'invalid when "2026-07-05@" — expected today | evening | anytime | someday | YYYY-MM-DD (set a reminder with reminder HH:mm)',
+    });
+    expect(splitWhenSugar("today@09:00", true, MCP_WHEN_LABELS)).toEqual({
+      kind: "error",
+      message: 'when "today@09:00" carries an @time suffix and reminder was also given — use one',
+    });
+  });
+
+  it("CLI labels are the default", () => {
+    expect(splitWhenSugar("x@", false)).toEqual(splitWhenSugar("x@", false, CLI_WHEN_LABELS));
+  });
+});


### PR DESCRIPTION
## Phase 2 of the re-architecture: the consumer air gap

The CLI (`src/cli/**`) and MCP server (`src/mcp/**`) become pure **consumers** of the library through **one entry point, `src/index.ts`** — never importing a library internal directly. As ratified: *"the CLI will be just a consumer of the API that could theoretically exist in its own separate package; the client API is a black box."*

Four commits:

1. **feat(read): shared per-view filter contract** — `src/read/filter-contract.ts`: a declarative `FILTER_CONTRACT` table (one row per view: overdue / tag-semantics / bound-model / status-widening), the ONE implementation of the tag-conflict predicates (`hasTagPresence`/`tagFlagConflict`, formerly duplicated in `cli/tag-filters.ts` + `mcp/server.ts`), and `validateViewArgs`. Both surfaces' per-view guards now derive from the table; each keeps its own exact usage copy via a vocab.
2. **feat(core): public error + shared `when` parser** — `ReferenceResolutionError` (+ `RefCandidate`) is now deliberate public API from `index.ts`; the three instanceof-and-format blocks catch the public type. The `--when DATE@TIME` sugar is extracted to `src/model/when-sugar.ts` (`splitWhenSugar`), consumed by both surfaces (MCP `add_todo`/`update_todo` gain the same split).
3. **refactor: sweep every internal import onto the public surface** — all `src/cli/**` + `src/mcp/**` library-internal imports now resolve to `index.ts`. Surface-only presentation (glyphs/width/render/style) stays intra-surface. `readShortcutProxies` becomes a library accessor `shortcutProxies()`.
4. **test + docs: enforce + record** — `test/unit/import-boundary.test.ts` statically enforces the boundary; `docs/design/architecture.md` gains a "Consumer boundary (air gap)" section; `CLAUDE.md` gains the policy line.

### Notable, flagged

- **Public API shift:** the MCP server is a consumer surface that eagerly imports zod + the MCP SDK. Static-re-exporting `createThingsMcpServer` from `index.ts` would drag those into every consumer's eager graph (breaking the guest-bundle lazy-load rule). It is now reached via a **lazy `loadMcpServer()`** accessor on the barrel; `createThingsMcpServer` is no longer a direct named export of `index.ts` (still available on the `mcp/server` module and via `loadMcpServer()`). Tests already imported it directly, so none were affected.
- **Small MCP behavior addition:** MCP `when` now accepts the `DATE@TIME` sugar (previously CLI-only), per "consumed by both".

### Verification

`npm run check` passes by exit code (typecheck + lint + fmt + 1388 tests, incl. 26 new boundary + 6 when-sugar). CLI loads via `bin/things.js`; `loadMcpServer()` constructs a server at runtime. No import cycles reach the eager graph; zod/SDK stay lazy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)