### PR TITLE
fix(test): lint warning in isoFromToday (main is red)

### DIFF
--- a/test/cli/e2e.test.ts
+++ b/test/cli/e2e.test.ts
@@ -48,8 +48,9 @@ const withTty = <T>(value: boolean | undefined, fn: () => T): T => {
 function isoFromToday(days: number): string {
   const d = new Date();
   d.setDate(d.getDate() + days);
-  const p = (n: number): string => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}`;
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${mm}-${dd}`;
 }
 
 const titlesOf = (stdout: string): string[] =>


### PR DESCRIPTION
Follow-up to #189: the nested pad helper tripped consistent-function-scoping under denyWarnings. Full `npm run check` exit 0 locally this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCDrYjLDAwAS3uhxi3d4j8