### PR TITLE
fix(explore): plain-language client error on non-JSON responses

### DIFF
--- a/scripts/explore/index.html
+++ b/scripts/explore/index.html
@@ -459,6 +459,14 @@
             headers: { "content-type": "application/json" },
             body: JSON.stringify({ command }),
           });
+          if (!res.ok || !(res.headers.get("content-type") || "").includes("json")) {
+            const text = await res.text();
+            throw new Error(
+              res.status === 403
+                ? "signed out — reopen the ?key= URL from the server output (each restart mints a new key)"
+                : `server error ${res.status}: ${text.slice(0, 200)}`,
+            );
+          }
           const r = await res.json();
           $("meta").hidden = false;
           const status = $("status");


### PR DESCRIPTION
A stale or wrong `?key=` gets a `text/plain` 403 from the explore server, which the client fed straight to `res.json()` — surfacing in Safari as the opaque "SyntaxError: The string did not match the expected pattern". Check `res.ok` and the content-type before parsing and report what actually happened: signed out → reopen the keyed URL (each restart mints a new key); anything else → status + body excerpt.

Dev-tooling only (`scripts/explore/` is the maintainer's local read-only DB explorer); no library/CLI/MCP surface touched, no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYbJensXxHpJK1v1VDXYUD