### PR TITLE
test: tz-safe reanchor guard test + move-heading drive-gui CI tripwire

### DIFF
--- a/test/cli/heading-drivegui-cli.test.ts
+++ b/test/cli/heading-drivegui-cli.test.ts
@@ -81,10 +81,11 @@ function envelope(): Record<string, unknown> {
   return JSON.parse(line) as Record<string, unknown>;
 }
 
-/** A source project with a lone heading, plus a distinct destination project. */
+/** A source project with two headings, plus a distinct destination project. */
 function seedHeadingScenario(): { src: string; dest: string } {
   const src = seedProject(fixture.db, { title: "Source" });
   seedHeading(fixture.db, { title: "Phase 1", project: src });
+  seedHeading(fixture.db, { title: "Phase 2", project: src });
   const dest = seedProject(fixture.db, { title: "Destination" });
   return { src, dest };
 }
@@ -97,6 +98,15 @@ const scenarios: Array<{ name: string; argv: (s: { src: string; dest: string }) 
   {
     name: "project move-heading-to-project",
     argv: ({ src, dest }) => ["project", "move-heading-to-project", src, "Phase 1", "--to", dest],
+  },
+  // move-heading rode the private-reorder wire until CHORDMH1 moved it to the
+  // chord ui vector; lab:regress caught the e2e still asserting the OLD refusal
+  // three releases later (the 0.20.0 retro gate run). This row is the CI-visible
+  // tripwire under the same ack/config gate law its siblings already lock — a
+  // genuine move (Phase 2 → first), so no earlier no-op path can short-circuit.
+  {
+    name: "project move-heading",
+    argv: ({ src }) => ["project", "move-heading", src, "Phase 2", "--first"],
   },
 ];
 

--- a/test/unit/repeat-reanchor.test.ts
+++ b/test/unit/repeat-reanchor.test.ts
@@ -12,6 +12,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { localToday } from "../../src/model/dates.ts";
 import { COMMANDS } from "../../src/write/commands.ts";
 import { evaluateGuards, type GuardBlock } from "../../src/write/guards.ts";
 import {
@@ -206,7 +207,10 @@ describe("vector + gate routing", () => {
 describe("H-REPEAT-REANCHOR — the measured edges", () => {
   it("refuses a date that is not strictly after today (REANCH1 §5: it kills the app)", () => {
     const uuid = seedTemplate();
-    const today = new Date().toISOString().slice(0, 10);
+    // The guard's boundary is the DEVICE-LOCAL calendar day (pre.todayIso via
+    // localToday) — deriving "today" in UTC made this flake on any host whose
+    // local date trails UTC (fails every evening in the Americas).
+    const today = localToday(new Date());
     expect(check("todo.reschedule-repeat", { uuid, next: today })?.hazard).toBe(
       "H-REPEAT-REANCHOR",
     );


### PR DESCRIPTION
Follow-ups from the v0.20.0 retroactive `lab:regress` gate run (#653): the UTC-vs-local-day flake in `repeat-reanchor.test.ts` (reproduced and re-verified fixed at 00:54 UTC / 19:54 CDT — inside the flake window), and the `move-heading` ack/config gate tripwire its sibling verbs already had — the CI-visible lock that would have caught the e2e drift three releases earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Fznww4jzfseXniTsQMyZy