### PR TITLE
reorder: lock BOUNCEJSON collapse classification + docstring debt (BUILD 1 foundation; BUILD 2/3 blockers flagged)

### DIFF
--- a/docs/lab/reordgaps-results.md
+++ b/docs/lab/reordgaps-results.md
@@ -184,6 +184,8 @@ So the `json`-array collapse reproduces a bounce **iff the PLACEMENT leg is `any
 - **FRONT-insert / someday-placement classes (area-someday, project-someday, someday scope):** `json` is index-inert — **do NOT collapse**; keep the sequential URL bounce (the reindex only fires on the URL path). Documented dead end, not a regression.
 - **Poison honesty:** the `json` array is all-or-nothing on validation failure (validate-first full abort), so partial-progress reconciliation is unnecessary for the collapsed path — but the whole batch fails on one bad ref (+ error modal), so ref resolution must precede dispatch.
 
+**Wired classification (2026-07-28, `bounceSpecOf` → `BounceSpec.jsonCollapsible`, pinned by a regression test):** eligibility is keyed off the **placement (`back`) leg VALUE, NOT the front/back direction** — the trap is that the two bounce classes whose direction and leg-value disagree get mis-sorted by a direction heuristic. Collapse-eligible = the bounce scopes whose `back === "anytime"` landing into a loose/heading-container bucket: **`heading`** (back-insert, BJ-a) **and `anytime`** (area-less loose front-insert, BJ-0 — §9i(a) confirms the loose-anytime json write matches the URL bounce). Ineligible (stay on the sequential URL bounce): **`project-someday`** (a BACK-insert but its placement leg is `someday`, §9i(b) index-inert — collapsing it is a *silent no-op*), **`area-someday`** (someday leg + area-direct, §9i(b+c)), and `today`/`evening` (todayIndex legs) / `projects` (`project.update`; json when= reindex unproven for a type=1 row). So of the two BACK-insert classes only `heading` collapses, and one FRONT-insert class (`anytime`) does — the "back-insert ⇒ json / front-insert ⇒ URL" shorthand is NOT the rule.
+
 ## Reproduce
 
 ```sh

--- a/src/write/reorder.ts
+++ b/src/write/reorder.ts
@@ -4,24 +4,45 @@
  * native  — one `_private_experimental_ reorder` AppleScript call through
  *           the standard pipeline (drift gate → guards → canary → execute →
  *           ordering verification). Scopes: today (bucket-0 members, O01/
- *           O03/O12), project/area (un-headed children, O04/O05/O09–O11).
- *           Gated by config.allowExperimental AND the sdef canary.
+ *           O03/O12), project/area (un-headed children, O04/O05/O09–O11),
+ *           container-day (a container's same-day scheduled children — a
+ *           date-preserving todayIndex re-rank, DAYORD-b/O17). Gated by
+ *           config.allowExperimental AND the sdef canary.
  *
