### PR TITLE
ci: create GitHub Release from CHANGELOG on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Release
-# Publishes to npm when a v* tag is pushed. The full check suite gates the
+# Publishes to npm when a v* tag is pushed, then creates the matching GitHub
+# Release from the tag's CHANGELOG section. The full check suite gates the
 # publish twice: explicitly below (visible in logs, survives a package.json
 # edit) and via the package's own prepublishOnly script.
 on:
@@ -20,6 +21,13 @@ jobs:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
+      - name: Verify tag matches package.json version
+        run: |
+          pkg="v$(node -p 'require("./package.json").version')"
+          if [ "$pkg" != "$GITHUB_REF_NAME" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match package.json $pkg" >&2
+            exit 1
+          fi
       - run: npm run check
       - run: npm run build
       # Trusted publishing: add this repo + workflow as a Trusted Publisher in
@@ -29,3 +37,28 @@ jobs:
       - run: npm publish
         # env:
         #   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # Separate job so the npm-publishing job keeps contents: read.
+  github-release:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Release from CHANGELOG section
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          notes="$(awk -v ver="$version" '$0 ~ "^## " ver " " {flag=1; next} /^## / {flag=0} flag' CHANGELOG.md)"
+          {
+            echo "See [CHANGELOG.md](https://github.com/${GITHUB_REPOSITORY}/blob/main/CHANGELOG.md) for full history."
+            echo
+            echo "$notes"
+          } > /tmp/release-notes.md
+          if [ -z "$notes" ]; then
+            gh release create "$GITHUB_REF_NAME" --verify-tag --title "$GITHUB_REF_NAME" --generate-notes
+          else
+            gh release create "$GITHUB_REF_NAME" --verify-tag --title "$GITHUB_REF_NAME" --notes-file /tmp/release-notes.md
+          fi


### PR DESCRIPTION
## Summary
- The tag-triggered release workflow published to npm but never created a GitHub Release, which is why the releases page stalled at v0.3.0. Adds a `github-release` job that extracts the tag's CHANGELOG section and creates the release automatically (falls back to `--generate-notes` if the section is missing). Runs as a separate job so the npm-publishing job keeps `contents: read`.
- Adds a guard that fails the publish if the pushed tag doesn't match `package.json`'s version, preventing a mislabeled npm publish.
- Releases v0.4.0–v0.10.0 were backfilled manually from their CHANGELOG sections (GitHub orders releases by tag commit date, so they slot in chronologically and v0.10.0 carries the Latest badge).

## Test plan
- YAML validated locally; the awk extraction is the same expression used for the manual backfill of v0.4.0–v0.10.0, verified against all seven sections.
- Will be exercised end-to-end by the next `v*` tag push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEGRrsqzxnQKCz7mAD8U5d