### PR TITLE
fix(test): isoFromToday formats the LOCAL date, not the UTC one

### DIFF
--- a/test/cli/e2e.test.ts
+++ b/test/cli/e2e.test.ts
@@ -38,11 +38,18 @@ const withTty = <T>(value: boolean | undefined, fn: () => T): T => {
   }
 };
 
-/** ISO calendar date `days` from the real today (the CLI uses the real clock). */
+/**
+ * ISO calendar date `days` from the real LOCAL today (the CLI uses the real
+ * clock and computes "today" at local midnight). Formatted from the local
+ * date parts — NOT via toISOString(), which is UTC and yields the wrong
+ * calendar date whenever the local date and the UTC date differ (e.g. any
+ * US-evening run), silently shifting every seeded deadline by a day.
+ */
 function isoFromToday(days: number): string {
   const d = new Date();
   d.setDate(d.getDate() + days);
-  return d.toISOString().slice(0, 10);
+  const p = (n: number): string => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
 }
 
 const titlesOf = (stdout: string): string[] =>


### PR DESCRIPTION
The six --overdue e2e tests fail on any evening-US local run (local date ≠ UTC date) because the seed helper formatted via toISOString(). CI never caught it — UTC runners have local==UTC. Product code is unaffected (the one other toISOString().slice site, occurrences.ts, is deliberate tz-less UTC arithmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCDrYjLDAwAS3uhxi3d4j8