### PR TITLE
deputy: consent-stall-proof handshake + correct signing detection

### DIFF
--- a/deputy/src/server.swift
+++ b/deputy/src/server.swift
@@ -15,6 +15,23 @@ final class Server {
   private let osaQueue = DispatchQueue(label: "things-deputy.osa")
   private let logQueue = DispatchQueue(label: "things-deputy.log")
   private var reader: SqliteReader?  // guarded by dbQueue
+  /// Last successful container resolution. Guarded by its OWN lock — never by
+  /// dbQueue — so hello's cache read can never queue behind a locate/sql that
+  /// is mid-stall awaiting TCC consent on that queue.
+  private let cacheLock = NSLock()
+  private var cachedDbPath: String?
+
+  private func readCachedDbPath() -> String? {
+    cacheLock.lock()
+    defer { cacheLock.unlock() }
+    return cachedDbPath
+  }
+
+  private func storeCachedDbPath(_ path: String) {
+    cacheLock.lock()
+    cachedDbPath = path
+    cacheLock.unlock()
+  }
   private var listenFd: Int32 = -1
 
   init(paths: DeputyPaths, config: DeputyConfig, token: String) {
@@ -275,13 +292,22 @@ final class Server {
       "protocol": PROTOCOL_VERSION,
       "deputyVersion": DEPUTY_VERSION,
       "pid": Int(getpid()),
-      "dbPath": resolveDbPath() ?? NSNull(),
+      // Cheap cached read ONLY — the handshake must never touch the protected
+      // container. On an ungranted machine that touch blocks in the kernel
+      // awaiting TCC consent, and a handshake that can hang on a consent
+      // dialog deadlocks every client (observed live 2026-08-21). The client
+      // resolves the path with the `locate` verb, which is allowed to stall.
+      "dbPath": readCachedDbPath() ?? NSNull(),
       "uptimeMs": Int(Date().timeIntervalSince(startedAt) * 1000),
     ]
   }
 
   private func handleLocate(id: Any?) -> [String: Any] {
+    // The first locate on an ungranted machine BLOCKS in open() until the
+    // user answers the macOS consent prompt — deliberate: this is the verb
+    // the grant ceremony rides. Result cached for hello.
     let candidates = locateCandidates()
+    if let first = candidates.first { storeCachedDbPath(first) }
     guard let first = candidates.first else {
       return errorResponse(
         id: id, code: "not-found",
@@ -298,6 +324,7 @@ final class Server {
       guard let dbPath = resolveDbPath() else {
         return errorResponse(id: id, code: "not-found", message: "no Things database to query (locate failed and no dbPath configured)")
       }
+      storeCachedDbPath(dbPath)
       do {
         reader = try SqliteReader(path: dbPath)
       } catch {

--- a/src/cli/commands/deputy.ts
+++ b/src/cli/commands/deputy.ts
@@ -44,7 +44,7 @@ function renderStatus(status: DeputyStatus): string {
   if (status.hello !== null) {
     lines.push(
       `  version: ${status.hello.deputyVersion} (protocol ${status.hello.protocol}, pid ${status.hello.pid})`,
-      `  database: ${status.hello.dbPath ?? "not found"}`,
+      `  database: ${status.hello.dbPath ?? "not yet resolved (resolved on first read)"}`,
     );
   }
   if (status.signing !== null) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -10,7 +10,7 @@ import { PKG_VERSION, type GroupBlock, type Truncation } from "./contracts.ts";
 import { BASELINES } from "./db/baselines/index.ts";
 import { openConnection, type ThingsConnection } from "./db/connection.ts";
 import { createDeputyDbFacade } from "./deputy/db-facade.ts";
-import { deputyRoutesDb, deputyRouting } from "./deputy/routing.ts";
+import { deputyDbPath, deputyRoutesDb } from "./deputy/routing.ts";
 import {
   compareToBaseline,
   observeSchema,
@@ -911,7 +911,7 @@ export function openThings(options: OpenOptions = {}): ThingsClient {
     options.dbPath !== undefined ? { dbPath: options.dbPath } : undefined,
     env,
   )
-    ? (deputyRouting(env).hello?.dbPath ?? null)
+    ? deputyDbPath(env)
     : null;
   const located =
     routedDbPath !== null

--- a/src/deputy/install.ts
+++ b/src/deputy/install.ts
@@ -5,7 +5,7 @@
  * crashed deputy relaunches with its identity (and therefore its macOS
  * permission grants) intact.
  */
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import {
   chmodSync,
   copyFileSync,
@@ -99,22 +99,13 @@ export interface DeputySigning {
 
 /** codesign facts about a binary (diagnostic output — may name mechanisms). */
 export function deputySigningInfo(binaryPath: string): DeputySigning {
-  let out: string;
-  try {
-    out = execFileSync("codesign", ["-dvv", binaryPath], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: 10_000,
-    });
-  } catch (err) {
-    const e = err as { stderr?: string; stdout?: string };
-    const text = `${e.stdout ?? ""}${e.stderr ?? ""}`;
-    if (/not signed at all/i.test(text)) return { state: "unsigned", authority: null };
-    // codesign prints details on stderr and still exits 0 on success — a
-    // nonzero exit with no recognizable marker is an unknown state.
-    out = text;
-    if (out === "") return { state: "unknown", authority: null };
-  }
+  // spawnSync, not execFileSync: codesign prints its details on STDERR while
+  // exiting 0, and execFileSync only surfaces stderr on the failure path — the
+  // success case must read both streams.
+  const res = spawnSync("codesign", ["-dvv", binaryPath], { encoding: "utf8", timeout: 10_000 });
+  const out = `${res.stdout ?? ""}${res.stderr ?? ""}`;
+  if (res.error !== undefined || out === "") return { state: "unknown", authority: null };
+  if (/not signed at all/i.test(out)) return { state: "unsigned", authority: null };
   if (/Signature=adhoc/i.test(out)) return { state: "adhoc", authority: null };
   const authority = /Authority=(.+)/.exec(out)?.[1]?.trim() ?? null;
   return authority !== null

--- a/src/deputy/routing.ts
+++ b/src/deputy/routing.ts
@@ -47,6 +47,8 @@ interface ActiveState {
   token: string;
   bridge: DeputySyncBridge;
   client: DeputyAsyncClient;
+  /** Memoized `locate` result (undefined = not asked yet this process). */
+  dbPathMemo?: string | null;
 }
 
 interface InactiveState {
@@ -233,6 +235,40 @@ export async function deputyAsyncRequest(
       timeoutMs,
     ),
   );
+}
+
+/**
+ * A first container touch on an ungranted machine blocks in the kernel until
+ * the user answers the macOS consent prompt — give the human time to find it.
+ */
+const FIRST_CONTACT_LOCATE_TIMEOUT_MS = 90_000;
+
+/**
+ * The deputy-resolved container database path, or null when the deputy is
+ * inactive or cannot resolve one. The handshake never touches the protected
+ * container (a consent stall there would deadlock every client), so on first
+ * contact this asks the `locate` verb — the request the grant ceremony rides,
+ * deliberately allowed to stall while the user answers the consent prompt.
+ */
+export function deputyDbPath(env: NodeJS.ProcessEnv = process.env): string | null {
+  const active = activeState(env);
+  if (active === null) return null;
+  if (active.hello.dbPath !== null) return active.hello.dbPath;
+  if (active.dbPathMemo !== undefined) return active.dbPathMemo;
+  process.stderr.write(
+    "things-api deputy: first database access through the helper — if macOS shows a consent prompt for things-deputy, approve it (waiting up to 90s)\n",
+  );
+  try {
+    const res = deputySyncRequest({ verb: "locate" }, FIRST_CONTACT_LOCATE_TIMEOUT_MS, env);
+    active.dbPathMemo = typeof res["path"] === "string" ? res["path"] : null;
+  } catch (err) {
+    active.dbPathMemo = null;
+    const why = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `things-api deputy: could not resolve the database through the helper (${why}) — this read runs DIRECT\n`,
+    );
+  }
+  return active.dbPathMemo;
 }
 
 /**

--- a/src/diagnose.ts
+++ b/src/diagnose.ts
@@ -13,7 +13,7 @@ import { decodeRecurrenceRule } from "./model/recurrence.ts";
 import { BASELINES } from "./db/baselines/index.ts";
 import { openConnection, ThingsDbOpenError } from "./db/connection.ts";
 import { createDeputyDbFacade } from "./deputy/db-facade.ts";
-import { deputyRoutesDb, deputyRouting } from "./deputy/routing.ts";
+import { deputyDbPath, deputyRoutesDb } from "./deputy/routing.ts";
 import { compareToBaseline, observeSchema } from "./db/fingerprint.ts";
 import { locateThingsDb, ThingsDbNotFoundError } from "./db/locate.ts";
 import {
@@ -262,7 +262,7 @@ export function diagnose(dbPath?: string, options: DiagnoseOptions = {}): Diagno
   // Mirror openThings: deputy-brokered database access for the default
   // container db, local open for explicit paths (src/deputy/routing.ts).
   const routedDbPath = deputyRoutesDb(dbPath !== undefined ? { dbPath } : undefined)
-    ? (deputyRouting().hello?.dbPath ?? null)
+    ? deputyDbPath()
     : null;
   let located: ReturnType<typeof locateThingsDb>;
   try {

--- a/test/deputy/broker-integration.test.ts
+++ b/test/deputy/broker-integration.test.ts
@@ -146,12 +146,14 @@ echo "$1:$2:$3:$4:$5:$6"
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("handshakes with the package version and the configured db path", () => {
+  it("handshakes with the package version; dbPath is null until a locate/sql resolves it", () => {
     const res = request({ verb: "hello" });
     expect(res["ok"]).toBe(true);
     expect(res["protocol"]).toBe(1);
     expect(res["deputyVersion"]).toBe(PKG_VERSION);
-    expect(res["dbPath"]).toBe(dbPath);
+    // The handshake never touches the (TCC-protected) container — the path is
+    // unresolved until the first locate/sql, then cached (asserted below).
+    expect(res["dbPath"]).toBeNull();
   });
 
   it("rejects a bad token", () => {
@@ -282,9 +284,11 @@ echo "$1:$2:$3:$4:$5:$6"
     expect(res["ok"]).toBe(false);
   });
 
-  it("locate answers with the configured database", () => {
+  it("locate answers with the configured database, and hello then reports the cached path", () => {
     const res = request({ verb: "locate" });
     expect(res["ok"]).toBe(true);
     expect(res["path"]).toBe(dbPath);
+    const hello = request({ verb: "hello" });
+    expect(hello["dbPath"]).toBe(dbPath);
   });
 });

--- a/test/unit/deputy-routing.test.ts
+++ b/test/unit/deputy-routing.test.ts
@@ -19,6 +19,7 @@ import { osaExec, osaExecSync } from "../../src/deputy/osa.ts";
 import { shortcutsListSync, shortcutsRunExec } from "../../src/deputy/shortcuts-exec.ts";
 import { deputySocketPath, deputyTokenPath, reviveRow } from "../../src/deputy/protocol.ts";
 import {
+  deputyDbPath,
   deputyRoutesDb,
   deputyRouting,
   resetDeputyRoutingForTests,
@@ -38,6 +39,8 @@ interface MockOverrides {
   deputyVersion?: string;
   protocol?: number;
   dbPath?: string | null;
+  /** hello's cached-path field; defaults to dbPath (warm-cache deputy). */
+  helloDbPath?: string | null;
   sqlRows?: Record<string, unknown>[];
   osaResult?: Record<string, unknown>;
   token?: string;
@@ -60,6 +63,12 @@ async function startMock(overrides: MockOverrides = {}): Promise<void> {
         overrides.dbPath === undefined
           ? "/tmp/mock-things/D.thingsdatabase/main.sqlite"
           : overrides.dbPath,
+      helloDbPath:
+        overrides.helloDbPath !== undefined
+          ? overrides.helloDbPath
+          : overrides.dbPath === undefined
+            ? "/tmp/mock-things/D.thingsdatabase/main.sqlite"
+            : overrides.dbPath,
       sqlRows: overrides.sqlRows ?? [],
       osaResult: overrides.osaResult ?? { exitCode: 0, stdout: "ok\n", stderr: "" },
     },
@@ -163,6 +172,26 @@ describe("db routing rules", () => {
     expect(deputyRoutesDb({ dbPath: "/tmp/explicit.sqlite" })).toBe(false);
     process.env["THINGS_DB"] = "/tmp/env.sqlite";
     expect(deputyRoutesDb(undefined)).toBe(false);
+  });
+
+  it("deputyDbPath uses the handshake cache when warm", async () => {
+    await startMock();
+    expect(deputyDbPath()).toContain("main.sqlite");
+  });
+
+  it("deputyDbPath falls back to locate on a cold handshake (first contact)", async () => {
+    await startMock({ helloDbPath: null });
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    expect(deputyDbPath()).toContain("main.sqlite");
+    expect(stderrSpy.mock.calls.map((c) => String(c[0])).join("")).toContain("consent prompt");
+    stderrSpy.mockRestore();
+  });
+
+  it("deputyDbPath is null (direct fallback) when locate cannot resolve", async () => {
+    await startMock({ helloDbPath: null, dbPath: null });
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    expect(deputyDbPath()).toBeNull();
+    stderrSpy.mockRestore();
   });
 });
 

--- a/test/unit/helpers/mock-deputy-worker.ts
+++ b/test/unit/helpers/mock-deputy-worker.ts
@@ -19,6 +19,8 @@ interface MockConfig {
   deputyVersion: string;
   protocol: number;
   dbPath: string | null;
+  /** hello's dbPath (the deputy's CACHE — null until a locate/sql resolved it). */
+  helloDbPath: string | null;
   sqlRows: Record<string, unknown>[];
   osaResult: Record<string, unknown>;
 }
@@ -41,7 +43,7 @@ function respond(req: Record<string, unknown>): Record<string, unknown> {
         protocol: cfg.protocol,
         deputyVersion: cfg.deputyVersion,
         pid: 4242,
-        dbPath: cfg.dbPath,
+        dbPath: cfg.helloDbPath,
         uptimeMs: 7,
       };
     case "sql":


### PR DESCRIPTION
Two live-ceremony findings from the maintainer's first install:

1. **Handshake deadlock on an ungranted machine (the big one).** `hello` eagerly resolved the db path, touching the TCC-protected container; the kernel holds that open() while consent is pending, so the very first `deputy status` hung the handshake and every subsequent connection piled into the stall (thread sample confirmed: conn threads in `locateCandidates → open()`, accept loop healthy). `hello` now returns only the deputy's cached path guarded by its own lock (never the db queue, which may legitimately be mid-stall); the client resolves the path via `locate` — the verb the grant ceremony rides — with a 90s first-contact budget, a watch-for-the-prompt stderr notice, and DIRECT fallback on failure. Live-suite asserts hello is null-before/cached-after.

2. **`deputySigningInfo` false 'unknown'.** codesign prints details to stderr and exits 0; execFileSync only surfaces stderr on failure, so every install warned about a fully signed binary. spawnSync reads both streams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLK6KCdfjfQrwAdSwP31S7