### PR TITLE
docs(up-next): retire the PRE-0.19.0 runway — v0.19.0 is cut and verified

### DIFF
--- a/docs/up-next.md
+++ b/docs/up-next.md
@@ -4,12 +4,6 @@ The working queue for the next session(s): **open items only**. An item is DELET
 
 **One-home rule:** every open item lives in exactly ONE of {this file, roadmap.md}. This file holds the short-horizon queue; roadmap holds durable strategy. No item is restated across the two.
 
-## PRE-0.19.0 — the release runway (Mike's pinned order, 2026-08-25; do these first, in this order)
-
-1. **Cut v0.19.0** (the release drill: five-file bump precedent #536/#496, tag, watch all three jobs). The `build-helpers` job's notarization leg is ALSO the pending verification that Apple's notary accepts the reader's new SBPL temporary-exception entitlements (#574) — watch that leg specifically; a rejection there means the self-bind entitlement story needs a fallback and the release halts. Consumer-verify the published tarball (prebuilt bundle = helpers 1.3.0, codesign/staple/spctl) per the v0.18.0 drill.
-
-Everything else stays queued below (Mike, 2026-08-25: "all the rest can remain on up-next").
-
 Sections are blocker-classes: **needs-Mike** (a decision, near-zero effort) · **VM-batchable** (autonomous lab campaigns) · **needs-human** (a short in-person sitting) · **calendar-pinned** (date-driven) · **small code** (unblocked, low effort) · **feature design** (wants an ideation round before code).
 
 ## needs-Mike — decisions blocked on him, near-zero effort


### PR DESCRIPTION
Both runway items have landed, so the section goes (git is the archive):

1. #580 — fixed in #584.
2. Cut v0.19.0 — tagged `v0.19.0` at 8aa55dc, all three release jobs green, tarball consumer-verified.

The section's closing note ("everything else stays queued below") goes with it; the blocker-class legend stays.

**The pending question is answered.** Apple's notary ACCEPTED the sandboxed reader carrying `com.apple.security.temporary-exception.sbpl` and `…temporary-exception.files.home-relative-path.read-write` (#574) — both are present in the published bundle's signature. The v0.19.0 tarball's `deputy/prebuilt/Things API Helper.app` (helpers 1.3.0) passes `codesign --verify --deep --strict`, `xcrun stapler validate`, and `spctl --assess --type execute` → `accepted / source=Notarized Developer ID`. No self-bind fallback is needed.

`npm run check`: exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eBQZm7s4r3dG8r8EZWdLp