### PR TITLE
docs(skill): raise the npx floor to 0.13.0 (flat read shapes)

### DIFF
--- a/skills/things-cli/SKILL.md
+++ b/skills/things-cli/SKILL.md
@@ -6,7 +6,7 @@ version: 0.0.0-dev
 
 # Things CLI
 
-`things` is a command-line interface to the user's Things 3 task database. Reads are instant SQL queries; writes go through the app itself and are checked after they land. Use `things` when it is on your PATH; otherwise — or when `things --version` reports below **0.12.0** — substitute `npx -y things-api@latest` in every command (identical subcommands and flags), which always pairs the current commands with their current help.
+`things` is a command-line interface to the user's Things 3 task database. Reads are instant SQL queries; writes go through the app itself and are checked after they land. Use `things` when it is on your PATH; otherwise — or when `things --version` reports below **0.13.0** — substitute `npx -y things-api@latest` in every command (identical subcommands and flags), which always pairs the current commands with their current help.
 
 `things --help` is the one-screen index; `things <group> --help` lists a group's verbs and flags (always current for the binary you invoke); `things help <topic>` opens a contract guide — topics: `agent`, `filters`, `ids`, `move`, `output`, `repeating`, `writes`.
 


### PR DESCRIPTION
The bundled skill now teaches the 0.13.0-only flat read shapes (flat container refs, heading catalog, dissolved buckets — the read-shape doctrine arc), but the `npx -y things-api@latest` substitution floor still said 0.12.0 — so an agent on a 0.12.0 binary would get flat-shape guidance against a nested-shape CLI instead of being routed to npx. One-word bump, flagged by the 0.13.0 release verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYbJensXxHpJK1v1VDXYUD