### PR TITLE
chore(lab): ship the Stage 9 consumer drill, and teach the Stage 5 diagnostic the post-#720 guard API

### DIFF
--- a/docs/reference/release-checklist.md
+++ b/docs/reference/release-checklist.md
@@ -205,6 +205,8 @@ spctl --assess --type exec -vv "$B"     # Gatekeeper accepts it offline, from th
 
 `spctl` accepting it with no network is the whole point of notarizing: a consumer installing the tarball gets a bundle launchd can start without a quarantine prompt. Finish with the same smoke the tarball drill used — the installed `things` answering against a throwaway fixture DB — then remove the temp prefixes.
 
+**WHERE IT RUNS: in the guest, like every other stage.** The host may `npm view` the published version and DOWNLOAD the tarball; it may not install or run it. [`lab/scripts/consumer-drill.sh`](../../lab/scripts/consumer-drill.sh) takes the downloaded tarball into a disposable clone and runs [`lab/guest/consumer-cells.sh`](../../lab/guest/consumer-cells.sh) there. Two notes it saves the next agent from rediscovering: the package's runtime dependencies must be shipped in beside it (`DEPS=`), because an airgapped guest has neither a registry nor npm and a raw tarball extract cannot start; and `xcrun stapler validate` exits **68** on an airgapped guest — it reaches for CloudKit — so `spctl --assess`, which reads the stapled ticket off the disk, is the offline proof, not stapler.
+
 ### Stage 10 — close out
 
 - Delete the landed items from [up-next.md](../up-next.md); update [roadmap.md](../roadmap.md), [capability-matrix.md](../capability-matrix.md) and [suite-audit.md](suite-audit.md) if the batch moved anything they track (usually done per-PR; check, don't assume).

--- a/lab/guest/consumer-cells.sh
+++ b/lab/guest/consumer-cells.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Runs ON THE GUEST, offline. The artifact under test is the tarball npm serves.
+set -u
+FAIL=0
+ok(){ echo "ok   $*"; }
+bad(){ echo "FAIL $*"; FAIL=$((FAIL+1)); }
+cd "$HOME/consumer"
+
+echo "== the tarball a consumer downloads =="
+shasum -a 256 published.tgz
+rm -rf pkg && mkdir pkg && tar xzf published.tgz -C pkg
+PKG="$HOME/consumer/pkg/package"
+VER=$(python3 -c "import json;print(json.load(open('$PKG/package.json'))['version'])")
+[ "$VER" = "0.20.9" ] && ok "package.json version 0.20.9" || bad "version is $VER"
+
+echo ""
+echo "== the installed CLI answers =="
+# A consumer runs `npm install -g things-api`, which resolves the package's
+# dependencies. This guest is airgapped and has no npm, so the runtime deps are
+# shipped beside the tarball and placed where node will find them — the package
+# itself is still the PUBLISHED artifact, byte for byte.
+mkdir -p "$PKG/node_modules"
+cp -R "$HOME/consumer/deps/." "$PKG/node_modules/" 2>/dev/null || true
+echo "     node_modules provided: $(ls "$PKG/node_modules" | tr '\n' ' ')"
+OUT=$("$HOME/consumer/bin/node" "$PKG/bin/things.js" --version 2>/dev/null)
+[ "$OUT" = "0.20.9" ] && ok "things --version -> $OUT" || bad "things --version -> $OUT"
+"$HOME/consumer/bin/node" "$PKG/bin/things.js" --help >/dev/null 2>&1 && ok "things --help renders" || bad "things --help failed"
+
+echo ""
+echo "== against a throwaway fixture DB =="
+FIX="$HOME/consumer/fixture.sqlite"
+python3 - "$FIX" <<'PY'
+import sqlite3, sys
+c = sqlite3.connect(sys.argv[1]); c.executescript("PRAGMA journal_mode=WAL;")
+c.commit(); c.close()
+PY
+THINGS_API_DB="$FIX" "$HOME/consumer/bin/node" "$PKG/bin/things.js" doctor --json >/tmp/doc.json 2>/dev/null
+if [ -s /tmp/doc.json ]; then ok "doctor answered against a throwaway DB"; head -c 220 /tmp/doc.json; echo; else bad "doctor produced nothing"; fi
+
+echo ""
+echo "== notarization, on the bundle inside the PUBLISHED package =="
+B="$PKG/deputy/prebuilt/Things API Helper.app"
+[ -d "$B" ] && ok "prebuilt bundle present in the published tarball" || { bad "no prebuilt bundle"; exit 1; }
+xattr -lr "$B" | grep -c quarantine | sed 's/^/     quarantine xattrs: /'
+if codesign --verify --deep --strict --verbose=2 "$B" 2>&1 | tail -3 | sed 's/^/     /'; then ok "codesign --verify --deep --strict"; else bad "codesign verify"; fi
+ST_OUT=$(xcrun stapler validate "$B" 2>&1); ST_CODE=$?
+echo "$ST_OUT" | tail -2 | sed 's/^/     /'
+if [ $ST_CODE -eq 0 ]; then ok "stapler validate"
+else echo "note stapler exit $ST_CODE — it reaches for CloudKit and this guest is AIRGAPPED; spctl below is the offline proof"; fi
+SP_OUT=$(spctl --assess --type exec -vv "$B" 2>&1); SP_CODE=$?
+echo "$SP_OUT" | sed 's/^/     /'
+if [ $SP_CODE -eq 0 ]; then ok "spctl accepts it OFFLINE, from the stapled ticket alone"; else bad "spctl rejected it (exit $SP_CODE)"; fi
+R="$B/Contents/Helpers/things-reader.app"
+if [ -d "$R" ]; then
+  codesign --verify --deep --strict "$R" 2>/dev/null && ok "the sandboxed reader is signed too" || bad "reader signature"
+else bad "no things-reader inside the bundle"; fi
+BV=$(defaults read "$B/Contents/Info" CFBundleShortVersionString 2>/dev/null)
+[ "$BV" = "1.4.0" ] && ok "helpers bundle version 1.4.0" || bad "helpers bundle version is '$BV'"
+
+echo ""
+echo "CONSUMER DRILL: $FAIL failures"
+exit $((FAIL > 0 ? 1 : 0))

--- a/lab/scripts/consumer-drill.sh
+++ b/lab/scripts/consumer-drill.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Stage 9 — the CONSUMER DRILL, IN THE GUEST (release-checklist.md).
+#
+#   TGZ=/path/to/things-api-<version>.tgz DEPS=/path/to/deps \
+#     bash lab/scripts/consumer-drill.sh
+#
+# The host may DOWNLOAD the published tarball and read it; it may not install or
+# run it against anything of the maintainer's. So the artifact a consumer
+# actually gets is verified inside a disposable clone: the CLI answers, and the
+# helper bundle inside the PUBLISHED package is signed, stapled, and accepted by
+# Gatekeeper with no network at all — which is the whole point of notarizing.
+#
+# DEPS is a directory of the package's runtime dependencies (commander, zod,
+# @modelcontextprotocol), copied in beside the extracted tarball. A real
+# consumer gets them from `npm install -g`; an airgapped guest has no registry
+# and no npm, so they cross the airgap the way node does. The PACKAGE under test
+# is still the published artifact, byte for byte.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+source lab/scripts/env.sh
+
+TGZ="${TGZ:?set TGZ to the published tarball}"
+GOLD="${GOLDEN_NAME:-things-lab-golden-v4}"
+VM="things-consumer-$(date +%H%M%S)"
+ART="lab/artifacts/$VM"; mkdir -p "$ART"
+NODE_BIN=$(node -e 'console.log(process.execPath)')
+
+cleanup() { echo "[drill] teardown $VM"; tart stop "$VM" >/dev/null 2>&1 || true; tart delete "$VM" >/dev/null 2>&1 || true; }
+echo "[drill] golden=$GOLD tarball=$TGZ"
+tart clone "$GOLD" "$VM"
+trap cleanup EXIT
+(tart run "$VM" --no-graphics >"$ART/tart-run.log" 2>&1 &)
+IP=$(lab_wait_for_ssh "$VM" 600)
+echo "[drill] ssh $IP"
+lab_ssh "$IP" 'sudo route -n delete default >/dev/null 2>&1 || true'
+lab_ssh "$IP" 'ping -c1 -t2 1.1.1.1 >/dev/null 2>&1 && echo "STILL ONLINE" || echo "airgapped: no route to the internet"'
+lab_ssh "$IP" 'sudo systemsetup -setusingnetworktime off >/dev/null 2>&1; sudo date 070512002026 >/dev/null'
+lab_ssh "$IP" 'mkdir -p ~/consumer/bin'
+lab_scp "$NODE_BIN" "admin@$IP:consumer/bin/node"
+lab_scp "$TGZ" "admin@$IP:consumer/published.tgz"
+lab_scp -r "$DEPS" "admin@$IP:consumer/deps"
+lab_ssh "$IP" 'chmod +x ~/consumer/bin/node'
+lab_scp "${CELLS:-lab/guest/consumer-cells.sh}" "admin@$IP:consumer/cells.sh"
+lab_ssh "$IP" 'chmod +x ~/consumer/cells.sh'
+set +e
+lab_ssh "$IP" 'bash ~/consumer/cells.sh' | tee "$ART/consumer-transcript.log"
+RESULT=${PIPESTATUS[0]}
+set -e
+echo "[drill] exit=$RESULT — artifacts in $ART"
+exit "$RESULT"

--- a/lab/scripts/stage5-ptrdiag.sh
+++ b/lab/scripts/stage5-ptrdiag.sh
@@ -59,10 +59,15 @@ if (VERB === 'windows') {
   var wins = front === null ? [] : ptrThingsWindows(front.pid, true);
   var inside = false, k;
   for (k = 0; k < wins.length; k++) if (ptrRectHas(wins[k].f, x, y)) inside = true;
+  var screen = ptrScreenAt(x, y);
   JSON.stringify({ point:[x,y], L1_front: front, L2_mainWindow: wins.length ? wins[0].f : null,
-    L2_contains: inside, L3_topBanded: list === null ? null : ptrTopWindowAt(list, x, y),
+    L2_contains: inside,
+    L3_order: 'the hit test is authoritative; the scan speaks only when it answers nothing (PTRGD1 §8)',
+    L3_screen: screen,
+    L3_scanOwner: list === null ? null : ptrScanOwnerAt(list, x, y, screen, ptrIsSystemOwner),
     L3_hitPid: ptrHitPidAt(x, y),
     L3_hitApp: (function(){ var p = ptrHitPidAt(x, y); return p === null ? null : ptrAppName(p) })(),
+    L3_verdict: ptrOcclusionVerdict(front === null ? null : front.pid, ptrHitPidAt(x, y), list, x, y, screen, ptrIsSystemOwner),
     sentence_drag: ptrGuard('drag the area row', [{x:x,y:y}], {}) }, null, 1)
 } else { JSON.stringify({error:'?'}) }
 \`);


### PR DESCRIPTION
Two things the v0.20.9 release had to improvise. Both now live in the repo so the next release does not.

## The Stage 5 pointer diagnostic was stale within hours of landing

`lab/scripts/stage5-ptrdiag.sh` still asked for `ptrTopWindowAt`, which PTRGD1 §8 (#720) replaced with `ptrScanOwnerAt` + `ptrOcclusionVerdict` when it made the window server's hit test the authoritative occlusion leg. The probe died with `ReferenceError: Can't find variable: ptrTopWindowAt` instead of answering.

It now reports the legs in the order the guard actually asks them, and adds the verdict itself. That is the point of a diagnostic generated from the **shipped** guard rather than a re-implementation — run against the fixed build on a v4h clone, the display-sized Notification Center surface is still present and the answer changes anyway:

```json
"L3_order":     "the hit test is authoritative; the scan speaks only when it answers nothing (PTRGD1 §8)",
"L3_scanOwner": { "pid": 691, "name": "Things" },
"L3_hitPid":    691,
"L3_verdict":   { "ok": true },
"sentence_drag": null
```

## Stage 9 had no runner, and its law says the guest

The checklist requires the consumer drill to run where every other stage does: the host may `npm view` the published version and download the tarball, never install or run it. `lab/scripts/consumer-drill.sh` + `lab/guest/consumer-cells.sh` take the downloaded artifact into a disposable clone and verify what a consumer actually gets — the version, `--version` / `--help`, `doctor` against a throwaway fixture DB, and the helper bundle's signature, staple and Gatekeeper verdict.

Its v0.20.9 run, on `things-api-0.20.9.tgz` as served by the registry (`sha256 ad1d2c28…`):

```
ok   package.json version 0.20.9
ok   things --version -> 0.20.9
ok   things --help renders
ok   doctor answered against a throwaway DB
ok   prebuilt bundle present in the published tarball     (quarantine xattrs: 0)
ok   codesign --verify --deep --strict                    satisfies its Designated Requirement
ok   spctl accepts it OFFLINE                             source=Notarized Developer ID
ok   the sandboxed reader is signed too
ok   helpers bundle version 1.4.0
CONSUMER DRILL: 0 failures
```

## Two traps, recorded in the checklist rather than left to be rediscovered

- **The runtime deps must be shipped in beside the tarball** (`DEPS=`). A consumer gets them from `npm install -g`; an airgapped guest has no registry and no npm, so a raw tarball extract cannot start and the drill reports three false failures. The package under test is still the published artifact, byte for byte.
- **`xcrun stapler validate` exits 68 on an airgapped guest** — it reaches for CloudKit (`CloudKit's response is inconsistent with expections`). The offline proof is `spctl --assess`, which reads the stapled ticket off the disk and needs no network. That distinction matters, because "notarization verified" via a tool that phoned home would prove the opposite of what the stage is for.

`npm run check` exit 0. `lab/` plus one reference doc — no shipped code.

Refs #676 #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWUgSSE1oz7Njk9Ly7aRER