### PR TITLE
refactor: post-alignment sweep — dead exports + stale reorder-grammar copy

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -14,8 +14,7 @@ import {
   type EnvelopeMeta,
 } from "../../index.ts";
 
-// Back-compat aliases for pre-seam consumers of the CLI module.
-export type DoctorReport = DiagnoseReport;
+// Back-compat alias for pre-seam consumers of the CLI module.
 export const runDoctor: (dbPath?: string) => DiagnoseResult = diagnose;
 
 function environmentLine(env: DiagnoseReport["environment"]): string {

--- a/src/write/guards.ts
+++ b/src/write/guards.ts
@@ -403,7 +403,7 @@ const GUARDS: Record<HazardId, GuardFn> = {
         detail:
           "evening reorder is bounce-only: the native command would silently clear " +
           "startBucket on every listed item (O03)",
-        remediation: "use write.reorder / `things reorder --scope evening` (bounce strategy)",
+        remediation: "use write.reorder / `things reorder <refs…> --in evening` (bounce strategy)",
       };
     }
     if (

--- a/src/write/pre-state.ts
+++ b/src/write/pre-state.ts
@@ -5,7 +5,7 @@
 import type { DatabaseSync } from "node:sqlite";
 
 import { encodePackedDate, localToday, type IsoDate } from "../model/dates.ts";
-import type { AnyTask, Project, TaskStatus, TaskType, Todo } from "../model/entities.ts";
+import type { AnyTask, TaskStatus, TaskType, Todo } from "../model/entities.ts";
 import { TASK_STATUS_FROM_DB } from "../model/entities.ts";
 import { byUuid } from "../read/detail.ts";
 import { deadNameMatchHint, resolveHeadingRef, resolveNamedRef } from "../read/queries.ts";
@@ -1273,8 +1273,4 @@ export function todayEveningFlagOf(
   if (row.start !== 1 && row.start !== 2) return null; // inbox (start=0)
   if (row.startDate === null || row.startDate > packedToday) return null; // someday / anytime / future
   return row.startBucket === 1 && row.startDate === packedToday ? "evening" : "today";
-}
-
-export function projectOf(task: AnyTask | null): Project | null {
-  return task !== null && task.type === "project" ? task : null;
 }


### PR DESCRIPTION
Cleanup round after the CLI/MCP surface alignment (#345–#357) and the automatic reorder fallbacks (#357). **No behavior changes** — `npm run check` green (typecheck + oxlint + fmt:check + 2243 tests).

## Removed symbols / paths

**Dead exports (unimported anywhere in src/ or test/):**
- `DoctorReport` type alias — `src/cli/commands/doctor.ts`. A pre-seam back-compat alias for `DiagnoseReport`, referenced nowhere. Per ALPHA-CONTRACT (no compat machinery), deleted outright. `runDoctor` (the sibling alias) stays — it is used by `test/cli/doctor.test.ts`.
- `projectOf(task)` — `src/write/pre-state.ts`. An exported helper with zero callers; also drops its now-orphaned `Project` type import.

**Stale deleted-grammar copy (#345 Phase B leftover):**
- `src/write/guards.ts` — the `H-REORDER-SCOPE` evening-reorder remediation cited `things reorder --scope evening`, a CLI form removed in Phase B (#345). Updated to the current spelling `things reorder <refs…> --in evening`. (No test asserts this string.)

## Deliberately left (surprises / not dead)

- **`ReorderParams.strategy` / `ReorderStrategy` (exported from `index.ts`) / the two `params.strategy === "native"|"bounce"` branches in `reorder.ts`** — these look like `--strategy` vocabulary residue, but they are **live public API**: `client.write.reorder(params: ReorderParams)` (client.ts:685) accepts a raw `strategy`, and 7 engine tests exercise both branches. The `--strategy` *CLI flag* is gone (locked out by `help-contract.test.ts`), but the library knob was deliberately retained. Not unreachable → not swept. The "omit --strategy" remediation copy inside those branches was left untouched for the same reason (it is reached only via the programmatic knob).
- **`#351` de-Today refusal** — already superseded *inline* by #354's flag-aware routing (HEADMOVE/LOOSEPARK/PROJPARK); there is no leftover dead refusal branch. `todayEveningFlagOf` remains the single-source flag marker.
- **`project-someday` BounceKind** — retained by design as the §9i json-collapse classification pin (documented in reorder.ts); no longer selected by `resolveStrategy`, which is intentional.
- **`magenta` (style.ts)** — unused ANSI-palette primitive; left for palette completeness (sibling to red/green/blue/cyan/yellow), zero maintenance cost, not vocabulary-related.
- **`FitStage` (width.ts)** — unused as a code annotation but referenced by name in `docs/design/width-aware-tty.md` as a design anchor; removing it would orphan that doc.
- **`ENUM_DOMAINS` (db/schema.ts)** — exported reference constant whose comment claims runtime-probe use but nothing references it. Possible latent gap (a drift probe that *should* consume it), not vocabulary residue — left untouched to avoid deleting something a probe ought to use.

## Consolidations considered, declined
- **Flag detection** is already unified — the three flag-aware swaps route through one `todayEveningFlagOf` check (reorder.ts:952). The one raw read at `move.ts:220` operates on a loaded `MoveeRow` (not a db uuid), so it can't call `todayEveningFlagOf` without changing input shape → not byte-equivalent.
- **Scratch teardown** across the fallback/park protocols already shares `scratchSuffix`/`countProjectChildren`/`verifyIndexOrder`. The remaining per-protocol bodies differ by container type (project vs area, `list-id=` vs `area-id=`) and insert direction — not byte-equivalent, so no further mechanical consolidation is safe.

MCP #348 surface had no orphaned scope-schema builders or dead `mutationResult` shapes (all framing helpers are live); oxlint (`correctness=error` + `denyWarnings`) is clean, so there are no unused imports/locals to sweep.

No CHANGELOG entry: no public `index.ts` export was removed (`ReorderStrategy` kept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QJEVCr27EgMFpwuVDukgX
