### PR TITLE
test: sweep the abandoned temp DIRECTORIES too (539/run → 0)

### DIFF
--- a/test/cli/config-get-cli.test.ts
+++ b/test/cli/config-get-cli.test.ts
@@ -3,12 +3,12 @@
  * Config is read from the scratch config dir + env only (no DB), so these run
  * anywhere.
  */
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { buildProgram } from "../../src/cli/main.ts";
+import { makeTempDir } from "../fixtures/temp-dir.ts";
 
 let configDir: string;
 let stdout: string[];
@@ -30,7 +30,7 @@ const ENV_KEYS = [
 ];
 
 beforeEach(() => {
-  const stateDir = mkdtempSync(join(tmpdir(), "things-api-config-get-"));
+  const stateDir = makeTempDir("things-api-config-get");
   configDir = join(stateDir, "config");
   for (const key of ENV_KEYS) envBackup[key] = process.env[key];
   // Clear every THINGS_API_* override so defaults are deterministic.

--- a/test/cli/permission-gates.test.ts
+++ b/test/cli/permission-gates.test.ts
@@ -8,8 +8,6 @@
  * container access, which is exactly the property under test — and no cell can
  * reach the host's real Things library or its consent state.
  */
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -20,6 +18,7 @@ import { resetCapabilityForTests } from "../../src/capability.ts";
 import { resetDeputyRoutingForTests } from "../../src/deputy/routing.ts";
 import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
 import { seedTodo } from "../fixtures/seed.ts";
+import { makeTempDir } from "../fixtures/temp-dir.ts";
 
 function runCli(argv: string[]): { stdout: string; stderr: string; exitCode: number } {
   const out: string[] = [];
@@ -60,7 +59,7 @@ const OVERRIDDEN = ["HOME", "THINGS_API_STATE_DIR", "THINGS_API_HELPERS", "THING
 
 beforeEach(() => {
   for (const key of OVERRIDDEN) saved[key] = process.env[key];
-  const sandbox = mkdtempSync(join(tmpdir(), "things-gate-"));
+  const sandbox = makeTempDir("things-gate");
   // No TCC.db under this HOME, so the Full Disk Access check fails; no marker
   // under this state dir, so no witnessed session grant; helpers forced off.
   process.env["HOME"] = sandbox;

--- a/test/cli/universal-dry-run.test.ts
+++ b/test/cli/universal-dry-run.test.ts
@@ -11,8 +11,7 @@
  *       nothing) or refuse loudly (mcp), never a silent no-op.
  * The existing write dry-run plans live in test/cli/write-cli.test.ts (untouched).
  */
-import { mkdtempSync, readdirSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -23,6 +22,7 @@ import { declaresDryRun, stripInertDryRun } from "../../src/cli/dry-run.ts";
 import { resolveInvocation } from "../../src/cli/resolve-invocation.ts";
 import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
 import { seedArea, seedProject, seedTodo } from "../fixtures/seed.ts";
+import { makeTempDir } from "../fixtures/temp-dir.ts";
 
 /**
  * Normalize the one non-deterministic field (`meta.elapsedMs`, a wall-clock
@@ -167,7 +167,7 @@ describe("local-side-effect commands honor --dry-run", () => {
   const envBackup: Record<string, string | undefined> = {};
 
   beforeEach(() => {
-    const stateDir = mkdtempSync(join(tmpdir(), "things-api-universal-dryrun-"));
+    const stateDir = makeTempDir("things-api-universal-dryrun");
     configDir = join(stateDir, "config");
     for (const k of ["THINGS_API_STATE_DIR", "THINGS_API_CONFIG_DIR", "THINGS_API_ACTOR"])
       envBackup[k] = process.env[k];

--- a/test/engine/write-batch-temp-ids.test.ts
+++ b/test/engine/write-batch-temp-ids.test.ts
@@ -5,7 +5,6 @@
  * `$refs` resolve against real rows. Mirrors write-simulator.test.ts's fence
  * setup.
  */
-import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -21,6 +20,7 @@ import { createSimulatorVector } from "../../src/write/vectors/simulator.ts";
 import type { WriteVector } from "../../src/write/vectors/types.ts";
 import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
 import { seedTodo } from "../fixtures/seed.ts";
+import { makeTempDir } from "../fixtures/temp-dir.ts";
 
 const NOW = new Date("2026-07-05T12:00:00Z");
 
@@ -85,15 +85,15 @@ const row = (uuid: string): Record<string, unknown> | undefined =>
 
 beforeEach(() => {
   fixture = buildFixtureDb({ benchMarker: true });
-  auditDirPath = mkdtempSync(join(tmpdir(), "batch-temp-audit-"));
+  auditDirPath = makeTempDir("batch-temp-audit");
   savedSim = process.env["THINGS_SIM_WRITES"];
   savedDb = process.env["THINGS_DB"];
   savedState = process.env["THINGS_API_STATE_DIR"];
   savedConfig = process.env["THINGS_API_CONFIG_DIR"];
   process.env["THINGS_SIM_WRITES"] = "1";
   process.env["THINGS_DB"] = fixture.path;
-  process.env["THINGS_API_STATE_DIR"] = mkdtempSync(join(tmpdir(), "batch-temp-state-"));
-  process.env["THINGS_API_CONFIG_DIR"] = mkdtempSync(join(tmpdir(), "batch-temp-config-"));
+  process.env["THINGS_API_STATE_DIR"] = makeTempDir("batch-temp-state");
+  process.env["THINGS_API_CONFIG_DIR"] = makeTempDir("batch-temp-config");
   vector = createSimulatorVector(fixture.path, { now: () => NOW });
 });
 afterEach(() => {

--- a/test/engine/write-clone.test.ts
+++ b/test/engine/write-clone.test.ts
@@ -6,7 +6,6 @@
  * checklist checked-state, terminal state with the exact stopDate, structure),
  * (c) the source is untouched, and (d) the refusal taxonomy.
  */
-import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -27,6 +26,7 @@ import {
   seedProject,
   seedTodo,
 } from "../fixtures/seed.ts";
+import { makeTempDir } from "../fixtures/temp-dir.ts";
 
 const NOW = new Date("2026-07-05T12:00:00Z");
 const TODAY = "2026-07-05";
@@ -100,8 +100,8 @@ beforeEach(() => {
   savedConfig = process.env["THINGS_API_CONFIG_DIR"];
   process.env["THINGS_SIM_WRITES"] = "1";
   process.env["THINGS_DB"] = fixture.path;
-  process.env["THINGS_API_STATE_DIR"] = mkdtempSync(join(tmpdir(), "clone-state-"));
-  process.env["THINGS_API_CONFIG_DIR"] = mkdtempSync(join(tmpdir(), "clone-config-"));
+  process.env["THINGS_API_STATE_DIR"] = makeTempDir("clone-state");
+  process.env["THINGS_API_CONFIG_DIR"] = makeTempDir("clone-config");
   vector = createSimulatorVector(fixture.path, { now: () => NOW });
 });
 function restoreEnv(k: string, v: string | undefined): void {

--- a/test/engine/write-collateral.test.ts
+++ b/test/engine/write-collateral.test.ts
@@ -17,7 +17,6 @@
  *   - a simulated collateral write            → verify-failed:collateral, naming
  *                                                the field and both values
  */
-import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -31,6 +30,7 @@ import { createSimulatorVector } from "../../src/write/vectors/simulator.ts";
 import type { CompiledInvocation, WriteVector } from "../../src/write/vectors/types.ts";
 import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
 import { seedTodo } from "../fixtures/seed.ts";
+import { makeTempDir } from "../fixtures/temp-dir.ts";
 
 const NOW = new Date("2026-07-05T12:00:00Z");
 const GUI = { dangerouslyDriveGui: true } as const;
@@ -119,8 +119,8 @@ describe("reschedule-repeat: an unrequested field movement is verify-failed:coll
     savedConfig = process.env["THINGS_API_CONFIG_DIR"];
     process.env["THINGS_SIM_WRITES"] = "1";
     process.env["THINGS_DB"] = fixture.path;
-    process.env["THINGS_API_STATE_DIR"] = mkdtempSync(join(tmpdir(), "collateral-state-"));
-    process.env["THINGS_API_CONFIG_DIR"] = mkdtempSync(join(tmpdir(), "collateral-config-"));
+    process.env["THINGS_API_STATE_DIR"] = makeTempDir("collateral-state");
+    process.env["THINGS_API_CONFIG_DIR"] = makeTempDir("collateral-config");
     vector = createSimulatorVector(fixture.path, { now: () => NOW });
   });
   afterEach(() => {

--- a/test/engine/write-promote-clone.test.ts
+++ b/test/engine/write-promote-clone.test.ts
@@ -7,7 +7,7 @@
  * an EMBEDDED leg (not an independent todo.clone summary), (e) the undo trash-both
  * + restore round-trip, (f) the refusal + gating copy. No Things app is touched.
  */
-import { existsSync, mkdtempSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -33,6 +33,7 @@ import { createSimulatorVector } from "../../src/write/vectors/simulator.ts";
 import type { WriteVector } from "../../src/write/vectors/types.ts";
 import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
 import { seedArea, seedProject, seedTodo } from "../fixtures/seed.ts";
+import { makeTempDir } from "../fixtures/temp-dir.ts";
 
 const NOW = new Date("2026-07-05T12:00:00Z");
 /** A pre-write umd well before NOW — the value --preserve-modified must return X to. */
@@ -145,9 +146,9 @@ beforeEach(() => {
   savedConfig = process.env["THINGS_API_CONFIG_DIR"];
   process.env["THINGS_SIM_WRITES"] = "1";
   process.env["THINGS_DB"] = fixture.path;
-  process.env["THINGS_API_STATE_DIR"] = mkdtempSync(join(tmpdir(), "promote-state-"));
-  process.env["THINGS_API_CONFIG_DIR"] = mkdtempSync(join(tmpdir(), "promote-config-"));
-  auditDir = mkdtempSync(join(tmpdir(), "promote-audit-"));
+  process.env["THINGS_API_STATE_DIR"] = makeTempDir("promote-state");
+  process.env["THINGS_API_CONFIG_DIR"] = makeTempDir("promote-config");
+  auditDir = makeTempDir("promote-audit");
   vector = createSimulatorVector(fixture.path, { now: () => NOW });
 });
 function restoreEnv(k: string, v: string | undefined): void {

--- a/test/engine/write-simulator.test.ts
+++ b/test/engine/write-simulator.test.ts
@@ -5,8 +5,6 @@
  * covered op asserts (a) an "ok" result, (b) the DB post-state by direct SQL,
  * and (c) an audit record appended.
  */
-import { randomUUID } from "node:crypto";
-import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -44,6 +42,7 @@ import {
   seedTag,
   seedTodo,
 } from "../fixtures/seed.ts";
+import { makeTempDir } from "../fixtures/temp-dir.ts";
 
 const NOW = new Date("2026-07-05T12:00:00Z");
 const NOW_EPOCH = Math.floor(NOW.getTime() / 1000);
@@ -118,8 +117,8 @@ describe("simulator write vector — covered operations", () => {
     savedConfig = process.env["THINGS_API_CONFIG_DIR"];
     process.env["THINGS_SIM_WRITES"] = "1";
     process.env["THINGS_DB"] = fixture.path;
-    process.env["THINGS_API_STATE_DIR"] = mkdtempSync(join(tmpdir(), "sim-state-"));
-    process.env["THINGS_API_CONFIG_DIR"] = mkdtempSync(join(tmpdir(), "sim-config-"));
+    process.env["THINGS_API_STATE_DIR"] = makeTempDir("sim-state");
+    process.env["THINGS_API_CONFIG_DIR"] = makeTempDir("sim-config");
     vector = createSimulatorVector(fixture.path, { now: () => NOW });
   });
   afterEach(() => {
@@ -690,7 +689,7 @@ describe("simulator write vector — covered operations", () => {
     // The undo executor replays an INVERSE mutation through the same pipeline
     // (and the same simulator vector) from the on-disk audit trail — so it needs
     // a real audit writer, not the in-memory array.
-    const auditDir = join(tmpdir(), `sim-audit-${randomUUID()}`);
+    const auditDir = makeTempDir("sim-audit");
     const writer = createAuditWriter({ dir: auditDir, secrets: [], enabled: true });
     const d = deps(vector, { audit: writer });
     const uuid = seedTodo(fixture.db, { title: "Before" });
@@ -1605,8 +1604,8 @@ describe("simulator fence", () => {
       THINGS_API_STATE_DIR: process.env["THINGS_API_STATE_DIR"],
       THINGS_API_CONFIG_DIR: process.env["THINGS_API_CONFIG_DIR"],
     };
-    process.env["THINGS_API_STATE_DIR"] = mkdtempSync(join(tmpdir(), "sim-state-"));
-    process.env["THINGS_API_CONFIG_DIR"] = mkdtempSync(join(tmpdir(), "sim-config-"));
+    process.env["THINGS_API_STATE_DIR"] = makeTempDir("sim-state");
+    process.env["THINGS_API_CONFIG_DIR"] = makeTempDir("sim-config");
   });
   afterEach(() => {
     for (const key of Object.keys(saved)) restoreEnv(key, saved[key]);
@@ -1760,8 +1759,8 @@ describe("simulator fence — host-escape guards (no live app under the fence)",
     };
     process.env["THINGS_SIM_WRITES"] = "1";
     process.env["THINGS_DB"] = fixture.path;
-    process.env["THINGS_API_STATE_DIR"] = mkdtempSync(join(tmpdir(), "sim-state-"));
-    process.env["THINGS_API_CONFIG_DIR"] = mkdtempSync(join(tmpdir(), "sim-config-"));
+    process.env["THINGS_API_STATE_DIR"] = makeTempDir("sim-state");
+    process.env["THINGS_API_CONFIG_DIR"] = makeTempDir("sim-config");
     vector = createSimulatorVector(fixture.path, { now: () => NOW });
   });
   afterEach(() => {

--- a/test/engine/write-verify-clock.test.ts
+++ b/test/engine/write-verify-clock.test.ts
@@ -15,7 +15,6 @@
  * guaranteeing the injected clock is ahead of the wall clock whenever the suite
  * runs. Before the fix the FUTURE case fails; after it, both verify.
  */
-import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -27,6 +26,7 @@ import { runMutation, type WriteDeps } from "../../src/write/pipeline.ts";
 import { createSimulatorVector } from "../../src/write/vectors/simulator.ts";
 import type { WriteVector } from "../../src/write/vectors/types.ts";
 import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
+import { makeTempDir } from "../fixtures/temp-dir.ts";
 
 // Far enough ahead that the injected clock is ALWAYS in the future relative to
 // the wall clock the suite runs under — this is exactly the condition the bug
@@ -88,8 +88,8 @@ beforeEach(() => {
   savedConfig = process.env["THINGS_API_CONFIG_DIR"];
   process.env["THINGS_SIM_WRITES"] = "1";
   process.env["THINGS_DB"] = fixture.path;
-  process.env["THINGS_API_STATE_DIR"] = mkdtempSync(join(tmpdir(), "vclock-state-"));
-  process.env["THINGS_API_CONFIG_DIR"] = mkdtempSync(join(tmpdir(), "vclock-config-"));
+  process.env["THINGS_API_STATE_DIR"] = makeTempDir("vclock-state");
+  process.env["THINGS_API_CONFIG_DIR"] = makeTempDir("vclock-config");
 });
 afterEach(() => {
   fixture.close();

--- a/test/fixtures/temp-dir.ts
+++ b/test/fixtures/temp-dir.ts
@@ -1,0 +1,60 @@
+/**
+ * Throwaway temp DIRECTORIES for tests — state dirs, config dirs, audit dirs,
+ * sandbox roots — swept by the same setup file that sweeps fixture databases
+ * (`test/setup/fixture-sweep.ts`).
+ *
+ * This is the sibling of the fixture-db leak: ~22 call sites did
+ * `mkdtempSync(join(tmpdir(), "<prefix>-"))` and never removed the directory, so
+ * one suite run abandoned 539 of them. Rather than ask every site to remember an
+ * `afterAll`, the maker registers the path and the sweep deletes it — a new call
+ * site is clean by default.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Vitest isolates the module graph per test file, so the registry would
+ * otherwise be per-file while the WORKER PROCESS outlives it — the exit backstop
+ * below has to see every file's paths, hence the process-global home.
+ */
+const REGISTRY_KEY = Symbol.for("things-api.test.temp-dirs");
+const registry: Set<string> = ((globalThis as Record<symbol, unknown>)[REGISTRY_KEY] ??=
+  new Set<string>()) as Set<string>;
+
+const EXIT_HOOK_KEY = Symbol.for("things-api.test.temp-dir-exit-hook");
+if ((globalThis as Record<symbol, unknown>)[EXIT_HOOK_KEY] === undefined) {
+  (globalThis as Record<symbol, unknown>)[EXIT_HOOK_KEY] = true;
+  // Backstop only: the per-file afterAll sweep does the real work. This catches
+  // processes that never reach it — a crashed vitest worker, say.
+  process.on("exit", () => sweepTempDirs());
+}
+
+/**
+ * Make a registered throwaway directory. `prefix` is the bare name — the
+ * separator and the random suffix are appended, so `makeTempDir("sim-state")`
+ * yields `<tmpdir>/sim-state-XXXXXX`.
+ *
+ * Lifetime is the whole test FILE (the sweep runs in `afterAll`), which is what
+ * the sites that set `THINGS_API_STATE_DIR` once at module scope need.
+ */
+export function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), `${prefix}-`));
+  registry.add(dir);
+  return dir;
+}
+
+/** Delete one registered directory and forget it. A path already gone is a no-op. */
+export function removeTempDir(dir: string): void {
+  rmSync(dir, { recursive: true, force: true });
+  registry.delete(dir);
+}
+
+/**
+ * Delete every directory made by this process so far. Safe to call repeatedly —
+ * `removeTempDir` deletes the entry it is visiting, which Set iteration defines
+ * as fine, and a path already gone is a no-op.
+ */
+export function sweepTempDirs(): void {
+  for (const dir of registry) removeTempDir(dir);
+}

--- a/test/setup/fixture-sweep.ts
+++ b/test/setup/fixture-sweep.ts
@@ -1,19 +1,22 @@
 /**
- * Suite-wide cleanup for the throwaway fixture databases.
+ * Suite-wide cleanup for the throwaway fixture databases and temp directories.
  *
  * `buildFixtureDb` is called from ~90 test files and ~630 sites, most of which
- * never close their handle, let alone delete the file. Rather than ask every
- * site to remember, the builder registers each path and this setup file sweeps
- * the registry — so a new call site is clean by default.
+ * never close their handle, let alone delete the file. `makeTempDir` covers the
+ * sibling class — the state/config/audit directories. Rather than ask every site
+ * to remember, both register what they hand out and this setup file sweeps the
+ * registries — so a new call site is clean by default.
  *
  * `afterAll` (per test FILE, since setup files run once per file) rather than
- * `afterEach`: fixtures built in a `beforeAll` or at module scope stay alive for
- * the whole file. Peak residue is therefore one file's worth of fixtures.
+ * `afterEach`: fixtures and directories built in a `beforeAll` or at module scope
+ * stay alive for the whole file. Peak residue is therefore one file's worth.
  */
 import { afterAll } from "vitest";
 
 import { sweepFixtureDbs } from "../fixtures/build-db.ts";
+import { sweepTempDirs } from "../fixtures/temp-dir.ts";
 
 afterAll(() => {
   sweepFixtureDbs();
+  sweepTempDirs();
 });

--- a/test/unit/area-filter.test.ts
+++ b/test/unit/area-filter.test.ts
@@ -4,8 +4,6 @@
  * keep-rule. Exercised through the client read methods (where the filter is
  * applied, before bounding) for `anytime` (grouped) and `today` (the split).
  */
-import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -13,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { openThings, ReferenceResolutionError, type ThingsClient } from "../../src/index.ts";
 import { buildFixtureDb, type FixtureDb } from "../fixtures/build-db.ts";
 import { seedArea, seedHeading, seedProject, seedTodo } from "../fixtures/seed.ts";
+import { makeTempDir } from "../fixtures/temp-dir.ts";
 
 const NOW = new Date(2026, 6, 2, 12, 0); // local 2026-07-02
 
@@ -57,7 +56,7 @@ function seedWorld(): { alpha: string; beta: string } {
 
 beforeEach(() => {
   fx = buildFixtureDb();
-  stateDir = mkdtempSync(join(tmpdir(), "things-api-area-filter-"));
+  stateDir = makeTempDir("things-api-area-filter");
 });
 afterEach(() => fx?.close());
 

--- a/test/unit/bench-loop.test.ts
+++ b/test/unit/bench-loop.test.ts
@@ -5,8 +5,7 @@
  * directly. Covers: allowlist rejection, gate revert, accept/revert tie-breaks,
  * the gui needs-mike path, and the state-file append.
  */
-import { mkdtempSync, readFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -71,6 +70,7 @@ import type {
   RefinerOutput,
 } from "../../bench/refiner.ts";
 import type { RunRecord } from "../../bench/types.ts";
+import { makeTempDir } from "../fixtures/temp-dir.ts";
 
 // --- fixtures --------------------------------------------------------------
 
@@ -783,7 +783,7 @@ describe("appendLoopState", () => {
   }
 
   it("creates the file then appends, preserving prior entries", () => {
-    const dir = mkdtempSync(join(tmpdir(), "loop-state-"));
+    const dir = makeTempDir("loop-state");
     const path = join(dir, "loop-state.json");
 
     appendLoopState(path, toStateEntry(makeResult({ iteration: 1 }), "2026-07-17T00:00:00Z"));
@@ -1021,7 +1021,7 @@ describe("extractLessons", () => {
 
 describe("appendLedger idempotence", () => {
   it("creates the arm file, appends once, and never duplicates across re-runs", () => {
-    const dir = mkdtempSync(join(tmpdir(), "ledger-"));
+    const dir = makeTempDir("ledger");
     const path = join(dir, "cli.md");
     const batch1 = [
       buildLedgerEntry(iterationResult({ iteration: 1 }), {

--- a/test/unit/bench-sandbox.test.ts
+++ b/test/unit/bench-sandbox.test.ts
@@ -10,8 +10,7 @@
  * emitted in one turn dropped one edit ~1/3 of the time.
  */
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { fileURLToPath } from "node:url";
@@ -20,11 +19,12 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import { buildBenchFixture } from "../../bench/fixture.ts";
 import { createSandbox, type Sandbox } from "../../bench/sandbox.ts";
+import { makeTempDir } from "../fixtures/temp-dir.ts";
 
 const BIN = join(dirname(fileURLToPath(import.meta.url)), "../../bin/things.js");
 
 function fenceEnv(dbPath: string): Record<string, string> {
-  const root = mkdtempSync(join(tmpdir(), "sandbox-test-"));
+  const root = makeTempDir("sandbox-test");
   mkdirSync(join(root, "config"));
   mkdirSync(join(root, "state"));
   return {

--- a/test/unit/capability.test.ts
+++ b/test/unit/capability.test.ts
@@ -285,13 +285,13 @@ describe("writeCapability", () => {
 
 // ── fixture helper ───────────────────────────────────────────────────────────
 
-import { mkdtempSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { makeTempDir } from "../fixtures/temp-dir.ts";
 
 /** A state dir holding a marker for pid 4242 of Ghostty. */
 function sessionFixture(): string {
-  const dir = mkdtempSync(join(tmpdir(), "things-session-"));
+  const dir = makeTempDir("things-session");
   writeFileSync(
     join(dir, "session-grant.json"),
     JSON.stringify({

--- a/test/unit/direct-setup.test.ts
+++ b/test/unit/direct-setup.test.ts
@@ -5,8 +5,7 @@
  * link, the Apple Event, the container open, the install sheets — is stubbed.
  * No cell in this file may reach the host's real consent state.
  */
-import { existsSync, mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
@@ -18,6 +17,7 @@ import {
 } from "../../src/direct-setup.ts";
 import { resetCapabilityForTests } from "../../src/capability.ts";
 import { CeremonyStopped, createWizard } from "../../src/wizard.ts";
+import { makeTempDir } from "../fixtures/temp-dir.ts";
 
 /**
  * A ceremony wired entirely to stubs. Defaults describe the hardest machine:
@@ -29,10 +29,10 @@ function ceremony(over: Partial<DirectSetupDeps> = {}): DirectSetupDeps {
   return {
     env: {
       __CFBundleIdentifier: "com.mitchellh.ghostty",
-      THINGS_API_STATE_DIR: mkdtempSync(join(tmpdir(), "things-setup-")),
+      THINGS_API_STATE_DIR: makeTempDir("things-setup"),
       // A scratch config dir, so the ceremony's `ui-enabled` read cannot pick
       // up the developer's own stored config and change what the closing says.
-      THINGS_API_CONFIG_DIR: mkdtempSync(join(tmpdir(), "things-setup-cfg-")),
+      THINGS_API_CONFIG_DIR: makeTempDir("things-setup-cfg"),
       THINGS_API_HELPERS: "false",
     },
     // Strict mode unless a cell asks otherwise: no TTY gate, no explainers.

--- a/test/unit/session-grant.test.ts
+++ b/test/unit/session-grant.test.ts
@@ -6,9 +6,7 @@
  * it describes goes away, because the macOS grant it records dies at exactly
  * that moment.
  */
-import { mkdtempSync, readFileSync, existsSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { readFileSync, existsSync } from "node:fs";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import {
@@ -18,6 +16,7 @@ import {
   witnessSessionGrant,
   type SessionGrantDeps,
 } from "../../src/session-grant.ts";
+import { makeTempDir } from "../fixtures/temp-dir.ts";
 
 const BUNDLE = "com.mitchellh.ghostty";
 const START = "Thu Jul 16 00:29:43 2026";
@@ -36,7 +35,7 @@ function deps(over: Partial<SessionGrantDeps> = {}): SessionGrantDeps {
 }
 
 beforeEach(() => {
-  stateDir = mkdtempSync(join(tmpdir(), "things-session-"));
+  stateDir = makeTempDir("things-session");
 });
 
 describe("witnessing", () => {


### PR DESCRIPTION
Closes the sibling half of the `mkdtemp` leak. The fixture-db half is already fixed (`buildFixtureDb` registers every path, `test/setup/fixture-sweep.ts` sweeps it per test file). This is the other class named in `docs/up-next.md`: ~22 call sites did `mkdtempSync(join(tmpdir(), "<prefix>-"))` for a state/config/audit dir and never removed it.

## Measured, this host, full suite

| | leftover directories in `$TMPDIR` after one `vitest run` |
| --- | --- |
| before (`origin/main`, 737475d) | **539** |
| after | **0** |

Method: snapshot `ls $TMPDIR` before and after a full run, `comm` the two, keep the entries that are directories. Worst offenders in the baseline matched the up-next entry — `sim-state-`/`sim-config-` 85 each, `promote-*` 60 each, `things-setup-*` 35 each, then `clone-*`, `things-session-`, `things-api-config-get-`, `things-gate-`, `things-api-area-filter-`, `batch-temp-*`, `collateral-*`, `things-api-universal-dryrun-`, `vclock-*`, `sandbox-test-`, `loop-state-`, `ledger-`.

## Shape

- **`test/fixtures/temp-dir.ts`** — `makeTempDir(prefix)` mkdtemps into `$TMPDIR` and registers the path in a process-global registry, plus `removeTempDir`/`sweepTempDirs`. Same construction as `build-db.ts`'s registry (`Symbol.for` home so the registry outlives vitest's per-file module isolation, and a `process.on("exit")` backstop for a crashed worker).
- **`test/setup/fixture-sweep.ts`** — now sweeps both registries in its `afterAll`.
- `afterAll` per test FILE, not `afterEach`: the sites that set `THINGS_API_STATE_DIR` once at module scope need the directory to outlive every test in the file. Peak residue is one file's worth.
- Converted only the sites the measured residue named as leaking. Sites that already `rmSync` their own dir are untouched, per the up-next entry.
- One non-`mkdtemp` leaker moved too: `sim-audit-<uuid>` in `write-simulator.test.ts`, a path the audit writer creates lazily.

No CHANGELOG entry — test infrastructure, nothing user-visible.

`npm run check` green by exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eBQZm7s4r3dG8r8EZWdLp