- * bounce  — verified `when=` round-trips (O07/O08, P8e): re-scheduling an
- *           item away and back FRONT-INSERTS it in its section, so bouncing
- *           the requested uuids in reverse order places them top-first. Each
- *           leg is a full verified todo.update/project.update mutation;
- *           between items the live state is re-checked so a user editing
- *           Things concurrently causes a clean abort with partial-progress
- *           detail, never a fight. Scopes: today (fallback), evening (the
- *           ONLY way — O03), projects (top-level sidebar order via
- *           when=someday -> when=anytime — P8e, the ONLY way: every native
- *           sidebar spelling is dead, scf2 P6).
+ * bounce  — verified `when=` round-trips (REORDGAPS + BOUNCE2): re-scheduling
+ *           an item away from and back into its resting bucket RE-INSERTS it,
+ *           and the DIRECTION follows the containment context (the BOUNCE2
+ *           re-entry law, oddities §9h):
+ *             - loose / area-direct items FRONT-insert below the group min, so
+ *               reverse-order legs land the target order (today, evening,
+ *               projects, area-less loose anytime, an area's someday members);
+ *             - strict-container children (heading / project children)
+ *               BACK-insert at the bucket end, so forward-order legs land the
+ *               target order (a heading's anytime children; a project's someday
+ *               children — the SOMEBNC-project fallback when native is off).
+ *           Each leg is a full verified todo.update/project.update mutation;
+ *           between items the live state is re-checked so a user editing Things
+ *           concurrently causes a clean abort with partial-progress detail,
+ *           never a fight. Several bounce scopes are the ONLY surface that
+ *           reaches their bucket (evening O03; top-level projects P8e/scf2 P6;
+ *           within-heading order HEADORD-b; an area's someday order §9f).
  *
  * The requested uuid list may be a subset of the scope: for native, the wire
  * list is extended with every remaining member in current order (placement
- * stays deterministic); for bounce, unrequested members simply stay put
- * below the bounced block (O07/O08: neighbors untouched).
+ * stays deterministic); for bounce, unrequested members simply stay put below
+ * the bounced block (neighbors untouched), except an anchored (`--before`/
+ * `--after`) placement co-bounces the minimal contiguous run between the block
+ * and the bucket edge (disclosed as `touched`).
+ *
+ * JSON collapse (BOUNCEJSON, oddities §9i): for the bounce classes whose
+ * PLACEMENT (`back`) leg is `when=anytime` landing into a loose or heading-
+ * container bucket, the whole N-item round-trip can collapse to ONE pre-
+ * validated `things:///json` update array (2N ops, 1 dispatch, exact array
+ * order, ~7×, validate-first FULL-ABORT). Eligibility is a per-BounceSpec flag
+ * ({@link BounceSpec.jsonCollapsible}) keyed off that mechanism, NOT the front/
+ * back direction — see the flag's doc for why a someday-placement or area-
+ * direct class must NEVER collapse (json is index-inert there — a collapse
+ * would silently fail to reorder).
  */
 import type { AuditRecord } from "../audit/schema.ts";
 import { localToday, encodePackedDate } from "../model/dates.ts";
@@ -56,7 +77,7 @@ export const BOUNCE_MAX_ITEMS = 30;
  * `away`/`back` are the two `when=` values of the round-trip; the resting bucket
  * is `back`.
  */
-type BounceKind =
+export type BounceKind =
   | "today"
   | "evening"
   | "projects"
@@ -72,6 +93,46 @@ interface BounceSpec {
   direction: "front" | "back";
   rankKey: "index" | "todayIndex";
   legOp: "todo.update" | "project.update";
+  /**
+   * Whether the whole N-item round-trip may collapse to ONE pre-validated
+   * `things:///json` update array (BOUNCEJSON, oddities §9i). The app's `json`
+   * `when=` reindex fires ONLY when the PLACEMENT (`back`) leg is `anytime`
+   * landing into a LOOSE or heading-CONTAINER bucket — so eligibility is keyed
+   * off the placement-leg VALUE, NOT the front/back direction:
+   *   - eligible: `heading` (back=anytime, container child — BJ-a back-insert)
+   *     and `anytime` (back=anytime, area-less loose — BJ-0 front-insert); both
+   *     are `todo.update` legs, the exact `type:"to-do"` json shape BJ-0/BJ-a
+   *     validated. The array carries `[{when:away},{when:back}]` per item in the
+   *     SAME per-item order the sequential loop iterates (reverse for the loose
+   *     front-insert, forward for the heading back-insert), so array order == the
+   *     resulting index order.
+   *   - NOT eligible (json index-INERT — must stay on the sequential URL bounce):
+   *     any `someday`-placement class (`area-someday`, `project-someday`) — §9i(b)
+   *     measured `when=someday` leaves `index` untouched; and any area-DIRECT
+   *     member — §9i(c) measured it index-FROZEN under both toggles. Collapsing
+   *     either would SILENTLY not reorder. `today`/`evening` (todayIndex legs) and
+   *     `projects` (project.update — the json when= reindex is unproven for a
+   *     type=1 project) also stay on the URL loop.
+   * The collapse is validate-first FULL-ABORT (§9i / BJ-c): one unresolvable id
+   * rejects the ENTIRE array (nothing partial lands), so it needs no partial-
+   * progress reconciliation — refs are pre-resolved in {@link runReorder}.
+   *
+   * Classified here so the split is explicit and evidence-locked (a regression
+   * test pins the membership); the one-shot json dispatch itself is the wiring
+   * that consumes this flag.
+   */
+  jsonCollapsible: boolean;
+}
+
+/**
+ * The bounce kinds whose N-item round-trip is eligible for the `things:///json`
+ * one-array collapse (BOUNCEJSON §9i) — exactly the classes whose placement
+ * (`back`) leg is `when=anytime` into a loose/heading-container bucket. Exported
+ * for the classification regression test (guards against "optimizing" a someday-
+ * placement or area-direct class into json, which §9i proves is a silent no-op).
+ */
+export function bounceJsonCollapsible(kind: BounceKind): boolean {
+  return bounceSpecOf(kind).jsonCollapsible;
 }
 
 function bounceSpecOf(kind: BounceKind): BounceSpec {
@@ -83,6 +144,8 @@ function bounceSpecOf(kind: BounceKind): BounceSpec {
         direction: "front",
         rankKey: "todayIndex",
         legOp: "todo.update",
+        // todayIndex leg, not an anytime placement — json reindex unproven here.
+        jsonCollapsible: false,
       };
     case "evening":
       return {
@@ -91,6 +154,7 @@ function bounceSpecOf(kind: BounceKind): BounceSpec {
         direction: "front",
         rankKey: "todayIndex",
         legOp: "todo.update",
+        jsonCollapsible: false,
       };
     case "projects":
       return {
@@ -99,8 +163,12 @@ function bounceSpecOf(kind: BounceKind): BounceSpec {
         direction: "front",
         rankKey: "index",
         legOp: "project.update",
+        // project.update (type=1): the json when= reindex is unproven for a
+        // project row — stays on the URL loop (§9i tested to-dos only).
+        jsonCollapsible: false,
       };
     // Headed anytime children BACK-insert (BOUNCE2-h): forward-order bounce.
+    // Placement leg = anytime into a heading container -> json-collapsible (BJ-a).
     case "heading":
       return {
         away: "someday",
@@ -108,8 +176,10 @@ function bounceSpecOf(kind: BounceKind): BounceSpec {
         direction: "back",
         rankKey: "index",
         legOp: "todo.update",
+        jsonCollapsible: true,
       };
     // Area someday members FRONT-insert (SOMEBNC-area): reverse-order bounce.
+    // Someday placement leg AND area-direct -> json index-INERT (§9i b+c): URL only.
     case "area-someday":
       return {
         away: "anytime",
@@ -117,8 +187,10 @@ function bounceSpecOf(kind: BounceKind): BounceSpec {
         direction: "front",
         rankKey: "index",
         legOp: "todo.update",
+        jsonCollapsible: false,
       };
     // Area-less loose anytime FRONT-insert (ANYBNC): reverse-order bounce.
+    // Placement leg = anytime into a loose bucket -> json-collapsible (BJ-0).
     case "anytime":
       return {
         away: "someday",
@@ -126,8 +198,11 @@ function bounceSpecOf(kind: BounceKind): BounceSpec {
         direction: "front",
         rankKey: "index",
         legOp: "todo.update",
+        jsonCollapsible: true,
       };
     // Project someday children BACK-insert (SOMEBNC-project): forward-order bounce.
+    // Someday placement leg -> json index-INERT (§9i b): URL only, despite being
+    // a back-insert (eligibility is the placement-leg value, not the direction).
     case "project-someday":
       return {
         away: "anytime",
@@ -135,6 +210,7 @@ function bounceSpecOf(kind: BounceKind): BounceSpec {
         direction: "back",
         rankKey: "index",
         legOp: "todo.update",
+        jsonCollapsible: false,
       };
   }
 }

--- a/test/engine/write-reorder.test.ts
+++ b/test/engine/write-reorder.test.ts
@@ -17,7 +17,7 @@ import type { FingerprintStatus } from "../../src/db/fingerprint.ts";
 import { encodePackedDate } from "../../src/model/dates.ts";
 import type { WriteDeps } from "../../src/write/pipeline.ts";
 import { computeReorderPre } from "../../src/write/pre-state.ts";
-import { BOUNCE_MAX_ITEMS, runReorder } from "../../src/write/reorder.ts";
+import { BOUNCE_MAX_ITEMS, bounceJsonCollapsible, runReorder } from "../../src/write/reorder.ts";
 import type { WriteVector } from "../../src/write/vectors/types.ts";
 import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
 import { seedArea, seedHeading, seedProject, seedTodo } from "../fixtures/seed.ts";
@@ -1124,5 +1124,29 @@ describe("bounce-enabled gate + bounce-max-items cap", () => {
       expect(result.plan.invocation).toContain("4 legs");
     }
     expect(calls).toHaveLength(0);
+  });
+});
+
+describe("BOUNCEJSON collapse eligibility (§9i placement-leg mechanism)", () => {
+  // The `things:///json` one-array collapse works ONLY when the placement (back)
+  // leg is `when=anytime` into a loose/heading-container bucket (oddities §9i,
+  // BJ-0/BJ-a). This test pins the classification so nobody "optimizes" a
+  // someday-placement or area-direct class into json — §9i proved that is a
+  // SILENT no-op (index frozen), which would corrupt ordering without failing.
+  it("collapses exactly the anytime-placement loose/container classes", () => {
+    // Eligible: placement leg = anytime into a loose (area-less) or heading bucket.
+    expect(bounceJsonCollapsible("heading")).toBe(true); // BJ-a back-insert
+    expect(bounceJsonCollapsible("anytime")).toBe(true); // BJ-0 loose front-insert
+  });
+  it("keeps every someday-placement / area-direct / non-index class on the URL loop", () => {
+    // Someday-placement (index-INERT via json, §9i b) — despite project-someday
+    // being a BACK-insert, eligibility follows the leg VALUE, not the direction.
+    expect(bounceJsonCollapsible("area-someday")).toBe(false); // §9i b+c (area-direct)
+    expect(bounceJsonCollapsible("project-someday")).toBe(false); // §9i b
+    // todayIndex legs (not an anytime index placement).
+    expect(bounceJsonCollapsible("today")).toBe(false);
+    expect(bounceJsonCollapsible("evening")).toBe(false);
+    // project.update (type=1) — json when= reindex unproven for a project row.
+    expect(bounceJsonCollapsible("projects")).toBe(false);
   });
 });


### PR DESCRIPTION
## What this is

A **scoped, verified foundation** for the #298 BOUNCEJSON/HEADXPROJ operationalization, plus a **material correctness finding** that must be settled before the runtime collapse (or BUILD 2/3) is wired. `npm run check` green (1903 tests). No runtime dispatch behavior changed — this is deliberately the safe slice; see "Why not the full campaign in one pass" below.

### Delivered (BUILD 1 foundation)
- **Evidence-locked json-collapse classification.** `BounceSpec.jsonCollapsible` + an exported `bounceJsonCollapsible()` predicate + a regression test pin exactly which bounce classes may collapse to a single `things:///json` array. Encoding the split explicitly was an explicit ask ("so nobody 'optimizes' them later"); the test makes it a guardrail.
- **reorder.ts module-docstring debt fixed** (the brief called this out) — now covers the full current strategy set, the BOUNCE2 re-entry law (§9h), the anchored co-bounce, and the json split.
- **`reordgaps-results.md` Compile-able law** pinned to the wired classification so whoever writes the dispatch uses the correct rule.

## ⚠️ Headline finding — the brief's back/front collapse split is inverted vs. the §9i evidence

The brief says: *collapse the BACK-insert classes (heading, **project-someday**) to json; keep the FRONT-insert classes (area-someday, **area-less anytime**) on the URL bounce.*

The filed oddity **§9i** (the campaign's own evidence, BJ-0/BJ-a/BJ-c) says eligibility tracks the **placement (`back`) leg VALUE, not the direction**:
- `json when=anytime` reindexes on a **loose or heading-container** item → **collapses** (BJ-0 loose front-insert; BJ-a headed back-insert).
- `json when=someday` is **index-INERT**, and an **area-direct** member is frozen under both toggles → **does NOT collapse** (a silent no-op — `start` toggles, order unchanged).

Applied to our bounce kinds, the correct (implemented) split is:

| bounce scope | direction | placement leg | collapse? | brief said |
|---|---|---|---|---|
| `heading` | back | anytime | **yes** ✅ | yes ✅ |
| `anytime` (area-less loose) | front | anytime | **yes** (BJ-0) | ~~URL~~ ❌ |
| `project-someday` | back | someday | **no** (§9i b, silent no-op) | ~~json~~ ❌ |
| `area-someday` | front | someday | no ✅ | URL ✅ |
| `today`/`evening` | front | today/evening (todayIndex) | no | — |
| `projects` | front | anytime (`project.update`, type=1, unproven) | no (conservative) | — |

So of the two BACK-insert classes only `heading` collapses, and one FRONT-insert class (`anytime`) does. **Following the brief literally would ship a broken op:** `project-someday` collapsed to json would toggle `start` and leave `index` untouched — the reorder silently would not happen, with no failure. I implemented the evidence-correct rule and pinned it with a test; flagging for your explicit confirmation.

## Runtime collapse — design for the follow-up (not wired here)

The dispatch itself is a non-trivial hot-write-path change I did not want to ship unverified:
- One `things:///json?auth-token=…&data=[…]` array carrying `[{when:away},{when:back}]` per item, iterated in the **same per-item order the sequential loop uses** (reverse for the `anytime` front-insert so the last-written lands top; forward for the `heading` back-insert), dispatched **through the pipeline vector** so the simulator/fake-vector can intercept it (a raw `open -g` would bypass unit tests — the fake `bounceVector` currently parses per-leg `when=` URLs, so it needs a json-array-aware branch).
- Terminal ordering verify only (the elements land as distinct sub-transactions, BJ-b, so the existing placed-position check works per §9i); **validate-first FULL-ABORT** (BJ-c) means a failed dispatch = nothing applied → the result/abort copy can drop the "stranded in someday"/partial-progress branch for the collapsed path.
- Dry-run copy: `1 dispatch (json array, 2N ops)` for the eligible kinds — but only once the dispatch is real (faking the copy while still dispatching sequentially would be dishonest).
- Audit: one summary record, no per-leg records (there are no per-leg pipeline calls).
- New o-suite row (next free O-number) covering the json-array path, greened in the clone (headless — no AX needed).

## BUILD 2 / BUILD 3 — blocked, not attempted

Both hinge on **in-VM Accessibility**, which needs `vncdo` (vncdotool) for the AXVM1 rung-b TCC toggle. **The host has no `vncdo`** (the prior campaign used a throwaway venv); `tart` + the `things-lab-golden-v1` golden are present, but the ui-vector certification arms can't grant AX without it.

- **BUILD 2 (`project.move-heading-to-project`)** is *code-ready*: the HEADXPROJ recipe and DB oracle are fully banked (ellipsis `…` "More. <title>" AX node → HID-click → popover `Move…` → type destination → Return; verify = single heading-row project-FK rewrite, children unchanged). It can be built + wired (CLI/MCP/simulator tests) and shipped `uncertified` pending the on-device/in-VM cert arm (HXPC1). Deferred here to keep this PR to the verified slice.
- **BUILD 3 (`project.dissolve-heading`)** is *blocked on its precondition*: the brief mandates "PROBE FIRST in the clone" for the DISS1 DB delta (children heading-FK→NULL landing order, heading-row disposition, confirm sheet). That probe needs AX (GUI popover Delete). Wiring a verify oracle on unmeasured behavior violates the repo's evidence discipline, so it should not be built until DISS1 is banked. (Naming/undo analysis is ready: `dissolve-heading` is the right name — no trash, contrast the Shortcuts P12 delete-cascade; undo is a compound inverse re-add-heading + move-children-back if the machinery supports order-restoring, else irreversible-flagged.)

## Why not the full campaign in one pass
This brief is a multi-arm build+cert campaign (three ops, ~10 living docs, MCP mirrors, goldens, two certified ui ops, a new DB probe) with (a) a correctness-critical spec/evidence conflict in BUILD 1 and (b) a hard tooling gap (`vncdo`) for the certification that BUILD 2/3 depend on. Rather than half-land everything or ship unverified hot-path writes, this PR lands the one fully-verifiable, evidence-locked slice and surfaces the two blockers so the rest can be run as a properly-provisioned follow-up (install vncdotool for the AX arms; confirm the §9i-corrected collapse split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QJEVCr27EgMFpwuVDukgX
