### PR TITLE
fix(bench): accept bare-JSON final answers (grading fairness)

### DIFF
--- a/bench/grade.ts
+++ b/bench/grade.ts
@@ -70,7 +70,13 @@ function getPath(root: unknown, path: string): unknown {
   return cur;
 }
 
-/** Extract the parsed JSON from the LAST fenced ```json block (fallback: last ``` block). */
+/**
+ * Extract the parsed JSON from the LAST fenced ```json block (fallback: last
+ * ``` block). If the message carries no parseable fence at all, fall back to
+ * parsing the whole trimmed message as JSON — subjects sometimes reply with a
+ * bare object, which is substantively correct and graded as such (observed in
+ * batch loop-cli-r2: a right answer zeroed purely on fence formatting).
+ */
 export function parseFinalAnswer(text: string | null): unknown {
   if (text === null) return undefined;
   const fences = [...text.matchAll(/```(\w*)\n([\s\S]*?)```/g)];
@@ -83,7 +89,11 @@ export function parseFinalAnswer(text: string | null): unknown {
       // try the next candidate
     }
   }
-  return undefined;
+  try {
+    return JSON.parse(text.trim());
+  } catch {
+    return undefined;
+  }
 }
 
 function runSql(fixturePath: string, query: string): unknown {

--- a/test/unit/bench-grade-answer.test.ts
+++ b/test/unit/bench-grade-answer.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Final-answer extraction fairness: fenced JSON preferred, bare-JSON message
+ * accepted as a fallback (batch loop-cli-r2 refutation: a substantively
+ * correct bare-object reply was zeroed purely on fence formatting).
+ */
+import { describe, expect, it } from "vitest";
+
+import { parseFinalAnswer } from "../../bench/grade.ts";
+
+describe("parseFinalAnswer", () => {
+  it("prefers the last fenced json block", () => {
+    const text = 'ignore\n```json\n{"a":1}\n```\ntext\n```json\n{"a":2}\n```\n';
+    expect(parseFinalAnswer(text)).toEqual({ a: 2 });
+  });
+
+  it("falls back to any fence when no json-tagged fence parses", () => {
+    const text = 'prose\n```\n{"b":3}\n```\n';
+    expect(parseFinalAnswer(text)).toEqual({ b: 3 });
+  });
+
+  it("accepts a bare-JSON message when no fence exists", () => {
+    expect(parseFinalAnswer('{"section":"evening"}')).toEqual({ section: "evening" });
+    expect(parseFinalAnswer('  {"found":true,\n "title":"X"}  ')).toEqual({
+      found: true,
+      title: "X",
+    });
+  });
+
+  it("returns undefined for prose with neither fence nor bare JSON", () => {
+    expect(parseFinalAnswer("The item is in the evening section.")).toBeUndefined();
+    expect(parseFinalAnswer(null)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Deterministic fallback in parseFinalAnswer: when no fenced block parses, try the whole trimmed message as JSON. Substantively-correct bare-object replies (observed in loop-cli-r2) are no longer zeroed on fence formatting. Tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)