### PR TITLE
fix(release): package.json repository field for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,15 @@
   "name": "things-api",
   "version": "0.11.0",
   "description": "Typed TypeScript library + CLI for Things 3 (Cultured Code) — verified writes, audit trail, schema-drift detection",
+  "homepage": "https://github.com/mikegreiling/things-api#readme",
+  "bugs": {
+    "url": "https://github.com/mikegreiling/things-api/issues"
+  },
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mikegreiling/things-api.git"
+  },
   "bin": {
     "things": "bin/things.js"
   },


### PR DESCRIPTION
The v0.11.0 publish failed provenance validation (E422: repository.url empty, expected the GitHub repo) — the field never existed and npm's check tightened since 0.10.0. Adds repository/homepage/bugs. The v0.11.0 tag will be re-cut on this commit after merge; no npm version was consumed (ETARGET confirms nothing published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FTjg4ekARHdWntGR2VqnnQ