### PR TITLE
deputy status: capture launchctl stderr, friendlier not-running headline

### DIFF
--- a/src/cli/commands/deputy.ts
+++ b/src/cli/commands/deputy.ts
@@ -29,13 +29,18 @@ function envelopeMeta(started: number): EnvelopeMeta {
 }
 
 function renderStatus(status: DeputyStatus): string {
-  const lines = [
-    `deputy: ${status.running ? "running" : status.detail}`,
+  const lines = [`deputy: ${status.running ? "running" : "does not appear to be running"}`];
+  // The plain no-socket case needs no elaboration; a socket that exists but
+  // misbehaves (not answering, handshake refused) is worth its own line.
+  if (!status.running && !status.detail.startsWith("not running")) {
+    lines.push(`  detail: ${status.detail}`);
+  }
+  lines.push(
     `  routing: ${status.enabled ? "enabled" : "disabled (things config set deputy-enabled true)"}`,
     `  launchd: ${status.plistInstalled ? (status.loaded ? "installed + loaded" : "installed, NOT loaded") : "not installed (things deputy install)"}`,
     `  binary: ${status.binaryInstalled ? "installed" : "not installed"}`,
     `  socket: ${status.socketPath}`,
-  ];
+  );
   if (status.hello !== null) {
     lines.push(
       `  version: ${status.hello.deputyVersion} (protocol ${status.hello.protocol}, pid ${status.hello.pid})`,

--- a/src/deputy/install.ts
+++ b/src/deputy/install.ts
@@ -49,7 +49,14 @@ function launchTarget(): string {
 
 function launchctl(args: string[]): { ok: boolean; output: string } {
   try {
-    const output = execFileSync("launchctl", args, { encoding: "utf8", timeout: 10_000 });
+    // stderr must be captured, never inherited: a routine negative probe
+    // ("Could not find service … in domain") is a state we REPORT, not noise
+    // the child gets to print over our own output.
+    const output = execFileSync("launchctl", args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 10_000,
+    });
     return { ok: true, output };
   } catch (err) {
     const e = err as { stdout?: string; stderr?: string; message?: string };

--- a/test/cli/deputy-cli.test.ts
+++ b/test/cli/deputy-cli.test.ts
@@ -56,7 +56,8 @@ describe("things deputy status", () => {
   it("reports a bare machine honestly (nothing installed, not running, routing disabled)", async () => {
     await run(["deputy", "status"]);
     const out = stdout.join("");
-    expect(out).toContain("deputy: not running");
+    expect(out).toContain("deputy: does not appear to be running");
+    expect(out).not.toContain("detail:");
     expect(out).toContain("routing: disabled");
     expect(process.exitCode).toBe(0);
   });


### PR DESCRIPTION
Papercut reported by the maintainer on first `things deputy status` run (nothing installed yet): `launchctl print`'s stderr ("Bad request. / Could not find service … 503") leaked over our output because the wrapper captured stdout only, and the headline read as diagnostic soup. Now: stderr captured (a negative probe is state we report, not noise the child prints), headline is `deputy: does not appear to be running`, and non-trivial diagnoses (socket present but unresponsive, handshake refused) keep a dedicated detail line. Test updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLK6KCdfjfQrwAdSwP31S7