### PR TITLE
fix(test-safety): launchctl inert under the test shield

### DIFF
--- a/src/deputy/install.ts
+++ b/src/deputy/install.ts
@@ -233,6 +233,16 @@ function launchTarget(): string {
 }
 
 function launchctl(args: string[]): { ok: boolean; output: string } {
+  // The other half of the test blast-shield: with the LaunchAgents dir
+  // redirected, real launchctl calls would still act on the REAL jobs while
+  // the plists are fakes — tests booted the live helpers out mid-check on
+  // 2026-08-24 exactly this way. Under the override, launchctl is inert.
+  if ((process.env["THINGS_API_LAUNCH_AGENTS_DIR"] ?? "") !== "") {
+    return {
+      ok: false,
+      output: "launchctl disabled under THINGS_API_LAUNCH_AGENTS_DIR (test shield)",
+    };
+  }
   try {
     // stderr must be captured, never inherited: a routine negative probe
     // ("Could not find service … in domain") is a state we REPORT, not noise


### PR DESCRIPTION
Second limb of today's test-mutates-host incident: the plist seam (#574) protected the files, but suites still ran real `launchctl bootout` against the live labels, unloading Mike's running helpers mid-check. Under THINGS_API_LAUNCH_AGENTS_DIR (set globally in vitest), launchctl is now inert. Full check green (3386).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eBQZm7s4r3dG8r8EZWdLp