### PR TITLE
fix(read): spell the memo-key NUL delimiters as \x00 escapes

### DIFF
--- a/src/read/queries.ts
+++ b/src/read/queries.ts
@@ -915,7 +915,7 @@ export function titleRoundTrips(
 export function makeRefPromoter(db: DatabaseSync): RefPromoter {
   const memo = new Map<string, string | null>();
   const resolve = (kind: RefKind, title: string, projectUuid?: string): string | null => {
-    const key = `${kind} ${projectUuid ?? ""} ${title}`;
+    const key = `${kind}\x00${projectUuid ?? ""}\x00${title}`;
     if (memo.has(key)) return memo.get(key) ?? null;
     const uuid = resolveTitleForRoundTrip(db, kind, title, projectUuid);
     memo.set(key, uuid);


### PR DESCRIPTION
The #362 ref-promoter memo key embedded two literal 0x00 bytes as composite-key delimiters. Behaviorally identical, but raw NULs make grep (and friends) classify `src/read/queries.ts` as binary. Spelled as `\x00` escapes instead — same delimiter, clean text file. Found during the #368 rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYbJensXxHpJK1v1VDXYUD