### PR TITLE
fix(release): install-skill test tolerates a stamped working tree

### DIFF
--- a/test/cli/install-skill.test.ts
+++ b/test/cli/install-skill.test.ts
@@ -89,8 +89,12 @@ describe("install-skill: built-in copy fallback", () => {
     const h = newHome();
     const before = bundledSkillVersion();
     installSkill({}, fallbackDeps(h));
-    expect(bundledSkillVersion()).toBe(before); // repo placeholder untouched
-    expect(before).toBe("0.0.0-dev");
+    expect(bundledSkillVersion()).toBe(before); // repo copy untouched (the invariant)
+    // `before` is normally the committed `0.0.0-dev` placeholder, but at release
+    // time the workflow stamps the working tree with the real version before
+    // `npm publish` re-runs `check` (prepublishOnly) — so assert only that the
+    // stamp is a well-formed version, not the specific placeholder. Both parse.
+    expect(parseSemver(before)).not.toBeNull();
   });
 
   it("re-add cleanly overwrites: stale content and orphan files are removed", () => {


### PR DESCRIPTION
## Problem

The v0.12.0 publish (tag `v0.12.0`, run 30705941252) failed inside `npm publish`'s `prepublishOnly` (`npm run check && npm run build && node scripts/stamp-skill.mjs`):

```
FAIL test/cli/install-skill.test.ts > never modifies the repo's own SKILL.md
AssertionError: expected '0.12.0' to be '0.0.0-dev'
```

The release workflow runs an explicit `node scripts/stamp-skill.mjs` step (stamping `skills/things-cli/SKILL.md` to the package version) **before** `npm publish`. `prepublishOnly` then re-runs `npm run check` over that already-stamped tree, and the test hard-coded `expect(before).toBe("0.0.0-dev")` — false once the tree carries a real stamp. Nothing was published (registry returns E404 for 0.12.0; `latest` still 0.11.0).

This assertion was tightened by #359, which is why 0.11.0 (pre-#359) never hit it and 0.12.0 (first release after) does. `scripts/stamp-skill.mjs` already documents that a local `npm publish` leaves SKILL.md stamped, so the assertion was brittle against the documented workflow too.

## Fix

Relax the over-specified assertion to `parseSemver(before)` non-null — the same tree-agnostic pattern the sibling "the bundled SKILL.md carries a parseable version stamp" test already uses. The test's real invariant (installSkill leaves the repo copy untouched, `before === after`) stays fully asserted; a genuinely broken/missing stamp still fails.

## Verification

`npm run check` (exit 0) over **both** a clean tree and a stamped tree (all 2243 tests), reproducing the exact `prepublishOnly` condition.

After merge the `v0.12.0` tag is re-pointed to the new main HEAD to re-trigger the publish (mirrors the #250→#251 re-tag for 0.11.0's provenance fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QJEVCr27EgMFpwuVDukgX