### PR TITLE
deputy install: unlink before copy (kernel CS cache is per-vnode)

### DIFF
--- a/src/deputy/install.ts
+++ b/src/deputy/install.ts
@@ -141,6 +141,12 @@ export function installDeputy(
 
   // Stop a running deputy before overwriting its binary (ignore "not loaded").
   launchctl(["bootout", launchTarget()]);
+  // Unlink FIRST: the kernel caches code-signature state per vnode, so
+  // copying over an inode that has ever been executed makes every future exec
+  // die with SIGKILL "Taskgated Invalid Signature" — even though the new
+  // bytes' signature verifies clean on disk (observed live 2026-08-21, a
+  // launchd 10s crash-respawn loop). A fresh inode resets the cache.
+  rmSync(target, { force: true });
   copyFileSync(source, target);
   chmodSync(target, 0o755);
 


### PR DESCRIPTION
Third live-ceremony finding: the FIRST install ran fine, but a REinstall copied the new binary over the already-executed inode — the kernel's per-vnode code-signature cache then rejected every exec with SIGKILL `Taskgated Invalid Signature` (crash report attached the verdict; `codesign --verify` was clean on disk; launchd sat in a 10s crash-respawn loop and `status` honestly said not running). `rmSync` before `copyFileSync` gives a fresh vnode and a fresh cache — the same class of fix build-deputy.sh already carries for ld overwrites.

Verified live on the maintainer's host: fresh-inode copy executes, launchd kickstart brings the deputy up, `things deputy status` reports running with the Developer ID signature and the lazily-resolved database path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLK6KCdfjfQrwAdSwP31S7