### PR TITLE
docs: redact lab credentials and personal paths; add public-repo safety rail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 
 ## Safety rails (non-negotiable)
 
+- **This is a PUBLIC repository.** Everything committed — code, docs, probe evidence, test fixtures, git history — is visible to anyone who cares to look. Never commit: PII; personal task-manager data (no task titles, project names, notes, or any other content derived from Mike's production Things DB — this includes "example" data and test fixtures, which must be fully synthetic, never copied or paraphrased from the real database); account credentials of ANY kind, ephemeral or otherwise (throwaway lab accounts, disposable inboxes, one-time codes included — record those only in gitignored `lab/artifacts/`). Remember that git history is public too: redacting a file later does not unpublish it, so get it right before committing.
 - Production Things DB (this host): READS ONLY, and only via `scripts/prod-read.sh` (one stable command shape — ad-hoc shapes re-trigger macOS consent). NEVER write to production; never point new binary shapes at the prod container (even `doctor`).
 - Writes go exclusively through official app surfaces (URL scheme / AppleScript / Shortcuts) — never direct SQLite writes. All write probing happens in disposable Tart VMs (`docs/lab/`).
 

--- a/docs/lab/headless-research.md
+++ b/docs/lab/headless-research.md
@@ -81,10 +81,9 @@ None of these is an authoritative "last synced with the server" timestamp — th
 
 **Documented airgap exception (sanctioned).** This probe REQUIRES the sync server, so the airgap step was deliberately skipped: network stayed UP and the guest clock NTP-synced to real time (Mon Jul 13 2026). Preflight verified in-guest that the golden's trial is still valid at the real date — Things launched un-nagged ("5 days left", `A-01-launch.png`), trial expiry ~2026-07-18. Two clones (A, B) of `things-lab-golden-v1`, one at a time (2-VM budget), both signed into a single throwaway account. The host Things app/container was never touched.
 
-**Throwaway account (LIVE — burnable).** Created inside A's Things app via a disposable [mail.tm](https://mail.tm) inbox (readable over HTTPS from the host: `POST /token` → `GET /messages`) + random password, no Apple ID. Credentials recorded in `account-credentials.env`:
-- Things Cloud email `sync2labc9c6ca5c@web-library.net`, password `6s844pso7xwqjpaa` (16 lowercase+digits — vncdo can't type shifted chars).
-- mail.tm inbox password `PQOq8o4s-Y7jSRqi`. Verification: the confirmation mail from `thingscloud@culturedcode.com` carried a 6-digit code (one-time `112780`).
-- **Cleanup state: account is LIVE.** Web account management at `https://cloud.culturedcode.com` is reachable (HTTP 200) but deletion was not automatable headlessly this run. The account is safely burnable — throwaway email (mail.tm inboxes lapse) + recorded random password; both VMs deleted. Left for optional manual web deletion.
+**Throwaway account (burned).** Created inside A's Things app via a disposable [mail.tm](https://mail.tm) inbox (readable over HTTPS from the host: `POST /token` → `GET /messages`) + random password (16 lowercase+digits — vncdo can't type shifted chars), no Apple ID. Credentials were recorded only in `account-credentials.env` (gitignored artifact); the values formerly quoted in this doc have been redacted per the repo-visibility policy in [AGENTS.md](../../AGENTS.md).
+- Verification: the confirmation mail from `thingscloud@culturedcode.com` carried a one-time 6-digit code, fetched via the mail.tm API.
+- **Cleanup state: DELETED (2026-07-16), verified.** The original run's "manual web deletion" premise was wrong — `cloud.culturedcode.com` is not a web UI but the Syncrony sync API, and account deletion is one authenticated call, no email confirmation: `DELETE https://cloud.culturedcode.com/version/1/account/{email}` with header `Authorization: Password {password}` → `202 Accepted`, and the account resource goes `404 NotFound` within seconds (vs `401` for bad credentials on a live account — the 404/401 split is the deletion proof). Evidence: `lab/artifacts/burn-account-20260716-205854/` (gitignored). Endpoint shape per [nicolai86/things-cloud-sdk](https://github.com/nicolai86/things-cloud-sdk) and [disrupted/things-cloud-api](https://github.com/disrupted/things-cloud-api). This is the fast path if the lab ever needs to burn another Things Cloud account. Both probe VMs were deleted at the end of the original run.
 
 ### `BSSyncronyMetadata` — the SYNC1 headline, answered
 
@@ -92,7 +91,7 @@ None of these is an authoritative "last synced with the server" timestamp — th
 
 | key (stable) | decoded value | role |
 |---|---|---|
-| `WrEsQjsPnAqJYj12iDJHh7` | `sync2labc9c6ca5c@web-library.net` | account email |
+| `WrEsQjsPnAqJYj12iDJHh7` | *(account email — redacted)* | account email |
 | `XqhSTrhuoVfTqCeYdmi2H8` | `199f528b-1243-4ebf-8151-1284598cb3da` | account/sync-history UUID (**shared across devices**, not a per-device id) |
 | `5WPYRFuhkhgEcy39zNsbur` | `SYPrepActionNone` | sync-prep action state |
 | **`GryCJ44xPcJG6go5KeTZp1`** | **NSDate double ≈ now** (e.g. `805659262.1` = 2026-07-13 18:14:22 UTC) | **last-sync timestamp — advances on every sync** |

--- a/docs/research/08-resume-and-next-steps.md
+++ b/docs/research/08-resume-and-next-steps.md
@@ -8,24 +8,24 @@ Canonical current copy:
 - `/Volumes/Workspace/Projects/second-brain/docs/ai-gtd-things`
 
 Matching backup copies:
-- `/Users/mike/Projects-backup-2026-04-26/second-brain/docs/ai-gtd-things`
-- `/Users/mike/Desktop/junk/stuff/jank/junk/junk/ai-gtd-things-backup-20260313-183252/ai-gtd-things`
+- `~/Projects-backup-2026-04-26/second-brain/docs/ai-gtd-things`
+- `~/Desktop/junk/stuff/jank/junk/junk/ai-gtd-things-backup-20260313-183252/ai-gtd-things`
 
 Useful transcript/context sources:
-- `/Users/mike/Desktop/pkm-reconstruction/transcripts/01_2026-03-01_second-brain-ai-2026.md`
-- `/Users/mike/Desktop/pkm-reconstruction/transcripts/02_2026-03-02_task-management-discussion.md`
-- `/Users/mike/Desktop/pkm-reconstruction/transcripts/03_2026-03-03_reverse-engineering-things-app.md`
-- `/Users/mike/Desktop/pkm-reconstruction/transcripts/11_2026-03-11_obsidian-things-integration.md`
-- `/Users/mike/Desktop/pkm-reconstruction/transcripts/16_2026-03-13_things-app-automation.md`
-- `/Users/mike/Desktop/pkm-reconstruction/transcripts/17_2026-03-13_macos-virtualization-for-testing.md`
-- `/Users/mike/Desktop/pkm-reconstruction/transcripts/30_2026-03-25_gtd-para-things-alignment.md`
+- `~/Desktop/pkm-reconstruction/transcripts/01_2026-03-01_second-brain-ai-2026.md`
+- `~/Desktop/pkm-reconstruction/transcripts/02_2026-03-02_task-management-discussion.md`
+- `~/Desktop/pkm-reconstruction/transcripts/03_2026-03-03_reverse-engineering-things-app.md`
+- `~/Desktop/pkm-reconstruction/transcripts/11_2026-03-11_obsidian-things-integration.md`
+- `~/Desktop/pkm-reconstruction/transcripts/16_2026-03-13_things-app-automation.md`
+- `~/Desktop/pkm-reconstruction/transcripts/17_2026-03-13_macos-virtualization-for-testing.md`
+- `~/Desktop/pkm-reconstruction/transcripts/30_2026-03-25_gtd-para-things-alignment.md`
 
 Likely original Codex session:
-- `/Users/mike/.codex/sessions/2026/03/02/rollout-2026-03-02T14-01-57-019cb024-a47d-7a91-a7ac-425c580fdb0f.jsonl`
+- `~/.codex/sessions/2026/03/02/rollout-2026-03-02T14-01-57-019cb024-a47d-7a91-a7ac-425c580fdb0f.jsonl`
 
 Provenance note:
-- On 2026-03-13, that session recorded a safety backup at `/Users/mike/Desktop/ai-gtd-things-backup-20260313-183252/ai-gtd-things`, removal of nested git metadata from `/Users/mike/Projects/second-brain/docs/ai-gtd-things/.git`, and top-level commit `004b9f9` (`Add AI GTD Things research docs`).
-- The surviving Desktop backup currently found under `/Users/mike/Desktop/junk/stuff/jank/junk/junk/ai-gtd-things-backup-20260313-183252/ai-gtd-things` still has the nested repo's two commits: `190c412` and `d406674`.
+- On 2026-03-13, that session recorded a safety backup at `~/Desktop/ai-gtd-things-backup-20260313-183252/ai-gtd-things`, removal of nested git metadata from `~/Projects/second-brain/docs/ai-gtd-things/.git`, and top-level commit `004b9f9` (`Add AI GTD Things research docs`).
+- The surviving Desktop backup currently found under `~/Desktop/junk/stuff/jank/junk/junk/ai-gtd-things-backup-20260313-183252/ai-gtd-things` still has the nested repo's two commits: `190c412` and `d406674`.
 
 Non-canonical artifact:
 - `/Volumes/Workspace/Projects/test/src/things` appears to be a small throwaway test area, not the Things CLI/API implementation.

--- a/docs/research/09-session-context-extract.md
+++ b/docs/research/09-session-context-extract.md
@@ -1,7 +1,7 @@
 # Step 9 - Original Codex Session Context Extract
 
 Source session:
-- `/Users/mike/.codex/sessions/2026/03/02/rollout-2026-03-02T14-01-57-019cb024-a47d-7a91-a7ac-425c580fdb0f.jsonl`
+- `~/.codex/sessions/2026/03/02/rollout-2026-03-02T14-01-57-019cb024-a47d-7a91-a7ac-425c580fdb0f.jsonl`
 
 Extraction date:
 - 2026-06-19
@@ -31,7 +31,7 @@ Initial user goal:
 
 Initial implementation outcome:
 - The workspace was empty.
-- Seven Markdown artifacts were created under `/Users/mike/Projects/second-brain/docs/ai-gtd-things`.
+- Seven Markdown artifacts were created under `~/Projects/second-brain/docs/ai-gtd-things`.
 - Sources included Cultured Code support docs, official Things URL scheme docs, `things.py` docs/source, and `things-mcp`.
 
 Important framing from the first pass:
@@ -141,7 +141,7 @@ Ordering caveats:
 ### 2026-03-13 - Git / Provenance
 
 The docs were accidentally created as a nested git repo under:
-- `/Users/mike/Projects/second-brain/docs/ai-gtd-things/.git`
+- `~/Projects/second-brain/docs/ai-gtd-things/.git`
 
 Nested repo commits:
 - `190c412` - initial docs
@@ -150,13 +150,13 @@ Nested repo commits:
 User requested removing the nested git repo and committing at top level.
 
 Recorded outcome:
-- Safety backup created at `/Users/mike/Desktop/ai-gtd-things-backup-20260313-183252/ai-gtd-things`.
+- Safety backup created at `~/Desktop/ai-gtd-things-backup-20260313-183252/ai-gtd-things`.
 - Nested `.git` removed from `docs/ai-gtd-things`.
 - Docs committed in the top-level `second-brain` repo.
 - Top-level commit: `004b9f9` (`Add AI GTD Things research docs`).
 
 Current recovered location differs by path mount:
-- Original session path: `/Users/mike/Projects/second-brain`
+- Original session path: `~/Projects/second-brain`
 - Current canonical path: `/Volumes/Workspace/Projects/second-brain`
 
 ## Final Step 3 Closure
@@ -232,7 +232,7 @@ Guardrails:
 Use these patterns if more provenance is needed:
 
 ```sh
-jq -r 'select(.type=="response_item" and .payload.type=="message") | [.timestamp, .payload.role, ((.payload.content[0].text // .payload.content[0].content // "") | gsub("\n"; " ") | .[0:220])] | @tsv' /Users/mike/.codex/sessions/2026/03/02/rollout-2026-03-02T14-01-57-019cb024-a47d-7a91-a7ac-425c580fdb0f.jsonl
+jq -r 'select(.type=="response_item" and .payload.type=="message") | [.timestamp, .payload.role, ((.payload.content[0].text // .payload.content[0].content // "") | gsub("\n"; " ") | .[0:220])] | @tsv' ~/.codex/sessions/2026/03/02/rollout-2026-03-02T14-01-57-019cb024-a47d-7a91-a7ac-425c580fdb0f.jsonl
 ```
 
 Useful search terms:


### PR DESCRIPTION
## Summary
Preparation for making the repository public:

- **`docs/lab/headless-research.md`** — redacts the SYNC2 throwaway Things Cloud + mail.tm credential values. The account itself has been **deleted and verified** (DELETE → `202 Accepted`, then stable `404` on the account resource; evidence in gitignored `lab/artifacts/burn-account-20260716-205854/`), so the historical values remaining in git history are inert. The cleanup note now records the discovered one-call deletion recipe: `cloud.culturedcode.com` is the Syncrony sync API (not a web UI), and `DELETE /version/1/account/{email}` with `Authorization: Password {password}` burns an account with no email confirmation.
- **`docs/research/08`, `09`** — genericizes `/Users/mike/...` paths to `~/...`.
- **`AGENTS.md`** — standing safety rail: this is a public repository, everything (including git history) is visible; no PII, no personal task-manager data (fixtures/examples must be fully synthetic, never derived from the production Things DB), no account credentials of any kind, ephemeral or otherwise.

## Test plan
- `git grep` sweep for every credential value returns zero matches in tracked files.
- Docs-only change; CI exercises fmt/lint as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEGRrsqzxnQKCz7mAD8U5d